### PR TITLE
[WIP] Use cachetools at the storage level

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ matplotlib
 scipy
 Cython
 https://github.com/dib-lab/khmer/archive/master.zip
-
+cachetools

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ SETUP_METADATA = \
                                language="c++",
                                extra_compile_args=EXTRA_COMPILE_ARGS,
                                extra_link_args=EXTRA_LINK_ARGS)],
-    "install_requires": ["screed>=0.9", "PyYAML>=3.11", "ijson"],
+    "install_requires": ["screed>=0.9", "PyYAML>=3.11", "ijson", "cachetools>=2.0.0"],
     "setup_requires": ['Cython>=0.25.2', "setuptools>=18.0"],
     "extras_require": {
         'test' : ['pytest', 'pytest-cov', 'numpy', 'matplotlib', 'scipy'],

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -176,6 +176,9 @@ class SBT(object):
     def save(self, tag, storage=None):
         version = 3
 
+        if not tag.endswith('.sbt.json'):
+            tag + '.sbt.json'
+
         fn = tag + '.sbt.json'
 
         if storage is None:

--- a/sourmash_lib/sbt_storage.py
+++ b/sourmash_lib/sbt_storage.py
@@ -142,7 +142,9 @@ class IPFSStorage(Storage):
 
 class RedisStorage(Storage):
 
-    def __init__(self, **kwargs):
+    def __init__(self, cachesize=DEFAULT_CACHESIZE, **kwargs):
+        super(RedisStorage, self).__init__(cachesize=cachesize)
+
         import redis
         self.redis_args = kwargs
         self.conn = redis.Redis(**self.redis_args)
@@ -151,6 +153,7 @@ class RedisStorage(Storage):
         self.conn.set(path, content)
         return path
 
+    @cachedmethod(operator.attrgetter('_cache'))
     def load(self, path):
         return self.conn.get(path)
 

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -34,7 +34,11 @@ class SigLeaf(Leaf):
             buf = BytesIO(self.storage.load(self._path))
             with TextIOWrapper(buf) as data:
                 it = signature.load_signatures(data)
-                self._data, = list(it)              # should only be one signature
+                data, = list(it)              # should only be one signature
+                if self._cache_results:
+                    self._data = data
+                else:
+                    return data
         return self._data
 
     @data.setter


### PR DESCRIPTION
Add a cache at the storage level. This is not very efficient, because even with cached access it is still necessary to write the file to a Tempfile, because khmer can only load nodegraphs from disk... Probably need to move the cache to the Node/Leaf level instead (as a class attribute/method?)

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
