### PR TITLE
Fix segfault in MinHash.set_abundances

### DIFF
--- a/sourmash_lib/_minhash.cc
+++ b/sourmash_lib/_minhash.cc
@@ -178,10 +178,10 @@ minhash_set_counters(MinHash_Object * me, PyObject * args)
     }
 
     if (!me->track_abundance) {
-        KmerMinHash *old_mh = me->mh;
-        me->mh = new KmerMinAbundance(*old_mh);
-        me->track_abundance = true;
-        delete old_mh;
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "Use track_abundance=True when constructing the MinHash to use set_abundances.");
+        return NULL;
     }
 
     KmerMinAbundance *mh = (KmerMinAbundance*)me->mh;

--- a/sourmash_lib/_minhash.cc
+++ b/sourmash_lib/_minhash.cc
@@ -177,7 +177,15 @@ minhash_set_counters(MinHash_Object * me, PyObject * args)
         return NULL;
     }
 
+    if (!me->track_abundance) {
+        KmerMinHash *old_mh = me->mh;
+        me->mh = new KmerMinAbundance(*old_mh);
+        me->track_abundance = true;
+        delete old_mh;
+    }
+
     KmerMinAbundance *mh = (KmerMinAbundance*)me->mh;
+
     PyObject *key, *value;
     Py_ssize_t pos = 0;
 

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -254,6 +254,14 @@ class KmerMinAbundance: public KmerMinHash {
     KmerMinAbundance(unsigned int n, unsigned int k, bool prot) :
         KmerMinHash(n, k, prot) { };
 
+    KmerMinAbundance(KmerMinHash minhash) :
+        KmerMinHash(minhash) {
+            for (auto m : minhash.mins) {
+                mins[m] = 1;
+            }
+            max_mins = (*std::max_element(mins.begin(), mins.end())).first;
+        };
+
     virtual void add_hash(HashIntoType h) {
         if (mins.size() < num) {
             mins[h] += 1;

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -254,14 +254,6 @@ class KmerMinAbundance: public KmerMinHash {
     KmerMinAbundance(unsigned int n, unsigned int k, bool prot) :
         KmerMinHash(n, k, prot) { };
 
-    KmerMinAbundance(KmerMinHash minhash) :
-        KmerMinHash(minhash) {
-            for (auto m : minhash.mins) {
-                mins[m] = 1;
-            }
-            max_mins = (*std::max_element(mins.begin(), mins.end())).first;
-        };
-
     virtual void add_hash(HashIntoType h) {
         if (mins.size() < num) {
             mins[h] += 1;

--- a/sourmash_lib/test__minhash.py
+++ b/sourmash_lib/test__minhash.py
@@ -36,6 +36,8 @@
 from __future__ import print_function
 from __future__ import absolute_import, unicode_literals
 
+import pytest
+
 from ._minhash import MinHash, hash_murmur
 
 # add:
@@ -468,6 +470,8 @@ def test_abundance_compare():
 
 def test_set_abundance():
     a = MinHash(20, 10, track_abundance=False)
-    a.add_hash(1)
-    a.add_hash(2)
-    a.set_abundances({1: 3, 2: 4})
+
+    with pytest.raises(RuntimeError) as e:
+        a.set_abundances({1: 3, 2: 4})
+
+    assert "track_abundance=True when constructing" in e.value.args[0]

--- a/sourmash_lib/test__minhash.py
+++ b/sourmash_lib/test__minhash.py
@@ -46,6 +46,7 @@ from ._minhash import MinHash, hash_murmur
 # * nan on empty minhash
 # * define equals
 
+
 def test_basic_dna(track_abundance):
     # verify that MHs of size 1 stay size 1, & act properly as bottom sketches.
     mh = MinHash(1, 4, track_abundance=track_abundance)
@@ -463,3 +464,10 @@ def test_abundance_compare():
     assert x >= 0.3, x
     assert a.compare(a) == 1.0
     assert b.compare(b) == 1.0
+
+
+def test_set_abundance():
+    a = MinHash(20, 10, track_abundance=False)
+    a.add_hash(1)
+    a.add_hash(2)
+    a.set_abundances({1: 3, 2: 4})


### PR DESCRIPTION
Fixes #73 Raise an exception when calling `set_abundances` on a KmerMinHash instance instead of a KmerMinAbundance instance.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
