### PR TITLE
Seed when computing hashes now a parameter for all C-level

### DIFF
--- a/sourmash_lib/_minhash.cc
+++ b/sourmash_lib/_minhash.cc
@@ -530,6 +530,11 @@ bool check_IsMinHash(PyObject * mh)
 }
 
 
+PyDoc_STRVAR(hash_murmur_doc,
+             "hash_murmur(string [, seed])\n\n"
+             "Compute a hash for a string, optionally using a seed (an integer). "
+             "The default seed is in DEFAULT_HASH_SEED.");
+
 static PyObject * hash_murmur(PyObject * self, PyObject * args)
 {
     const char * kmer;
@@ -544,8 +549,8 @@ static PyObject * hash_murmur(PyObject * self, PyObject * args)
 
 static PyMethodDef MinHashModuleMethods[] = {
     {
-        "hash_murmur",     hash_murmur,
-        METH_VARARGS,       "",
+        "hash_murmur", hash_murmur,
+        METH_VARARGS, hash_murmur_doc,
     },
     { NULL, NULL, 0, NULL } // sentinel
 };

--- a/sourmash_lib/_minhash.cc
+++ b/sourmash_lib/_minhash.cc
@@ -6,7 +6,8 @@
 
 typedef unsigned long long HashIntoType;
 typedef std::set<HashIntoType> CMinHashType;
-uint64_t _hash_murmur(const std::string& kmer);
+uint64_t _hash_murmur(const std::string& kmer,
+		      const uint32_t seed);
 
 #include "_minhash.hh"
 #include "../third-party/smhasher/MurmurHash3.h"
@@ -22,6 +23,7 @@ uint64_t _hash_murmur(const std::string& kmer);
 #define Py_TPFLAGS_HAVE_ITER 0
 #endif
 
+#define  DEFAULT_SEED 42
 
 extern "C" {
     MOD_INIT(_minhash);
@@ -288,10 +290,12 @@ static PyObject * minhash___copy__(MinHash_Object * me, PyObject * args)
     KmerMinHash * new_mh = NULL;
 
     if (me->track_abundance == true) {
-         new_mh = new KmerMinAbundance(mh->num, mh->ksize, mh->is_protein);
+      new_mh = new KmerMinAbundance(mh->num, mh->ksize,
+				    mh->is_protein, mh->seed);
          ((KmerMinAbundance*)new_mh)->merge(*(KmerMinAbundance*)mh);
     } else {
-         new_mh = new KmerMinHash(mh->num, mh->ksize, mh->is_protein);
+      new_mh = new KmerMinHash(mh->num, mh->ksize,
+			       mh->is_protein, mh->seed);
          new_mh->merge(*mh);
     }
 
@@ -488,14 +492,17 @@ MinHash_new(PyTypeObject * subtype, PyObject * args, PyObject * kwds)
     }
 
     unsigned int _n, _ksize;
+    uint32_t seed = DEFAULT_SEED;
     PyObject * track_abundance_o = Py_False;
     PyObject * is_protein_o = NULL;
-
-    static const char* const_kwlist[] = {"n", "ksize", "is_protein", "track_abundance", NULL};
+ 
+    static const char* const_kwlist[] = {"n", "ksize", "is_protein", "track_abundance", "seed", NULL};
     static char** kwlist = const_cast<char**>(const_kwlist);
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "II|OO", kwlist,
-                          &_n, &_ksize, &is_protein_o, &track_abundance_o)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "II|OOI", kwlist,
+				     &_n, &_ksize, &is_protein_o,
+				     &track_abundance_o,
+				     &seed)) {
         return NULL;
     }
 
@@ -506,10 +513,10 @@ MinHash_new(PyTypeObject * subtype, PyObject * args, PyObject * kwds)
     }
 
     if (PyObject_IsTrue(track_abundance_o)) {
-        myself->mh = new KmerMinAbundance(_n, _ksize, is_protein);
+      myself->mh = new KmerMinAbundance(_n, _ksize, is_protein, seed);
         myself->track_abundance = true;
     } else {
-        myself->mh = new KmerMinHash(_n, _ksize, is_protein);
+      myself->mh = new KmerMinHash(_n, _ksize, is_protein, seed);
         myself->track_abundance = false;
     }
 
@@ -528,12 +535,13 @@ bool check_IsMinHash(PyObject * mh)
 static PyObject * hash_murmur(PyObject * self, PyObject * args)
 {
     const char * kmer;
+    uint32_t seed = DEFAULT_SEED;
 
-    if (!PyArg_ParseTuple(args, "s", &kmer)) {
+      if (!PyArg_ParseTuple(args, "s|I", &kmer, &seed)) {
         return NULL;
     }
 
-    return PyLong_FromUnsignedLongLong(_hash_murmur(kmer));
+    return PyLong_FromUnsignedLongLong(_hash_murmur(kmer, seed));
 }
 
 static PyMethodDef MinHashModuleMethods[] = {
@@ -572,10 +580,10 @@ MOD_INIT(_minhash)
     return MOD_SUCCESS_VAL(m);
 }
 
-uint64_t _hash_murmur(const std::string& kmer) {
+uint64_t _hash_murmur(const std::string& kmer,
+		      const uint32_t seed) {
     uint64_t out[2];
     out[0] = 0; out[1] = 0;
-    uint32_t seed = 42;
     MurmurHash3_x64_128((void *)kmer.c_str(), kmer.size(), seed, &out);
     return out[0];
 }

--- a/sourmash_lib/_minhash.cc
+++ b/sourmash_lib/_minhash.cc
@@ -23,8 +23,6 @@ uint64_t _hash_murmur(const std::string& kmer,
 #define Py_TPFLAGS_HAVE_ITER 0
 #endif
 
-#define  DEFAULT_SEED 42
-
 extern "C" {
     MOD_INIT(_minhash);
 }
@@ -492,7 +490,7 @@ MinHash_new(PyTypeObject * subtype, PyObject * args, PyObject * kwds)
     }
 
     unsigned int _n, _ksize;
-    uint32_t seed = DEFAULT_SEED;
+    uint32_t seed = MINHASH_DEFAULT_SEED;
     PyObject * track_abundance_o = Py_False;
     PyObject * is_protein_o = NULL;
  
@@ -535,7 +533,7 @@ bool check_IsMinHash(PyObject * mh)
 static PyObject * hash_murmur(PyObject * self, PyObject * args)
 {
     const char * kmer;
-    uint32_t seed = DEFAULT_SEED;
+    uint32_t seed = MINHASH_DEFAULT_SEED;
 
       if (!PyArg_ParseTuple(args, "s|I", &kmer, &seed)) {
         return NULL;
@@ -571,6 +569,8 @@ MOD_INIT(_minhash)
     if (m == NULL) {
         return MOD_ERROR_VAL;
     }
+
+    PyModule_AddIntConstant(m, "DEFAULT_HASH_SEED", MINHASH_DEFAULT_SEED);
 
     Py_INCREF(&MinHash_Type);
     if (PyModule_AddObject( m, "MinHash",

--- a/sourmash_lib/_minhash.cc
+++ b/sourmash_lib/_minhash.cc
@@ -27,6 +27,7 @@ extern "C" {
     MOD_INIT(_minhash);
 }
 
+
 ////
 
 static int _MinHash_len(PyObject *);
@@ -45,12 +46,100 @@ static PySequenceMethods _MinHash_seqmethods[] = {
     0                           /* sq_inplace_repeat */
 };
 
-PyTypeObject MinHash_Type = {
+
+/* Forward declarations */
+static void MinHash_dealloc(MinHash_Object * obj);
+static PyObject * minhash_add_sequence(MinHash_Object * me, PyObject * args);
+static PyObject * minhash_add_protein(MinHash_Object * me, PyObject * args);
+static PyObject * minhash_add_hash(MinHash_Object * me, PyObject * args);
+static PyObject * minhash_get_mins(MinHash_Object * me, PyObject * args, PyObject * kwargs);
+static PyObject * minhash_set_counters(MinHash_Object * me, PyObject * args);
+static PyObject * minhash___copy__(MinHash_Object * me, PyObject * args);
+static PyObject * minhash_count_common(MinHash_Object * me, PyObject * args);
+static PyObject * minhash_compare(MinHash_Object * me, PyObject * args);
+static PyObject * minhash_merge(MinHash_Object * me, PyObject * args);
+static PyObject * minhash_is_protein(MinHash_Object * me, PyObject * args);
+  
+static PyMethodDef MinHash_methods [] = {
+    {
+        "add_sequence",
+        (PyCFunction)minhash_add_sequence, METH_VARARGS,
+        "Add kmer into MinHash"
+    },
+    {
+        "add_protein",
+        (PyCFunction)minhash_add_protein, METH_VARARGS,
+        "Add AA kmer into protein MinHash"
+    },
+    {
+        "add_hash",
+        (PyCFunction)minhash_add_hash, METH_VARARGS,
+        "Add kmer into MinHash"
+    },
+    {
+        "get_mins",
+        (PyCFunction)minhash_get_mins, METH_VARARGS | METH_KEYWORDS,
+        "Get MinHash signature"
+    },
+    {
+        "set_abundances",
+        (PyCFunction)minhash_set_counters, METH_VARARGS,
+        "Set abundances for MinHash hashes.",
+    },
+    {
+        "__copy__",
+        (PyCFunction)minhash___copy__, METH_VARARGS,
+        "Copy this MinHash object",
+    },
+    {
+        "count_common",
+        (PyCFunction)minhash_count_common, METH_VARARGS,
+        "Get number of hashes in common with other."
+    },
+    {
+        "compare",
+        (PyCFunction)minhash_compare, METH_VARARGS,
+        "Get the Jaccard similarity between this and other."
+    },
+    {
+        "merge",
+        (PyCFunction)minhash_merge, METH_VARARGS,
+        "Merge the other MinHash into this one."
+    },
+    {
+        "is_protein",
+        (PyCFunction)minhash_is_protein, METH_VARARGS,
+        "Return False if a DNA MinHash, True if protein."
+    },
+    { NULL, NULL, 0, NULL } // sentinel
+};
+
+
+PyDoc_STRVAR(minhash_get_seed_doc,
+             "Seed used for hashing (is set when the instance of "
+	     "MinHash is created).");
+static PyObject * minhash_get_seed(MinHash_Object *self);
+
+/* Getters and setters for MinHash */
+static PyGetSetDef MinHash_getseters[] = {
+  {"seed", 
+   (getter)minhash_get_seed,
+   NULL,
+   minhash_get_seed_doc,
+   NULL},
+  {NULL}          /* sentinel */
+};
+
+
+static PyObject * MinHash_new(PyTypeObject * subtype, PyObject * args, PyObject * kwds);
+
+
+static PyTypeObject MinHash_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
-    "_minhash.MinHash",                   /* tp_name */
+    "sourmash_lib._minhash.MinHash",      /* tp_name */
     sizeof(MinHash_Object),               /* tp_basicsize */
     0,                                    /* tp_itemsize */
-    0,                                    /* tp_dealloc */
+    (destructor)MinHash_dealloc,          /* tp_dealloc */
     0,                                    /* tp_print */
     0,                                    /* tp_getattr */
     0,                                    /* tp_setattr */
@@ -67,7 +156,29 @@ PyTypeObject MinHash_Type = {
     0,                                    /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                   /* tp_flags */
     "A MinHash sketch.",                  /* tp_doc */
+    0,                                    /* tp_traverse */
+    0,                                    /* tp_clear */
+    0,                                    /* tp_richcompare */
+    0,                                    /* tp_weaklistoffset */
+    0,                                    /* tp_iter */
+    0,                                    /* tp_iternext */
+    MinHash_methods,                      /* tp_methods */
+    0,                                    /* tp_members */
+    MinHash_getseters,                    /* tp_getset */
+    0,                                    /* tp_base */
+    0,                                    /* tp_dict */
+    0,                                    /* tp_descr_get */
+    0,                                    /* tp_descr_set */
+    0,                                    /* tp_dictoffset */
+    0,                                    /* tp_init */
+    0,                                    /* tp_alloc */
+    MinHash_new,                          /* tp_new */
+    0,                                    /* tp_free */
+    0                                     /* tp_is_gc */
 };
+
+
+
 
 bool check_IsMinHash(PyObject * mh);
 
@@ -90,6 +201,14 @@ MinHash_dealloc(MinHash_Object * obj)
     delete obj->mh;
     obj->mh = NULL;
     Py_TYPE(obj)->tp_free((PyObject*)obj);
+}
+
+
+static
+PyObject *
+minhash_get_seed(MinHash_Object *self)
+{
+  return PyLong_FromLong((long)(self->mh->seed));
 }
 
 static
@@ -426,59 +545,6 @@ static PyObject * minhash_is_protein(MinHash_Object * me, PyObject * args)
     return r;
 }
 
-static PyMethodDef MinHash_methods [] = {
-    {
-        "add_sequence",
-        (PyCFunction)minhash_add_sequence, METH_VARARGS,
-        "Add kmer into MinHash"
-    },
-    {
-        "add_protein",
-        (PyCFunction)minhash_add_protein, METH_VARARGS,
-        "Add AA kmer into protein MinHash"
-    },
-    {
-        "add_hash",
-        (PyCFunction)minhash_add_hash, METH_VARARGS,
-        "Add kmer into MinHash"
-    },
-    {
-        "get_mins",
-        (PyCFunction)minhash_get_mins, METH_VARARGS | METH_KEYWORDS,
-        "Get MinHash signature"
-    },
-    {
-        "set_abundances",
-        (PyCFunction)minhash_set_counters, METH_VARARGS,
-        "Set abundances for MinHash hashes.",
-    },
-    {
-        "__copy__",
-        (PyCFunction)minhash___copy__, METH_VARARGS,
-        "Copy this MinHash object",
-    },
-    {
-        "count_common",
-        (PyCFunction)minhash_count_common, METH_VARARGS,
-        "Get number of hashes in common with other."
-    },
-    {
-        "compare",
-        (PyCFunction)minhash_compare, METH_VARARGS,
-        "Get the Jaccard similarity between this and other."
-    },
-    {
-        "merge",
-        (PyCFunction)minhash_merge, METH_VARARGS,
-        "Merge the other MinHash into this one."
-    },
-    {
-        "is_protein",
-        (PyCFunction)minhash_is_protein, METH_VARARGS,
-        "Return False if a DNA MinHash, True if protein."
-    },
-    { NULL, NULL, 0, NULL } // sentinel
-};
 
 static
 PyObject *
@@ -521,6 +587,7 @@ MinHash_new(PyTypeObject * subtype, PyObject * args, PyObject * kwds)
     return self;
 }
 
+
 bool check_IsMinHash(PyObject * mh)
 {
     if (!PyObject_TypeCheck(mh, &MinHash_Type)) {
@@ -555,15 +622,9 @@ static PyMethodDef MinHashModuleMethods[] = {
     { NULL, NULL, 0, NULL } // sentinel
 };
 
+
 MOD_INIT(_minhash)
 {
-    MinHash_Type.tp_methods = MinHash_methods;
-    MinHash_Type.tp_dealloc = (destructor)MinHash_dealloc;
-    MinHash_Type.tp_new = MinHash_new;
-
-    if (PyType_Ready( &MinHash_Type ) < 0) {
-        return MOD_ERROR_VAL;
-    }
 
     PyObject * m;
 
@@ -576,6 +637,11 @@ MOD_INIT(_minhash)
     }
 
     PyModule_AddIntConstant(m, "DEFAULT_HASH_SEED", MINHASH_DEFAULT_SEED);
+
+    if (PyType_Ready( &MinHash_Type ) < 0) {
+        return MOD_ERROR_VAL;
+    }
+
 
     Py_INCREF(&MinHash_Type);
     if (PyModule_AddObject( m, "MinHash",

--- a/sourmash_lib/_minhash.cc
+++ b/sourmash_lib/_minhash.cc
@@ -600,7 +600,7 @@ bool check_IsMinHash(PyObject * mh)
 PyDoc_STRVAR(hash_murmur_doc,
              "hash_murmur(string [, seed])\n\n"
              "Compute a hash for a string, optionally using a seed (an integer). "
-             "The default seed is in DEFAULT_HASH_SEED.");
+             "The current default seed is returned by hash_seed().");
 
 static PyObject * hash_murmur(PyObject * self, PyObject * args)
 {
@@ -614,10 +614,23 @@ static PyObject * hash_murmur(PyObject * self, PyObject * args)
     return PyLong_FromUnsignedLongLong(_hash_murmur(kmer, seed));
 }
 
+PyDoc_STRVAR(hash_seed_doc,
+             "hash_seed() -> int\n\n"
+	     "Return the default seed when hashing.");
+
+static PyObject * hash_seed(void *)
+{
+  return PyLong_FromUnsignedLong((long)MINHASH_DEFAULT_SEED);
+}
+
 static PyMethodDef MinHashModuleMethods[] = {
     {
-        "hash_murmur", hash_murmur,
+      "hash_murmur", (PyCFunction)hash_murmur,
         METH_VARARGS, hash_murmur_doc,
+    },
+    {
+      "hash_seed", (PyCFunction)hash_seed,
+        METH_NOARGS, hash_seed_doc,
     },
     { NULL, NULL, 0, NULL } // sentinel
 };
@@ -635,8 +648,6 @@ MOD_INIT(_minhash)
     if (m == NULL) {
         return MOD_ERROR_VAL;
     }
-
-    PyModule_AddIntConstant(m, "DEFAULT_HASH_SEED", MINHASH_DEFAULT_SEED);
 
     if (PyType_Ready( &MinHash_Type ) < 0) {
         return MOD_ERROR_VAL;

--- a/sourmash_lib/_minhash.hh
+++ b/sourmash_lib/_minhash.hh
@@ -52,5 +52,6 @@ typedef struct {
     bool track_abundance = false;
 } MinHash_Object;
 
+
 #endif // _MINHASH_HH
  

--- a/sourmash_lib/_minhash.hh
+++ b/sourmash_lib/_minhash.hh
@@ -51,3 +51,4 @@ typedef struct {
 } MinHash_Object;
 
 #endif // _MINHASH_HH
+ 

--- a/sourmash_lib/_minhash.hh
+++ b/sourmash_lib/_minhash.hh
@@ -42,6 +42,8 @@
           ob = Py_InitModule3(name, methods, doc);
 #endif
 
+#define MINHASH_DEFAULT_SEED 42
+
 #include "kmer_min_hash.hh"
 
 typedef struct {

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -37,13 +37,14 @@ protected:
 class KmerMinHash
 {
 public:
+    const uint32_t seed;
     const unsigned int num;
     const unsigned int ksize;
     const bool is_protein;
     CMinHashType mins;
 
-    KmerMinHash(unsigned int n, unsigned int k, bool prot) :
-        num(n), ksize(k), is_protein(prot) { };
+    KmerMinHash(unsigned int n, unsigned int k, bool prot, uint32_t seed) :
+      num(n), ksize(k), is_protein(prot), seed(seed) { };
 
     virtual void _shrink() {
         while (mins.size() > num) {
@@ -56,8 +57,8 @@ public:
         mins.insert(h);
         _shrink();
     }
-    void add_word(std::string word) {
-        HashIntoType hash = _hash_murmur(word);
+  void add_word(std::string word) {
+    HashIntoType hash = _hash_murmur(word, seed);
         add_hash(hash);
     }
     void add_sequence(const char * sequence, bool force=false) {
@@ -251,8 +252,8 @@ class KmerMinAbundance: public KmerMinHash {
     CMinAbundanceType mins;
     HashIntoType max_mins;
 
-    KmerMinAbundance(unsigned int n, unsigned int k, bool prot) :
-        KmerMinHash(n, k, prot) { };
+  KmerMinAbundance(unsigned int n, unsigned int k, bool prot, uint32_t seed) :
+      KmerMinHash(n, k, prot, seed) { };
 
     virtual void add_hash(HashIntoType h) {
         if (mins.size() < num) {
@@ -278,7 +279,7 @@ class KmerMinAbundance: public KmerMinHash {
     virtual void _shrink() {
         while (mins.size() > num) {
             mins.erase(max_mins);
-            max_mins = (*std::max_element(mins.begin(), mins.end())).first;
+            max_mins = (*std::max_element(mins.begin(), m ins.end())).first;
         }
     }
 

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -279,7 +279,7 @@ class KmerMinAbundance: public KmerMinHash {
     virtual void _shrink() {
         while (mins.size() > num) {
             mins.erase(max_mins);
-            max_mins = (*std::max_element(mins.begin(), m ins.end())).first;
+            max_mins = (*std::max_element(mins.begin(), mins.end())).first;
         }
     }
 

--- a/sourmash_lib/test__minhash.py
+++ b/sourmash_lib/test__minhash.py
@@ -394,7 +394,7 @@ def test_murmur():
     assert x == 1731421407650554201
     
     y = hash_murmur("ACG", 43)
-     assert y != x
+    assert y != x
     
 
 def test_abundance_simple():

--- a/sourmash_lib/test__minhash.py
+++ b/sourmash_lib/test__minhash.py
@@ -390,6 +390,12 @@ def test_murmur():
     except TypeError:
         pass
 
+    x = hash_murmur("ACG", 42)
+    assert x == 1731421407650554201
+    
+    y = hash_murmur("ACG", 43)
+     assert y != x
+    
 
 def test_abundance_simple():
     a = MinHash(20, 5, False, track_abundance=True)


### PR DESCRIPTION
Initial changes to expose hashing seed used at C-level as a parameter (see issue #76).

If deemed reasonable this can be propagated up to command-line.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
