### PR TITLE
[MRG] Travis and tox updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.5
+python: 3.6
 
 sudo: required
 dist: trusty
@@ -11,6 +11,7 @@ branches:
 env:
   - TOX_ENV=py27
   - TOX_ENV=py35
+  - TOX_ENV=py36
 
 install:
 - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,8 @@ CLASSIFIERS = [
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: C++",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist=py27,py35
+envlist=py27,py35,py36
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 whitelist_externals=
     make
 deps=
-    https://api.github.com/repos/dib-lab/khmer/tarball/master
+    https://github.com/dib-lab/khmer/archive/master.tar.gz
     codecov
 commands=
     pip install -e .[test]


### PR DESCRIPTION
- set 3.6 as the default in travis
- run tests for 2.7, 3.5 and 3.6
- remove classifiers for 3.3 and 3.4, add for 3.6

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
