### PR TITLE
[MRG] Apply downsampling magic to sbt_search

### DIFF
--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -363,6 +363,12 @@ cdef class MinHash(object):
             distance = 2*math.acos(prod) / math.pi
             return 1.0 - distance
 
+    def containment(self, other):
+        """\
+        Calculate containment of self by other.
+        """
+        return self.count_common(other) / len(self.get_mins())
+
     def similarity_ignore_maxhash(self, MinHash other):
         a = set(self.get_mins())
 

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -10,6 +10,7 @@ from libc.stdint cimport uint32_t
 
 from ._minhash cimport KmerMinHash, KmerMinAbundance, _hash_murmur
 import math
+import copy
 
 
 # default MurmurHash seed
@@ -354,6 +355,10 @@ cdef class MinHash(object):
         if not self.track_abundance or ignore_abundance:
             return self.jaccard(other)
         else:
+            # can we merge? if not, raise exception.
+            aa = copy.copy(self)
+            aa.merge(other)
+
             a = self.get_mins(with_abundance=True)
             b = other.get_mins(with_abundance=True)
 
@@ -391,7 +396,8 @@ cdef class MinHash(object):
     cpdef set_abundances(self, dict values):
         if self.track_abundance:
             for k, v in values.items():
-                (<KmerMinAbundance*>address(deref(self._this))).mins[k] = v
+                if not self.max_hash or k < self.max_hash:
+                    (<KmerMinAbundance*>address(deref(self._this))).mins[k] = v
         else:
             raise RuntimeError("Use track_abundance=True when constructing "
                                "the MinHash to use set_abundances.")

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -255,6 +255,13 @@ cdef class MinHash(object):
 
         return a
 
+    def downsample_max_hash(self, *others):
+        max_hashes = [ x.max_hash for x in others ]
+        new_max_hash = min(self.max_hash, *max_hashes)
+        new_scaled = int(get_minhash_max_hash() / new_max_hash)
+
+        return self.downsample_scaled(new_scaled)
+
     def downsample_scaled(self, new_num):
         max_hash = self.max_hash
 

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -213,7 +213,7 @@ cdef class MinHash(object):
         if mm == 0:
             if self.hll:
                 genome_size = self.hll.estimate_cardinality()
-                genome_max_hash = max(self.get_mins())
+                mm = max(self.get_mins())
 
         return mm
 

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -779,21 +779,17 @@ def sbt_gather(args):
         # figure out what the resolution of the banding on the genome is,
         # based either on an explicit --scaled parameter, or on genome
         # cardinality (deprecated)
-        if best_leaf.minhash.max_hash:
-            R_genome = sourmash_lib.MAX_HASH / \
-              float(best_leaf.minhash.max_hash)
-        elif best_leaf.minhash.hll:
-            genome_size = best_leaf.minhash.hll.estimate_cardinality()
-            genome_max_hash = max(found_mins)
-            R_genome = float(genome_size) / float(genome_max_hash)
-        else:
+        if not best_leaf.minhash.max_hash:
             error('Best hash match in sbt_gather has no cardinality')
             error('Please prepare database of sequences with --scaled')
             sys.exit(-1)
 
+        R_genome = sourmash_lib.MAX_HASH / float(best_leaf.minhash.max_hash)
+
         # pick the highest R / lowest resolution
         R_comparison = max(R_metagenome, R_genome)
 
+        # CTB: these could probably be replaced by minhash.downsample_scaled.
         new_max_hash = sourmash_lib.MAX_HASH / float(R_comparison)
         query_mins = set([ i for i in query_mins if i < new_max_hash ])
         found_mins = set([ i for i in found_mins if i < new_max_hash ])

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -609,11 +609,16 @@ def sbt_search(args):
     for leaf in tree.find(search_fn, query, args.threshold):
         results.append((query.similarity(leaf.data, downsample=True),
                         leaf.data))
-        #results.append((leaf.data.similarity(ss), leaf.data))
 
     results.sort(key=lambda x: -x[0])   # reverse sort on similarity
+
+    if args.best_only:
+        notify("(truncated search because of --best-only; only trust top result")
+
+    notify("similarity   match")
+    notify("----------   -----")
     for (similarity, query) in results:
-        print('{:.2f} {}'.format(similarity, query.name()))
+        print('{:2.1f}%        {}'.format(similarity*100, query.name()))
 
     if args.save_matches:
         outname = args.save_matches.name

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -27,6 +27,7 @@ def search(args):
     parser.add_argument('-k', '--ksize', default=DEFAULT_K, type=int)
     parser.add_argument('-f', '--force', action='store_true')
     parser.add_argument('--save-matches', type=argparse.FileType('wt'))
+    parser.add_argument('--containment', action='store_true')
 
     sourmash_args.add_moltype_args(parser)
 
@@ -62,7 +63,10 @@ def search(args):
     # compute query x db
     distances = []
     for (x, filename) in against:
-        distance = query.similarity(x)
+        if args.containment:
+            distance = query.containment(x)
+        else:
+            distance = query.similarity(x)
         if distance >= args.threshold:
             distances.append((distance, x, filename))
 

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -603,7 +603,8 @@ def sbt_search(args):
 
     results = []
     for leaf in tree.find(search_fn, query, args.threshold):
-        results.append((query.similarity(leaf.data), leaf.data))
+        results.append((query.similarity(leaf.data, downsample=True),
+                        leaf.data))
         #results.append((leaf.data.similarity(ss), leaf.data))
 
     results.sort(key=lambda x: -x[0])   # reverse sort on similarity

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -623,7 +623,8 @@ def sbt_search(args):
     notify("similarity   match")
     notify("----------   -----")
     for (similarity, query) in results:
-        print('{:2.1f}%        {}'.format(similarity*100, query.name()))
+        pct = '{:.1f}%'.format(similarity*100)
+        notify('{:>6}       {}', pct, query.name())
 
     if args.save_matches:
         outname = args.save_matches.name

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -67,6 +67,7 @@ def search_minhashes(node, sig, threshold, results=None, downsample=True):
 class SearchMinHashesFindBest(object):
     def __init__(self, downsample=True):
         self.best_match = 0.
+        self.downsample = downsample
 
     def search(self, node, sig, threshold, results=None):
         mins = sig.minhash.get_mins()
@@ -75,7 +76,7 @@ class SearchMinHashesFindBest(object):
             try:
                 matches = node.data.minhash.count_common(sig.minhash)
             except Exception as e:
-                if 'mismatch in max_hash' in str(e) and downsample:
+                if 'mismatch in max_hash' in str(e) and self.downsample:
                     xx = sig.minhash.downsample_max_hash(node.data.minhash)
                     yy = node.data.minhash.downsample_max_hash(sig.minhash)
 

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import division
 
 from .sbt import Leaf
-from . import MinHash
+from . import _minhash, MinHash
 
 
 class SigLeaf(Leaf):
@@ -38,11 +38,21 @@ class SigLeaf(Leaf):
         self._data = new_data
 
 
-def search_minhashes(node, sig, threshold, results=None):
+def search_minhashes(node, sig, threshold, results=None, downsample=True):
     mins = sig.minhash.get_mins()
 
     if isinstance(node, SigLeaf):
-        matches = node.data.minhash.count_common(sig.minhash)
+        try:
+            matches = node.data.minhash.count_common(sig.minhash)
+        except Exception as e:
+            if 'mismatch in max_hash' in str(e) and downsample:
+                xx = sig.minhash.downsample_max_hash(node.data.minhash)
+                yy = node.data.minhash.downsample_max_hash(sig.minhash)
+
+                matches = yy.count_common(xx)
+            else:
+                raise
+
     else:  # Node or Leaf, Nodegraph by minhash comparison
         matches = sum(1 for value in mins if node.data.get(value))
 
@@ -55,14 +65,23 @@ def search_minhashes(node, sig, threshold, results=None):
 
 
 class SearchMinHashesFindBest(object):
-    def __init__(self):
+    def __init__(self, downsample=True):
         self.best_match = 0.
 
     def search(self, node, sig, threshold, results=None):
         mins = sig.minhash.get_mins()
 
         if isinstance(node, SigLeaf):
-            matches = node.data.minhash.count_common(sig.minhash)
+            try:
+                matches = node.data.minhash.count_common(sig.minhash)
+            except Exception as e:
+                if 'mismatch in max_hash' in str(e) and downsample:
+                    xx = sig.minhash.downsample_max_hash(node.data.minhash)
+                    yy = node.data.minhash.downsample_max_hash(sig.minhash)
+
+                    matches = yy.count_common(xx)
+                else:
+                    raise
         else:  # Node or Leaf, Nodegraph by minhash comparison
             matches = sum(1 for value in mins if node.data.get(value))
 

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -105,7 +105,7 @@ class SourmashSignature(object):
         "Compute similarity with the other MinHash signature."
         try:
             return self.minhash.similarity(other.minhash, ignore_abundance)
-        except Exception as e:
+        except ValueError as e:
             if 'mismatch in max_hash' in str(e) and downsample:
                 xx = self.minhash.downsample_max_hash(other.minhash)
                 yy = other.minhash.downsample_max_hash(self.minhash)

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -101,9 +101,17 @@ class SourmashSignature(object):
         return self.d.get('email'), self.d.get('name'), \
             self.d.get('filename'), sketch
 
-    def similarity(self, other, ignore_abundance=False):
+    def similarity(self, other, ignore_abundance=False, downsample=False):
         "Compute similarity with the other MinHash signature."
-        return self.minhash.similarity(other.minhash, ignore_abundance)
+        try:
+            return self.minhash.similarity(other.minhash, ignore_abundance)
+        except Exception as e:
+            if 'mismatch in max_hash' in str(e) and downsample:
+                xx = self.minhash.downsample_max_hash(other.minhash)
+                yy = other.minhash.downsample_max_hash(self.minhash)
+                return xx.similarity(yy, ignore_abundance)
+            else:
+                raise
 
     def jaccard(self, other):
         "Compute Jaccard similarity with the other MinHash signature."

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -117,6 +117,10 @@ class SourmashSignature(object):
         "Compute Jaccard similarity with the other MinHash signature."
         return self.minhash.similarity(other.minhash, True)
 
+    def containment(self, other):
+        "Compute containment by the other signature. Note: ignores abundance."
+        return self.minhash.containment(other.minhash)
+
 
 def _guess_open(filename):
     """

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -597,6 +597,25 @@ def test_search():
         assert '0.930' in out
 
 
+def test_search_containment():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', testdata1, testdata2],
+                                           in_directory=location)
+
+
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['search', 'short.fa.sig',
+                                            'short2.fa.sig', '--containment'],
+                                           in_directory=location)
+        print(status, out, err)
+        assert '1 matches' in err
+        assert '0.958' in out
+
+
 def test_search_gzip():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -907,6 +907,7 @@ def test_do_sourmash_sbt_combine():
                                            in_directory=location)
         print(err)
 
+        # we get notification of signature loading, too - so notify + result.
         assert err.count(filename) == 2
 
         status, out, err = utils.runscript('sourmash',
@@ -915,7 +916,7 @@ def test_do_sourmash_sbt_combine():
         print(err)
 
         # TODO: signature is loaded more than once,
-        # so checking if we get two results.
+        # so checking if we get three counts (notification + 2 results)
         # If we ever start reporting only one match (even if appears repeated),
         # change this test too!
         assert err.count(filename) == 3

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -747,10 +747,43 @@ def test_do_sourmash_sbt_search():
                                            ['sbt_search', 'zzz',
                                             'short.fa.sig'],
                                            in_directory=location)
-        print(out)
+        print(err)
 
-        assert testdata1 in out
-        assert testdata2 in out
+        assert testdata1 in err
+        assert testdata2 in err
+
+
+def test_do_sourmash_sbt_search_downsample():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', testdata1, testdata2,
+                                            '--scaled=10'],
+                                           in_directory=location)
+
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', testdata1,
+                                            '--scaled=5', '-o', 'query.sig'],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sbt_index', 'zzz',
+                                            'short.fa.sig',
+                                            'short2.fa.sig'],
+                                           in_directory=location)
+
+        assert os.path.exists(os.path.join(location, 'zzz.sbt.json'))
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['sbt_search', 'zzz',
+                                            'query.sig'],
+                                           in_directory=location)
+        print(err)
+
+        assert testdata1 in err
+        assert testdata2 in err
 
 
 def test_do_sourmash_sbt_index_single():
@@ -772,9 +805,9 @@ def test_do_sourmash_sbt_index_single():
                                            ['sbt_search', 'zzz',
                                             'short.fa.sig'],
                                            in_directory=location)
-        print(out)
+        print(err)
 
-        assert testdata1 in out
+        assert testdata1 in err
 
 
 def test_do_sourmash_sbt_search_selectprot():
@@ -844,10 +877,10 @@ def test_do_sourmash_sbt_index_traverse():
                                            ['sbt_search', 'zzz',
                                             'short.fa.sig'],
                                            in_directory=location)
-        print(out)
+        print(err)
 
-        assert testdata1 in out
-        assert testdata2 in out
+        assert testdata1 in err
+        assert testdata2 in err
 
 
 def test_do_sourmash_sbt_combine():
@@ -872,20 +905,20 @@ def test_do_sourmash_sbt_combine():
         status, out, err = utils.runscript('sourmash',
                                            ['sbt_search', 'zzz'] + [files[0]],
                                            in_directory=location)
-        print(out)
+        print(err)
 
-        assert out.count(filename) == 1
+        assert err.count(filename) == 2
 
         status, out, err = utils.runscript('sourmash',
                                            ['sbt_search', 'joined'] + [files[0]],
                                            in_directory=location)
-        print(out)
+        print(err)
 
         # TODO: signature is loaded more than once,
         # so checking if we get two results.
         # If we ever start reporting only one match (even if appears repeated),
         # change this test too!
-        assert out.count(filename) == 2
+        assert err.count(filename) == 3
 
 
 def test_do_sourmash_sbt_search_otherdir():
@@ -908,10 +941,10 @@ def test_do_sourmash_sbt_search_otherdir():
         sig_loc = os.path.join(location, 'short.fa.sig')
         status, out, err = utils.runscript('sourmash',
                                            ['sbt_search', sbt_name, sig_loc])
-        print(out)
+        print(err)
 
-        assert testdata1 in out
-        assert testdata2 in out
+        assert testdata1 in err
+        assert testdata2 in err
 
 
 def test_do_sourmash_sbt_search_bestonly():
@@ -934,9 +967,9 @@ def test_do_sourmash_sbt_search_bestonly():
                                            ['sbt_search', '--best-only', 'zzz',
                                             'short.fa.sig'],
                                            in_directory=location)
-        print(out)
+        print(err)
 
-        assert testdata1 in out
+        assert testdata1 in err
 
 
 def test_compare_with_abundance_1():


### PR DESCRIPTION
Fixes #146 (a bug in sbt_search). Also fixes #182 (`--containment` option in search).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
