### PR TITLE
[MRG] Use khmer from PyPI now that 2.1 is released

### DIFF
--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -28,9 +28,8 @@ python3.5 -m venv ~/py3
 . ~/py3/bin/activate
 pip install -U pip
 pip install -U Cython
-pip install -U jupyter jupyter_client ipython pandas matplotlib scipy scikit-learn
+pip install -U jupyter jupyter_client ipython pandas matplotlib scipy scikit-learn khmer
 
-pip install https://github.com/dib-lab/khmer/archive/master.zip
 pip install https://github.com/dib-lab/sourmash/archive/master.zip
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 matplotlib
 scipy
 Cython
-https://github.com/dib-lab/khmer/archive/master.zip
+khmer
 sphinx
 alabaster
 recommonmark

--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -55,7 +55,6 @@ import os
 
 import khmer
 from random import randint
-from numpy import array
 
 
 NodePos = namedtuple("NodePos", ["pos", "node"])
@@ -461,6 +460,8 @@ def filter_distance( filter_a, filter_b, n=1000 ) :
     filter_b : Second filter
     n        : Number of positions to compare (in groups of 8)
     """
+    from numpy import array
+
     A = filter_a.graph.get_raw_tables()
     B = filter_b.graph.get_raw_tables()
     distance = 0

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ passenv = CI TRAVIS TRAVIS_*
 whitelist_externals=
     make
 deps=
-    https://github.com/dib-lab/khmer/archive/master.tar.gz
     codecov
 commands=
     pip install -e .[test]


### PR DESCRIPTION
Updated docs to install khmer from PyPI, same with tox and requirements.txt

Also remove need to have `numpy` for commands that don't need `numpy`.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
