### PR TITLE
[MRG] Split MinHash.compare in two: intersection and compare

### DIFF
--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -281,7 +281,7 @@ cdef class MinHash(object):
 
         return a
 
-    def compare(self, MinHash other):
+    def intersection(self, MinHash other):
         cdef KmerMinAbundance *mh = NULL;
         cdef KmerMinAbundance *other_mh = NULL;
         cdef KmerMinAbundance *cmh = NULL;
@@ -310,7 +310,6 @@ cdef class MinHash(object):
             common = set(self.get_mins())
             common.intersection_update(other.get_mins())
             common.intersection_update([it.first for it in cmh.mins])
-            n = len(common)
         else:
             combined_mh = new KmerMinHash(num,
                                           deref(self._this).ksize,
@@ -323,9 +322,12 @@ cdef class MinHash(object):
             common = set(self.get_mins())
             common.intersection_update(other.get_mins())
             common.intersection_update(combined_mh.mins)
-            n = len(common)
 
-        size = max(combined_mh.size(), 1)
+        return common, max(combined_mh.size(), 1)
+
+    def compare(self, MinHash other):
+        common, size = self.intersection(other)
+        n = len(common)
         return n / size
 
     def jaccard(self, MinHash other):

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -231,6 +231,72 @@ def test_compare_1(track_abundance):
     assert b.compare(b) == 1.0
 
 
+def test_intersection_1(track_abundance):
+    a = MinHash(20, 10, track_abundance=track_abundance)
+    b = MinHash(20, 10, track_abundance=track_abundance)
+
+    a.add_sequence('TGCCGCCCAGCA')
+    b.add_sequence('TGCCGCCCAGCA')
+
+    common = set(a.get_mins())
+    combined_size = 3
+
+    intersection, size = a.intersection(b)
+    assert intersection == common
+    assert combined_size == size
+
+    intersection, size = b.intersection(b)
+    assert intersection == common
+    assert combined_size == size
+
+    intersection, size = b.intersection(a)
+    assert intersection == common
+    assert combined_size == size
+
+    intersection, size = a.intersection(a)
+    assert intersection == common
+    assert combined_size == size
+
+    # add same sequence again
+    b.add_sequence('TGCCGCCCAGCA')
+
+    intersection, size = a.intersection(b)
+    assert intersection == common
+    assert combined_size == size
+
+    intersection, size = b.intersection(b)
+    assert intersection == common
+    assert combined_size == size
+
+    intersection, size = b.intersection(a)
+    assert intersection == common
+    assert combined_size == size
+
+    intersection, size = a.intersection(a)
+    assert intersection == common
+    assert combined_size == size
+
+    a.add_sequence('GTCCGCCCAGTGA')
+    b.add_sequence('GTCCGCCCAGTGG')
+
+    new_in_common = set(a.get_mins()).intersection(set(b.get_mins()))
+    new_combined_size = 8
+
+    intersection, size = a.intersection(b)
+    assert intersection == new_in_common
+    assert size == new_combined_size
+
+    intersection, size = b.intersection(a)
+    assert intersection == new_in_common
+    assert size == new_combined_size
+
+    intersection, size = a.intersection(a)
+    assert intersection == set(a.get_mins())
+
+    intersection, size = b.intersection(b)
+    assert intersection == set(b.get_mins())
+
+
 def test_mh_copy(track_abundance):
     a = MinHash(20, 10, track_abundance=track_abundance)
 


### PR DESCRIPTION
I was talking with @halexand yesterday and the intersection seems to be a common use case. `compare` already does what is needed but return the similarity, so I moved most of the code to `intersection` and then implemented `compare` using `intersection`.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
