### PR TITLE
[MRG] SBT feature: combine trees

### DIFF
--- a/sourmash_lib/__main__.py
+++ b/sourmash_lib/__main__.py
@@ -8,7 +8,8 @@ import argparse
 from .logging import notify, error
 
 from .commands import (categorize, compare, compute, convert, dump, import_csv,
-                       sbt_gather, sbt_index, sbt_search, search, plot, watch)
+                       sbt_gather, sbt_index, sbt_combine, sbt_search, search,
+                       plot, watch)
 
 
 def main():
@@ -17,7 +18,8 @@ def main():
                 'import_csv': import_csv, 'dump': dump,
                 'sbt_index': sbt_index, 'sbt_search': sbt_search,
                 'categorize': categorize, 'sbt_gather': sbt_gather,
-                'watch': watch, 'convert': convert}
+                'watch': watch, 'convert': convert,
+                'sbt_combine': sbt_combine}
     parser = argparse.ArgumentParser(
         description='work with RNAseq signatures',
         usage='''sourmash <command> [<args>]
@@ -33,6 +35,7 @@ import_csv                  Import signatures from a CSV file.
 convert                     Convert signatures from YAML to JSON.
 
 sbt_index                   Index signatures with a Sequence Bloom Tree.
+sbt_combine                 Combine multiple Sequence Bloom Trees into a new one.
 sbt_search                  Search a Sequence Bloom Tree.
 categorize                  Categorize signatures with a SBT.
 sbt_gather                  Search a signature for multiple matches.

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -480,6 +480,35 @@ def dump(args):
         fp.close()
 
 
+def sbt_combine(args):
+    from sourmash_lib.sbt import SBT, GraphFactory
+    from sourmash_lib.sbtmh import SigLeaf
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('sbt_name', help='name to save SBT into')
+    parser.add_argument('sbts', nargs='+',
+                        help='SBTs to combine to a new SBT')
+    parser.add_argument('-x', '--bf-size', type=float, default=1e5)
+
+    sourmash_args.add_moltype_args(parser)
+
+    args = parser.parse_args(args)
+    moltype = sourmash_args.calculate_moltype(args)
+
+    inp_files = list(args.sbts)
+    notify('combining {} SBTs', len(inp_files))
+
+    tree = SBT.load(inp_files.pop(0), leaf_loader=SigLeaf.load)
+
+    for f in inp_files:
+        new_tree = SBT.load(f, leaf_loader=SigLeaf.load)
+        # TODO: check if parameters are the same for both trees!
+        tree.combine(new_tree)
+
+    notify('saving SBT under "{}"', args.sbt_name)
+    tree.save(args.sbt_name)
+
+
 def sbt_index(args):
     from sourmash_lib.sbt import SBT, GraphFactory
     from sourmash_lib.sbtmh import search_minhashes, SigLeaf

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -80,12 +80,13 @@ class SBT(object):
         self.factory = factory
         self.nodes = defaultdict(lambda: None)
         self.d = d
+        self.max_node = 0
 
     def new_node_pos(self, node):
-        if self.nodes:
-            return max(self.nodes) + 1
-        else:
-            return 0
+        while self.nodes[self.max_node] is not None:
+            self.max_node += 1
+        next_node = self.max_node
+        return next_node
 
     def add_node(self, node):
         pos = self.new_node_pos(node)

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -81,8 +81,7 @@ class SBT(object):
     def new_node_pos(self, node):
         while self.nodes[self.max_node] is not None:
             self.max_node += 1
-        next_node = self.max_node
-        return next_node
+        return self.max_node
 
     def add_node(self, node):
         pos = self.new_node_pos(node)
@@ -359,10 +358,16 @@ class SBT(object):
                             # An internal node, we need to update the name
                             new_node.name = "internal.{}".format(current_pos)
                         new_nodes[current_pos] = new_node
+                    if tree.nodes[pos] is None:
+                        del tree.nodes[pos]
                     current_pos += 1
             n_previous = n_next
             n_next = n_previous + int(self.d ** level)
             current_pos = n_next
+
+        # reset max_node, next time we add a node it will find the next
+        # empty position
+        self.max_node = 2
 
         # TODO: do we want to return a new tree, or merge into this one?
         self.nodes = new_nodes

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -359,7 +359,7 @@ class SBT(object):
                             # An internal node, we need to update the name
                             new_node.name = "internal.{}".format(current_pos)
                         new_nodes[current_pos] = new_node
-                    if tree.nodes[pos] is None:
+                    else:
                         del tree.nodes[pos]
                     current_pos += 1
             n_previous = n_next

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -183,6 +183,7 @@ class SBT(object):
                 structure[i] = None
                 continue
 
+            node = node.do_load()
             basename = os.path.basename(node.name)
             data = {
                 'filename': os.path.join('.sbt.' + basetag,

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -340,8 +340,8 @@ class SBT(object):
             larger, smaller = other, self
 
         n = Node(self.factory, name="internal.0")
-        larger.nodes[0].update(n)
-        smaller.nodes[0].update(n)
+        larger.nodes[0].do_load().update(n)
+        smaller.nodes[0].do_load().update(n)
         new_nodes = defaultdict(lambda: None)
         new_nodes[0] = n
 

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -342,6 +342,16 @@ class SBT(object):
     def leaves(self):
         return [c for c in self.nodes.values() if isinstance(c, Leaf)]
 
+    def combine(self, other):
+        # TODO: first pass, the dumb way:
+        # 1) find all leaves in other
+        # 2) add all leaves in other to self
+        # Why is is dumb? Because we already have all the internal nodes
+        # ready in other, so instead we can reuse them.
+        for leaf in other.leaves():
+            self.add_node(leaf)
+
+
 class Node(object):
     "Internal node of SBT."
 

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -348,17 +348,20 @@ class SBT(object):
 
         levels = int(math.ceil(math.log(len(larger.nodes), self.d))) + 1
         current_pos = 1
-        for level in range(1, levels):
+        n_previous = 0
+        n_next = 1
+        for level in range(1, levels + 1):
             for tree in (larger, smaller):
-                for pos in range(int(self.d ** (level - 1)),
-                                 int(self.d ** level)):
-                    if tree.nodes[pos - 1] is not None:
-                        new_node = copy(tree.nodes[pos - 1])
+                for pos in range(n_previous, n_next):
+                    if tree.nodes[pos] is not None:
+                        new_node = copy(tree.nodes[pos])
                         if isinstance(new_node, Node):
                             # An internal node, we need to update the name
                             new_node.name = "internal.{}".format(current_pos)
                         new_nodes[current_pos] = new_node
                     current_pos += 1
+            n_previous = n_next
+            n_next = n_previous + int(self.d ** level)
 
         # TODO: do we want to return a new tree, or merge into this one?
         self.nodes = new_nodes

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -183,7 +183,6 @@ class SBT(object):
                 structure[i] = None
                 continue
 
-            node = node.do_load()
             basename = os.path.basename(node.name)
             data = {
                 'filename': os.path.join('.sbt.' + basetag,
@@ -341,8 +340,8 @@ class SBT(object):
             larger, smaller = other, self
 
         n = Node(self.factory, name="internal.0")
-        larger.nodes[0].do_load().update(n)
-        smaller.nodes[0].do_load().update(n)
+        larger.nodes[0].update(n)
+        smaller.nodes[0].update(n)
         new_nodes = defaultdict(lambda: None)
         new_nodes[0] = n
 

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -306,16 +306,13 @@ class SBT(object):
         edge [arrowsize=0.8];
         """)
 
-        for i, node in iter(self):
-            if node is None:
-                continue
-
-            p = self.parent(i)
-            if p is not None:
-                if isinstance(node, Leaf):
-                    print('"', p.pos, '"', '->', '"', node.name, '";')
-                else:
-                    print('"', p.pos, '"', '->', '"', i, '";')
+        for i, node in list(self.nodes.items()):
+            if isinstance(node, Node):
+                print('"{}" [shape=box fillcolor=gray style=filled]'.format(
+                      node.name))
+                for j, child in self.children(i):
+                    if child is not None:
+                        print('"{}" -> "{}"'.format(node.name, child.name))
         print("}")
 
     def print(self):

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -362,6 +362,7 @@ class SBT(object):
                     current_pos += 1
             n_previous = n_next
             n_next = n_previous + int(self.d ** level)
+            current_pos = n_next
 
         # TODO: do we want to return a new tree, or merge into this one?
         self.nodes = new_nodes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,8 @@ import pytest
 @pytest.fixture(params=[True, False])
 def track_abundance(request):
     return request.param
+
+
+@pytest.fixture(params=[2, 5, 10])
+def n_children(request):
+    return request.param

--- a/tests/sourmash_tst_utils.py
+++ b/tests/sourmash_tst_utils.py
@@ -17,6 +17,12 @@ except ImportError:
     from io import StringIO
 
 
+SIG_FILES = [os.path.join('demo', f) for f in (
+  "SRR2060939_1.sig", "SRR2060939_2.sig", "SRR2241509_1.sig",
+  "SRR2255622_1.sig", "SRR453566_1.sig", "SRR453569_1.sig", "SRR453570_1.sig")
+]
+
+
 def scriptpath(scriptname='sourmash'):
     """Return the path to the scripts, in both dev and install situations."""
     # note - it doesn't matter what the scriptname is here, as long as

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -74,6 +74,7 @@ def test_simple():
     print([ x.metadata for x in root.find(search_kmer, "CAAAA") ])
     print([ x.metadata for x in root.find(search_kmer, "GAAAA") ])
 
+
 def test_longer_search():
     ksize = 5
     factory = GraphFactory(ksize, 100, 3)
@@ -205,3 +206,30 @@ def test_binary_nary_tree():
 
     assert set(results[2]) == set(results[5])
     assert set(results[5]) == set(results[10])
+
+
+def test_sbt_combine():
+    factory = GraphFactory(31, 1e5, 4)
+    tree = SBT(factory)
+    tree_1 = SBT(factory)
+    tree_2 = SBT(factory)
+
+    n_leaves = 0
+    for f in SIG_FILES:
+        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        leaf = SigLeaf(os.path.basename(f), sig)
+        tree.add_node(leaf)
+        if n_leaves < 4:
+            tree_1.add_node(leaf)
+        else:
+            tree_2.add_node(leaf)
+        n_leaves += 1
+
+    tree_1.combine(tree_2)
+
+    t1_leaves = {str(l) for l in tree_1.leaves()}
+    t_leaves = {str(l) for l in tree.leaves()}
+
+    assert len(t1_leaves) == n_leaves
+    assert len(t_leaves) == len(t1_leaves)
+    assert t1_leaves == t_leaves

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -243,3 +243,15 @@ def test_sbt_combine(n_children):
     assert t1_result == tree_result
 
     # TODO: save and load both trees
+
+    # check if adding a new node will use the next empty position
+    next_empty = 0
+    for n, d in tree_1.nodes.items():
+        if d is None:
+            next_empty = n
+            break
+    if not next_empty:
+        next_empty = n + 1
+
+    tree_1.add_node(leaf)
+    assert tree_1.max_node == next_empty

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -162,7 +162,8 @@ def test_tree_save_load(n_children):
 
     print('*' * 60)
     print("{}:".format(to_search.metadata))
-    old_result = [str(s) for s in tree.find(search_minhashes, to_search.data, 0.1)]
+    old_result = {str(s) for s in tree.find(search_minhashes,
+                                            to_search.data, 0.1)}
     print(*old_result, sep='\n')
 
     with utils.TempDirectory() as location:
@@ -172,8 +173,8 @@ def test_tree_save_load(n_children):
 
         print('*' * 60)
         print("{}:".format(to_search.metadata))
-        new_result = [str(s) for s in tree.find(search_minhashes,
-                                                to_search.data, 0.1)]
+        new_result = {str(s) for s in tree.find(search_minhashes,
+                                                to_search.data, 0.1)}
         print(*new_result, sep='\n')
 
         assert old_result == new_result
@@ -201,11 +202,11 @@ def test_binary_nary_tree():
     print('*' * 60)
     print("{}:".format(to_search.metadata))
     for d, tree in trees.items():
-        results[d] = [str(s) for s in tree.find(search_minhashes, to_search.data, 0.1)]
+        results[d] = {str(s) for s in tree.find(search_minhashes, to_search.data, 0.1)}
     print(*results[2], sep='\n')
 
-    assert set(results[2]) == set(results[5])
-    assert set(results[5]) == set(results[10])
+    assert results[2] == results[5]
+    assert results[5] == results[10]
 
 
 def test_sbt_combine(n_children):
@@ -235,10 +236,10 @@ def test_sbt_combine(n_children):
     assert t1_leaves == t_leaves
 
     to_search = next(signature.load_signatures(utils.get_test_data(SIG_FILES[0])))
-    t1_result = [str(s) for s in tree_1.find(search_minhashes,
-                                             to_search, 0.1)]
-    tree_result = [str(s) for s in tree.find(search_minhashes,
-                                             to_search, 0.1)]
+    t1_result = {str(s) for s in tree_1.find(search_minhashes,
+                                             to_search, 0.1)}
+    tree_result = {str(s) for s in tree.find(search_minhashes,
+                                             to_search, 0.1)}
     assert t1_result == tree_result
 
     # TODO: save and load both trees

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -15,9 +15,9 @@ SIG_FILES = [os.path.join('demo', f) for f in (
 ]
 
 
-def test_simple():
+def test_simple(n_children):
     factory = GraphFactory(5, 100, 3)
-    root = SBT(factory)
+    root = SBT(factory, d=n_children)
 
     leaf1 = Leaf("a", factory())
     leaf1.data.count('AAAAA')
@@ -75,10 +75,10 @@ def test_simple():
     print([ x.metadata for x in root.find(search_kmer, "GAAAA") ])
 
 
-def test_longer_search():
+def test_longer_search(n_children):
     ksize = 5
     factory = GraphFactory(ksize, 100, 3)
-    root = SBT(factory)
+    root = SBT(factory, d=n_children)
 
     leaf1 = Leaf("a", factory())
     leaf1.data.count('AAAAA')
@@ -150,9 +150,9 @@ def test_tree_v1_load():
     assert len(results_v1) == 4
 
 
-def test_tree_save_load():
+def test_tree_save_load(n_children):
     factory = GraphFactory(31, 1e5, 4)
-    tree = SBT(factory)
+    tree = SBT(factory, d=n_children)
 
     for f in SIG_FILES:
         sig = next(signature.load_signatures(utils.get_test_data(f)))
@@ -208,11 +208,11 @@ def test_binary_nary_tree():
     assert set(results[5]) == set(results[10])
 
 
-def test_sbt_combine():
+def test_sbt_combine(n_children):
     factory = GraphFactory(31, 1e5, 4)
-    tree = SBT(factory)
-    tree_1 = SBT(factory)
-    tree_2 = SBT(factory)
+    tree = SBT(factory, d=n_children)
+    tree_1 = SBT(factory, d=n_children)
+    tree_2 = SBT(factory, d=n_children)
 
     n_leaves = 0
     for f in SIG_FILES:
@@ -233,3 +233,12 @@ def test_sbt_combine():
     assert len(t1_leaves) == n_leaves
     assert len(t_leaves) == len(t1_leaves)
     assert t1_leaves == t_leaves
+
+    to_search = next(signature.load_signatures(utils.get_test_data(SIG_FILES[0])))
+    t1_result = [str(s) for s in tree_1.find(search_minhashes,
+                                             to_search, 0.1)]
+    tree_result = [str(s) for s in tree.find(search_minhashes,
+                                             to_search, 0.1)]
+    assert t1_result == tree_result
+
+    # TODO: save and load both trees

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -9,12 +9,6 @@ from sourmash_lib.sbt import SBT, GraphFactory, Leaf
 from sourmash_lib.sbtmh import SigLeaf, search_minhashes
 
 
-SIG_FILES = [os.path.join('demo', f) for f in (
-  "SRR2060939_1.sig", "SRR2060939_2.sig", "SRR2241509_1.sig",
-  "SRR2255622_1.sig", "SRR453566_1.sig", "SRR453569_1.sig", "SRR453570_1.sig")
-]
-
-
 def test_simple(n_children):
     factory = GraphFactory(5, 100, 3)
     root = SBT(factory, d=n_children)
@@ -138,7 +132,7 @@ def test_tree_v1_load():
     tree_v2 = SBT.load(utils.get_test_data('v2.sbt.json'),
                        leaf_loader=SigLeaf.load)
 
-    testdata1 = utils.get_test_data(SIG_FILES[0])
+    testdata1 = utils.get_test_data(utils.SIG_FILES[0])
     to_search = next(signature.load_signatures(testdata1))
 
     results_v1 = {str(s) for s in tree_v1.find(search_minhashes,
@@ -154,7 +148,7 @@ def test_tree_save_load(n_children):
     factory = GraphFactory(31, 1e5, 4)
     tree = SBT(factory, d=n_children)
 
-    for f in SIG_FILES:
+    for f in utils.SIG_FILES:
         sig = next(signature.load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.add_node(leaf)
@@ -188,7 +182,7 @@ def test_binary_nary_tree():
     trees[10] = SBT(factory, d=10)
 
     n_leaves = 0
-    for f in SIG_FILES:
+    for f in utils.SIG_FILES:
         sig = next(signature.load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         for tree in trees.values():
@@ -216,7 +210,7 @@ def test_sbt_combine(n_children):
     tree_2 = SBT(factory, d=n_children)
 
     n_leaves = 0
-    for f in SIG_FILES:
+    for f in utils.SIG_FILES:
         sig = next(signature.load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.add_node(leaf)
@@ -235,7 +229,8 @@ def test_sbt_combine(n_children):
     assert len(t_leaves) == len(t1_leaves)
     assert t1_leaves == t_leaves
 
-    to_search = next(signature.load_signatures(utils.get_test_data(SIG_FILES[0])))
+    to_search = next(signature.load_signatures(
+                        utils.get_test_data(utils.SIG_FILES[0])))
     t1_result = {str(s) for s in tree_1.find(search_minhashes,
                                              to_search, 0.1)}
     tree_result = {str(s) for s in tree.find(search_minhashes,

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -185,12 +185,16 @@ def test_binary_nary_tree():
     trees[5] = SBT(factory, d=5)
     trees[10] = SBT(factory, d=10)
 
+    n_leaves = 0
     for f in SIG_FILES:
         sig = next(signature.load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         for tree in trees.values():
             tree.add_node(leaf)
         to_search = leaf
+        n_leaves += 1
+
+    assert all([len(t.leaves()) == n_leaves for t in trees.values()])
 
     results = {}
     print('*' * 60)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -807,6 +807,44 @@ def test_do_sourmash_sbt_index_traverse():
         assert testdata2 in out
 
 
+def test_do_sourmash_sbt_combine():
+    with utils.TempDirectory() as location:
+        files = [utils.get_test_data(f) for f in utils.SIG_FILES]
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sbt_index', 'zzz'] + files,
+                                           in_directory=location)
+
+        assert os.path.exists(os.path.join(location, 'zzz.sbt.json'))
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sbt_combine', 'joined',
+                                            'zzz.sbt.json', 'zzz.sbt.json'],
+                                           in_directory=location)
+
+        assert os.path.exists(os.path.join(location, 'joined.sbt.json'))
+
+        filename = os.path.splitext(os.path.basename(utils.SIG_FILES[0]))[0]
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sbt_search', 'zzz'] + [files[0]],
+                                           in_directory=location)
+        print(out)
+
+        assert out.count(filename) == 1
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sbt_search', 'joined'] + [files[0]],
+                                           in_directory=location)
+        print(out)
+
+        # TODO: signature is loaded more than once,
+        # so checking if we get two results.
+        # If we ever start reporting only one match (even if appears repeated),
+        # change this test too!
+        assert out.count(filename) == 2
+
+
 def test_do_sourmash_sbt_search_otherdir():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')


### PR DESCRIPTION
Fixes #141 

The initial implementation just went thru the leaves in another tree and add to the original one. This is not so efficient because we recreate internal nodes (a lot).

A better solution is to create a new root, make each original tree a child of the new root, and reuse all the internal nodes already calculated. This is implemented now.

Possible improvements:
1) The current solution (create a new root) works well with binary trees, but if d>2 we could instead check to see if there is a position available near the root before inserting. This is more visible if you try to combine trees in sequence.
2) Since I'm not reorganizing the tree properly, the next available position will be between the combine trees (there might be an empty position on the left tree before we inserted on the right tree, for example). Need to do some more bookkeeping for the next available position.
3) Trees are not balanced anymore (there might be leaves in places other than the last level).

A more powerful solution would be to do a depth-first search in the original trees and replicate what is found in the new one, this would also support better case `1`.

For `2` and `3`, we only need that because the current `add_node` implementation expect the tree to be filled in order, without gaps. Other methods for adding nodes might not need it, tho (I'm thinking about doing a guided insertion, putting signatures closer to places where they have higher similarity, for example).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
