### PR TITLE
[MRG] Add deduction of ksize from query

### DIFF
--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -915,8 +915,7 @@ def watch(args):
 
     def get_ksize(tree):
         """Walk nodes in `tree` to find out ksize"""
-        for node in tree.nodes:
-            node = node.do_load()
+        for node in tree.nodes.values():
             if isinstance(node, sourmash_lib.sbtmh.SigLeaf):
                 return node.data.estimator.ksize
 
@@ -925,8 +924,8 @@ def watch(args):
     if ksize is None:
         ksize = get_ksize(tree)
 
-    E = sourmash_lib.Estimators(ksize=ksize, n=args.num_hashes,
-                                is_protein=is_protein)
+    E = sourmash_lib.MinHash(ksize=ksize, n=args.num_hashes,
+                             is_protein=is_protein)
     streamsig = sig.SourmashSignature('', E, filename='stdin',
                                       name=args.name)
 

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -24,10 +24,10 @@ def search(args):
     parser.add_argument('against', nargs='+', help='list of signatures')
     parser.add_argument('--threshold', default=0.08, type=float)
     parser.add_argument('-n', '--num-results', default=3, type=int)
-    parser.add_argument('-k', '--ksize', default=DEFAULT_K, type=int)
     parser.add_argument('-f', '--force', action='store_true')
     parser.add_argument('--save-matches', type=argparse.FileType('wt'))
 
+    sourmash_args.add_ksize_arg(parser, DEFAULT_K)
     sourmash_args.add_moltype_args(parser)
 
     args = parser.parse_args(args)
@@ -318,10 +318,10 @@ def compare(args):
 
     parser = argparse.ArgumentParser()
     parser.add_argument('signatures', nargs='+', help='list of signatures')
-    parser.add_argument('-k', '--ksize', type=int, default=DEFAULT_K, help='k-mer size (default: %(default)s)')
     parser.add_argument('-o', '--output')
     parser.add_argument('--ignore-abundance', action='store_true',
                         help='do NOT use k-mer abundances if present')
+    sourmash_args.add_ksize_arg(parser, DEFAULT_K)
     args = parser.parse_args(args)
 
     # load in the various signatures
@@ -705,12 +705,12 @@ def sbt_gather(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('sbt_name', help='name of SBT to search')
     parser.add_argument('query', help='query signature')
-    parser.add_argument('-k', '--ksize', type=int, default=DEFAULT_K)
     parser.add_argument('--threshold', default=0.05, type=float)
     parser.add_argument('-o', '--output', type=argparse.FileType('wt'))
     parser.add_argument('--csv', type=argparse.FileType('wt'))
     parser.add_argument('--save-matches', type=argparse.FileType('wt'))
 
+    sourmash_args.add_ksize_arg(parser, DEFAULT_K)
     sourmash_args.add_moltype_args(parser)
 
     args = parser.parse_args(args)
@@ -763,7 +763,7 @@ def sbt_gather(args):
 
     # define a function to build new signature object from set of mins
     def build_new_signature(mins):
-        e = sourmash_lib.MinHash(ksize=args.ksize, n=len(mins))
+        e = sourmash_lib.MinHash(ksize=query_ksize, n=len(mins))
         e.add_many(mins)
         return sig.SourmashSignature('', e)
 
@@ -886,7 +886,6 @@ def watch(args):
     parser.add_argument('sbt_name', help='name of SBT to search')
     parser.add_argument('inp_file', nargs='?', default='/dev/stdin')
     parser.add_argument('-o', '--output', type=argparse.FileType('wt'))
-    parser.add_argument('-k', '--ksize', type=int, default=DEFAULT_K)
     parser.add_argument('--threshold', default=0.05, type=float)
     parser.add_argument('--input-is-protein', action='store_true')
     sourmash_args.add_moltype_args(parser, default_dna=True)
@@ -894,6 +893,7 @@ def watch(args):
                         default=DEFAULT_N,
                         help='number of hashes to use in each sketch (default: %(default)i)')
     parser.add_argument('--name', type=str, default='stdin')
+    sourmash_args.add_ksize_arg(parser, DEFAULT_K)
     args = parser.parse_args(args)
 
     if args.input_is_protein and args.dna:
@@ -911,16 +911,27 @@ def watch(args):
         moltype = 'protein'
         is_protein = True
 
-    E = sourmash_lib.MinHash(ksize=args.ksize, n=args.num_hashes,
+    tree = SBT.load(args.sbt_name, leaf_loader=SigLeaf.load)
+
+    def get_ksize(tree):
+        """Walk nodes in `tree` to find out ksize"""
+        for node in tree.nodes:
+            node = node.do_load()
+            if isinstance(node, sourmash_lib.sbtmh.SigLeaf):
+                return node.data.estimator.ksize
+
+    # deduce ksize from the SBT we are loading
+    ksize = args.ksize
+    if ksize is None:
+        ksize = get_ksize(tree)
+
+    E = sourmash_lib.Estimators(ksize=ksize, n=args.num_hashes,
                                 is_protein=is_protein)
     streamsig = sig.SourmashSignature('', E, filename='stdin',
                                       name=args.name)
 
     notify('Computing signature for k={}, {} from stdin',
-           args.ksize, moltype)
-
-
-    tree = SBT.load(args.sbt_name, leaf_loader=SigLeaf.load)
+           ksize, moltype)
 
     def do_search():
         search_fn = SearchMinHashesFindBest().search

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -52,7 +52,7 @@ def search(args):
             continue
 
         sl = sig.load_signatures(filename,
-                                 select_ksize=args.ksize,
+                                 select_ksize=query_ksize,
                                  select_moltype=moltype)
 
         for x in sl:

--- a/sourmash_lib/sourmash_args.py
+++ b/sourmash_lib/sourmash_args.py
@@ -4,7 +4,8 @@ Utility functions for dealing with input args to the sourmash command line.
 import sys
 import os
 from . import signature
-from .logging import error, notify
+from .logging import error
+
 
 def add_moltype_args(parser, default_dna=None):
     parser.add_argument('--protein', dest='protein', action='store_true')
@@ -16,6 +17,11 @@ def add_moltype_args(parser, default_dna=None):
                         action='store_true')
     parser.add_argument('--no-dna', dest='dna', action='store_false')
     parser.set_defaults(dna=default_dna)
+
+
+def add_ksize_arg(parser, default):
+    parser.add_argument('-k', '--ksize', default=None, type=int,
+                        help='k-mer size (default: {d})'.format(d=default))
 
 
 def get_moltype(sig, require=False):
@@ -43,6 +49,7 @@ def calculate_moltype(args, default=None):
         moltype = 'dna'
 
     return moltype
+
 
 def load_query_signature(filename, select_ksize, select_moltype):
     sl = signature.load_signatures(filename,

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -637,6 +637,24 @@ def test_compare_deduce_molecule():
         assert 'min similarity in matrix: 0.944' in err
 
 
+def test_compare_deduce_ksize():
+    # deduce ksize, if it is unique
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '-k', '29',
+                                            testdata1, testdata2],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare', 'short.fa.sig',
+                                            'short2.fa.sig'],
+                                           in_directory=location)
+        print(status, out, err)
+        assert 'min similarity in matrix: 0.96' in err
+
+
 def test_search_deduce_molecule():
     # deduce DNA vs protein from query, if it is unique
     with utils.TempDirectory() as location:
@@ -674,6 +692,30 @@ def test_search_deduce_ksize():
         print(status, out, err)
         assert '1 matches' in err
         assert 'k=23' in err
+
+
+def test_search_deduce_ksize_and_select_appropriate():
+    # deduce ksize from query and select correct signature from DB
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '-k', '24',
+                                            testdata1],
+                                           in_directory=location)
+        # The DB contains signatres for multiple ksizes
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '-k', '23,24',
+                                            testdata2],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['search', 'short.fa.sig',
+                                            'short2.fa.sig'],
+                                           in_directory=location)
+        print(status, out, err)
+        assert '1 matches' in err
+        assert 'k=24' in err
 
 
 def test_search_deduce_ksize_not_unique():
@@ -1464,10 +1506,10 @@ def test_watch_deduce_ksize():
     with utils.TempDirectory() as location:
         testdata0 = utils.get_test_data('genome-s10.fa.gz')
         utils.runscript('sourmash',
-                        ['compute', testdata0, '-k', '31', '-o', '1.sig'],
+                        ['compute', testdata0, '-k', '29', '-o', '1.sig'],
                         in_directory=location)
 
-        args = ['sbt_index', '--dna', '-k', '31', 'zzz', '1.sig']
+        args = ['sbt_index', '--dna', '-k', '29', 'zzz', '1.sig']
         status, out, err = utils.runscript('sourmash', args,
                                            in_directory=location)
 
@@ -1480,7 +1522,7 @@ def test_watch_deduce_ksize():
 
         print(out)
         print(err)
-        assert 'Computing signature for k=31' in err
+        assert 'Computing signature for k=29' in err
         assert 'genome-s10.fa.gz, at 1.000' in err
 
 


### PR DESCRIPTION
Fixes #105 

When the query only contains one k-size then use that unless
user specified a particular k. Same when there is only one molecule type.

- [x] search
- [x] compare
- [x] watch
- [x] gather
---
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
