### PR TITLE
Test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python: 3.5
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+
+env:
+  - TOX_ENV=py27
+  - TOX_ENV=py35
+
+install:
+- pip install tox
+
+script:
+    CXX="g++-4.9" CC="gcc-4.9" tox -e $TOX_ENV

--- a/sourmash
+++ b/sourmash
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python
 from __future__ import print_function
 import sys
 import os

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -exu
 ./sourmash compute test.fq -f
 ./sourmash compare test.fq.sig test.fq.sig
 ./sourmash clean -n -s test.fq.sig

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist=py27,py35
+[testenv]
+whitelist_externals=
+    make
+deps=
+    numpy
+    screed
+	pytest
+commands=
+    ./test.sh
+	make test


### PR DESCRIPTION
Uses tox for running tests on 2.7 and 3.5 (and add a basic travis config)

``` bash
$ pip install tox
$ tox
```