### PR TITLE
[MRG] Refactor lazy loading

### DIFF
--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -74,16 +74,6 @@ def GraphFactory(ksize, starting_size, n_tables):
     return create_nodegraph
 
 
-class LazyNode(object):
-    def __init__(self, load_fn, *args):
-        self.load_fn = load_fn
-        self.args = args
-
-    def do_load(self):
-        sbt_node = self.load_fn(*self.args)
-        return sbt_node
-
-
 class SBT(object):
 
     def __init__(self, factory, d=2):
@@ -149,7 +139,6 @@ class SBT(object):
             if node_g is None:
                 continue
 
-            node_g = node_g.do_load()
             if node_p not in visited:
                 visited.add(node_p)
                 if search_fn(node_g, *args):
@@ -267,9 +256,9 @@ class SBT(object):
 
             if 'internal' in jnode['filename']:
                 jnode['factory'] = factory
-                sbt_node = LazyNode(Node.load, jnode, dirname)
+                sbt_node = Node.load(jnode, dirname)
             else:
-                sbt_node = LazyNode(leaf_loader, jnode, dirname)
+                sbt_node = leaf_loader(jnode, dirname)
 
             sbt_nodes.append(sbt_node)
 
@@ -298,9 +287,9 @@ class SBT(object):
 
             if 'internal' in node['filename']:
                 node['factory'] = factory
-                sbt_node = LazyNode(Node.load, node, dirname)
+                sbt_node = Node.load(node, dirname)
             else:
-                sbt_node = LazyNode(leaf_loader, node, dirname)
+                sbt_node = leaf_loader(node, dirname)
 
             sbt_nodes.append(sbt_node)
 
@@ -350,11 +339,13 @@ class SBT(object):
 
 
 class Node(object):
-    "Internal node of SBT; has 0, 1, or 2 children."
+    "Internal node of SBT."
 
-    def __init__(self, factory, name=None):
-        self.data = factory()
+    def __init__(self, factory, name=None, fullpath=None):
         self.name = name
+        self._factory = factory
+        self._data = None
+        self._filename = fullpath
 
     def __str__(self):
         return '*Node:{name} [occupied: {nb}, fpr: {fpr:.2}]'.format(
@@ -364,28 +355,34 @@ class Node(object):
     def save(self, filename):
         self.data.save(filename)
 
+    @property
+    def data(self):
+        if self._data is None:
+            if self._filename is None:
+                self._data = self._factory()
+            else:
+                self._data = khmer.load_nodegraph(self._filename)
+        return self._data
+
+    @data.setter
+    def data(self, new_data):
+        self._data = new_data
+
     @staticmethod
     def load(info, dirname):
-        new_node = Node(info['factory'], name=info['name'])
-
         filename = os.path.join(dirname, info['filename'])
-        new_node.data = khmer.load_nodegraph(filename)
+        new_node = Node(info['factory'], name=info['name'], fullpath=filename)
         return new_node
-
-    def do_load(self):                    # for lazy loading, quickfix
-        return self
 
 
 class Leaf(object):
-    def __init__(self, metadata, data, name=None):
+    def __init__(self, metadata, data=None, name=None, fullpath=None):
         self.metadata = metadata
         if name is None:
             name = metadata
         self.name = name
-        self.data = data
-
-    def do_load(self):                    # for lazy loading, quickfix
-        return self
+        self._data = data
+        self._filename = fullpath
 
     def __str__(self):
         return '**Leaf:{name} [occupied: {nb}, fpr: {fpr:.2}] -> {metadata}'.format(
@@ -393,17 +390,27 @@ class Leaf(object):
                 nb=self.data.n_occupied(),
                 fpr=khmer.calc_expected_collisions(self.data, True, 1.1))
 
+    @property
+    def data(self):
+        if self._data is None:
+            # TODO: what if self._filename is None?
+            self._data = khmer.load_nodegraph(self._filename)
+        return self._data
+
+    @data.setter
+    def data(self, new_data):
+        self._data = new_data
+
     def save(self, filename):
         self.data.save(filename)
 
     def update(self, parent):
         parent.data.update(self.data)
 
-    @staticmethod
-    def load(info, dirname):
-        filepath = os.path.join(dirname, info['filename'])
-        data = khmer.load_nodegraph(filepath)
-        return Leaf(info['metadata'], data, name=info['name'])
+    @classmethod
+    def load(cls, info, dirname):
+        filename = os.path.join(dirname, info['filename'])
+        return cls(info['metadata'], name=info['name'], fullpath=filename)
 
 
 def filter_distance( filter_a, filter_b, n=1000 ) :

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 
-import os
-
 from .sbt import Leaf
 from . import Estimators
 
@@ -17,12 +15,8 @@ class SigLeaf(Leaf):
 
         # this is here only for triggering the property load
         # before we reopen the file (and overwrite the previous
-        # content) ...
+        # content...)
         self.data
-
-        if filename == self._filename and os.exists(filename):
-            # TODO: file already exists, do we want to overwrite?
-            return
 
         with open(filename, 'w') as fp:
             signature.save_signatures([self.data], fp)

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
 from __future__ import division
-import os
 
 from .sbt import Leaf
 from . import Estimators
-
 
 class SigLeaf(Leaf):
     def __str__(self):
@@ -20,14 +18,17 @@ class SigLeaf(Leaf):
         for v in self.data.estimator.mh.get_mins():
             parent.data.count(v)
 
-    @staticmethod
-    def load(info, dirname):
-        from sourmash_lib import signature
+    @property
+    def data(self):
+        if self._data is None:
+            from sourmash_lib import signature
+            it = signature.load_signatures(self._filename)
+            self._data, = list(it)              # should only be one signature
+        return self._data
 
-        filename = os.path.join(dirname, info['filename'])
-        it = signature.load_signatures(filename)
-        data, = list(it)              # should only be one signature
-        return SigLeaf(info['metadata'], data, name=info['name'])
+    @data.setter
+    def data(self, new_data):
+        self._data = new_data
 
 
 def search_minhashes(node, sig, threshold, results=None):

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -1,8 +1,11 @@
 from __future__ import print_function
 from __future__ import division
 
+import os
+
 from .sbt import Leaf
 from . import Estimators
+
 
 class SigLeaf(Leaf):
     def __str__(self):
@@ -11,6 +14,16 @@ class SigLeaf(Leaf):
 
     def save(self, filename):
         from sourmash_lib import signature
+
+        # this is here only for triggering the property load
+        # before we reopen the file (and overwrite the previous
+        # content) ...
+        self.data
+
+        if filename == self._filename and os.exists(filename):
+            # TODO: file already exists, do we want to overwrite?
+            return
+
         with open(filename, 'w') as fp:
             signature.save_signatures([self.data], fp)
 


### PR DESCRIPTION
Use lazy loading of the `.data` property in `Node`, `Leaf` and `SigLeaf`.

(This also opens the path for using a cache for the data in the nodes: load all the nodes to memory, but only load the data when needed and with an upper bound for how much data can be loaded).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
