### PR TITLE
[MRG] Speed up MinHash by using a vector instead of a set

### DIFF
--- a/sourmash_lib/_minhash.pxd
+++ b/sourmash_lib/_minhash.pxd
@@ -9,11 +9,12 @@ from libcpp.memory cimport unique_ptr
 from libcpp.set cimport set
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t, uint64_t
+from libcpp.vector cimport vector
 
 
 cdef extern from "kmer_min_hash.hh":
     ctypedef uint64_t HashIntoType;
-    ctypedef set[HashIntoType] CMinHashType;
+    ctypedef vector[HashIntoType] CMinHashType;
     ctypedef map[HashIntoType, uint64_t] CMinAbundanceType;
 
 

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -61,7 +61,7 @@ public:
     virtual void _shrink() {
         // pass
     }
-    virtual void add_hash(HashIntoType h) {
+    virtual void add_hash(const HashIntoType h) {
       if (mins.back() > h or mins.size() < num) {
         auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
 
@@ -79,8 +79,8 @@ public:
         }
       }
     }
-    void add_word(std::string word) {
-        HashIntoType hash = _hash_murmur(word, seed);
+    void add_word(const std::string& word) {
+        const HashIntoType hash = _hash_murmur(word, seed);
         add_hash(hash);
     }
     void add_sequence(const char * sequence, bool force=false) {
@@ -90,8 +90,8 @@ public:
         const std::string seq = _checkdna(sequence, force);
         if (!is_protein) {
             for (unsigned int i = 0; i < seq.length() - ksize + 1; i++) {
-                std::string kmer = seq.substr(i, ksize);
-                std::string rc = _revcomp(kmer);
+                const std::string kmer = seq.substr(i, ksize);
+                const std::string rc = _revcomp(kmer);
                 if (kmer < rc) {
                     add_word(kmer);
                 } else {

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -81,19 +81,25 @@ public:
         // pass
     }
     virtual void add_hash(const HashIntoType h) {
-      if (h <= max_hash and (mins.back() > h or mins.size() < num)) {
-        auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
-
-        // must still be growing, we know the list won't get too long
-        if (pos == mins.cend()) {
+      if (h <= max_hash) {
+        if (mins.size() == 0) {
           mins.push_back(h);
+          return;
         }
-        // inserting somewhere in the middle, if this value isn't already
-        // in mins store it and shrink list if needed
-        else if (*pos != h) {
-          mins.insert(pos, h);
-          if (mins.size() > num) {
-            mins.pop_back();
+        else if (mins.back() > h or mins.size() < num) {
+          auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
+
+          // must still be growing, we know the list won't get too long
+          if (pos == mins.cend()) {
+            mins.push_back(h);
+          }
+          // inserting somewhere in the middle, if this value isn't already
+          // in mins store it and shrink list if needed
+          else if (*pos != h) {
+            mins.insert(pos, h);
+            if (mins.size() > num) {
+              mins.pop_back();
+            }
           }
         }
       }

--- a/sourmash_lib/test__minhash.py
+++ b/sourmash_lib/test__minhash.py
@@ -583,6 +583,7 @@ def test_abundance_count_common():
     assert b.get_mins(with_abundance=True) == [2110480117637990133,
                                                10798773792509008305]
 
+
 def test_abundance_compare():
     a = MinHash(20, 10, track_abundance=True)
     b = MinHash(20, 10, track_abundance=False)

--- a/sourmash_lib/test__minhash.py
+++ b/sourmash_lib/test__minhash.py
@@ -326,6 +326,33 @@ def test_mh_merge(track_abundance):
     assert d.compare(c) == 1.0
 
 
+def test_mh_merge_check_length(track_abundance):
+    a = MinHash(20, 10, track_abundance=track_abundance)
+    for i in range(0, 40, 2):
+        a.add_hash(i)
+
+    b = MinHash(20, 10, track_abundance=track_abundance)
+    for i in range(0, 80, 4):
+        b.add_hash(i)
+
+    c = a.merge(b)
+    assert(len(c.get_mins()) == 20)
+
+
+def test_mh_merge_check_length2(track_abundance):
+    # merged MH doesn't have full number of elements
+    a = MinHash(4, 10, track_abundance=track_abundance)
+    a.add_hash(3)
+    a.add_hash(1)
+    a.add_hash(4)
+
+    b = MinHash(4, 10, track_abundance=track_abundance)
+    b.add_hash(3)
+    b.add_hash(1)
+    b.add_hash(4)
+
+    c = a.merge(b)
+    assert(len(c.get_mins()) == 3)
 
 
 def test_mh_asymmetric_merge(track_abundance):
@@ -394,6 +421,7 @@ def test_mh_inplace_concat(track_abundance):
     assert c.get_mins() == d.get_mins()
     assert c.compare(d) == 1.0
     assert d.compare(c) == 1.0
+
 
 def test_mh_merge_diff_protein(track_abundance):
     a = MinHash(20, 5, False, track_abundance=track_abundance)

--- a/sourmash_lib/test__minhash.py
+++ b/sourmash_lib/test__minhash.py
@@ -620,3 +620,15 @@ def test_set_abundance():
         a.set_abundances({1: 3, 2: 4})
 
     assert "track_abundance=True when constructing" in e.value.args[0]
+
+
+def test_reviving_minhash():
+    # simulate reading a MinHash from disk
+    mh = MinHash(4294967295, 21, max_hash=184467440737095520, seed=42,
+                 track_abundance=False)
+    mins = (28945103950853965, 74690756200987412, 82962372765557409,
+            93503551367950366, 106923350319729608, 135116761470196737,
+            160165359281648267, 162390811417732001, 177939655451276972)
+
+    for m in mins:
+        mh.add_hash(m)


### PR DESCRIPTION
Keep the list of N minimum hash values dense and cache local by using a vector instead of a set.

Thoughts on the general sentiment?

I used `time_add_sequence` and `time_add_hash` from #100 as benchmarks:

| bench | add_sequence | add_hash |
|----------|-----------|------------|
| master | 0.81 | 0.16 |
| d92a3da | 0.68 | 0.11 |
| 0e6ec9e | 0.60 | 0.11 |
| 55bc2ad | 0.56 | 0.11 |

There are a few tests that don't yet pass and we can be much smarter in the `combine` methods. Before spending time cleaning it up: is the performance boost worth it? is the benchmark I used useful or should I try something else to conclude that it does speed things up?

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] No changes to the command line
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
