### PR TITLE
Use pickle to save LeafNodes

### DIFF
--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import division
+import pickle
 from glob import glob
 import os
 
@@ -14,9 +15,8 @@ class SigLeaf(Leaf):
                 name=self.name, metadata=self.metadata)
 
     def save(self, filename):
-        from sourmash_lib import signature
-        with open(filename, 'w') as fp:
-            signature.save_signatures([self.data], fp)
+        with open(filename, 'wb') as fp:
+            pickle.dump(self.data, fp)
 
     def update(self, parent):
         for v in self.data.estimator.mh.get_mins():
@@ -27,8 +27,8 @@ class SigLeaf(Leaf):
         from sourmash_lib import signature
 
         filename = os.path.join(dirname, info['filename'])
-        with open(filename, 'r') as fp:
-            data = next(signature.load_signatures(fp))
+        with open(filename, 'rb') as fp:
+            data = pickle.load(fp)
         return SigLeaf(info['metadata'], data, name=info['name'])
 
 


### PR DESCRIPTION
Question for @luizirber - is there a reason not to use pickle for the internal nodes, too? I'm not sure it matters one way or another but thought I'd ask.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
