### PR TITLE
unicode() not available on py3

### DIFF
--- a/sourmash
+++ b/sourmash
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python
 from __future__ import print_function
 import sys
 import os

--- a/sourmash_lib.py
+++ b/sourmash_lib.py
@@ -174,7 +174,7 @@ def complement(s):
     """
     Return complement of 's'.
     """
-    c = unicode(s).translate(__complementTranslation)
+    c = "".join(__complementTranslation[n] for n in s[::-1])
     return c
 
 
@@ -335,3 +335,7 @@ def test_protein_mh():
     print(e1._mins)
     assert 857194471 in e1._mins
     assert 1054538492 in e1._mins
+
+
+def test_complement():
+    assert complement('ATGGCAGTGACGATGCCG') == 'CGGCATCGTCACTGCCAT'

--- a/sourmash_lib.py
+++ b/sourmash_lib.py
@@ -174,7 +174,7 @@ def complement(s):
     """
     Return complement of 's'.
     """
-    c = "".join(__complementTranslation[n] for n in s[::-1])
+    c = "".join(__complementTranslation[n] for n in s)
     return c
 
 
@@ -338,4 +338,4 @@ def test_protein_mh():
 
 
 def test_complement():
-    assert complement('ATGGCAGTGACGATGCCG') == 'CGGCATCGTCACTGCCAT'
+    assert complement('ATGGCAGTGACGATGCCG') == 'TACCGTCACTGCTACGGC'


### PR DESCRIPTION
also remove python2 on hashbang.