### PR TITLE
[MRG] Let's fix this C++/Cython mess

### DIFF
--- a/sourmash_lib/_minhash.pxd
+++ b/sourmash_lib/_minhash.pxd
@@ -40,13 +40,13 @@ cdef extern from "kmer_min_hash.hh":
 
 
     cdef cppclass KmerMinAbundance(KmerMinHash):
-        CMinAbundanceType mins;
+        CMinAbundanceType mins_abund;
 
         KmerMinAbundance(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
         void add_hash(HashIntoType) except +ValueError
         void add_word(string word) except +ValueError
         void add_sequence(const char *, bool) except +ValueError
-        void merge_abund(const KmerMinAbundance&) except +ValueError
+        void merge(const KmerMinAbundance&) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         unsigned int count_common(const KmerMinAbundance&) except +ValueError
         unsigned long size()
@@ -54,7 +54,6 @@ cdef extern from "kmer_min_hash.hh":
 
 cdef class MinHash(object):
     cdef unique_ptr[KmerMinHash] _this
-    #cdef unique_ptr[KmerMinAbundance] _this
     cdef public bool track_abundance
 
     cpdef get_mins(self, bool with_abundance=*)

--- a/sourmash_lib/_minhash.pxd
+++ b/sourmash_lib/_minhash.pxd
@@ -15,7 +15,6 @@ from libcpp.vector cimport vector
 cdef extern from "kmer_min_hash.hh":
     ctypedef uint64_t HashIntoType;
     ctypedef vector[HashIntoType] CMinHashType;
-    ctypedef map[HashIntoType, uint64_t] CMinAbundanceType;
 
 
     cdef uint64_t _hash_murmur(const string, uint32_t seed)
@@ -30,7 +29,6 @@ cdef extern from "kmer_min_hash.hh":
         CMinHashType mins;
 
         KmerMinHash(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
-        void _shrink()
         void add_hash(HashIntoType) except +ValueError
         void add_word(string word) except +ValueError
         void add_sequence(const char *, bool) except +ValueError
@@ -40,7 +38,7 @@ cdef extern from "kmer_min_hash.hh":
 
 
     cdef cppclass KmerMinAbundance(KmerMinHash):
-        CMinAbundanceType mins_abund;
+        CMinHashType abunds;
 
         KmerMinAbundance(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
         void add_hash(HashIntoType) except +ValueError

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -172,9 +172,9 @@ cdef class MinHash(object):
     cpdef get_mins(self, bool with_abundance=False):
         cdef KmerMinAbundance *mh = <KmerMinAbundance*>address(deref(self._this))
         if with_abundance and self.track_abundance:
-            return mh.mins
+            return mh.mins_abund
         elif self.track_abundance:
-            return [it.first for it in mh.mins]
+            return [it.first for it in mh.mins_abund]
         else:
             return [it for it in deref(self._this).mins]
 
@@ -304,12 +304,12 @@ cdef class MinHash(object):
             other_mh = <KmerMinAbundance*>address(deref(other._this))
             cmh = <KmerMinAbundance*>combined_mh
 
-            cmh.merge_abund(deref(mh))
-            cmh.merge_abund(deref(other_mh))
+            cmh.merge(deref(mh))
+            cmh.merge(deref(other_mh))
 
             common = set(self.get_mins())
             common.intersection_update(other.get_mins())
-            common.intersection_update([it.first for it in cmh.mins])
+            common.intersection_update([it.first for it in cmh.mins_abund])
         else:
             combined_mh = new KmerMinHash(num,
                                           deref(self._this).ksize,
@@ -385,7 +385,7 @@ cdef class MinHash(object):
         cdef KmerMinAbundance *mh = <KmerMinAbundance*>address(deref(self._this))
         cdef KmerMinAbundance *other_mh = <KmerMinAbundance*>address(deref(other._this))
         if self.track_abundance:
-            deref(mh).merge_abund(deref(other_mh))
+            deref(mh).merge(deref(other_mh))
         else:
             deref(self._this).merge(deref(other._this))
 
@@ -396,7 +396,7 @@ cdef class MinHash(object):
         if self.track_abundance:
             for k, v in values.items():
                 if not self.max_hash or k < self.max_hash:
-                    (<KmerMinAbundance*>address(deref(self._this))).mins[k] = v
+                    (<KmerMinAbundance*>address(deref(self._this))).mins_abund[k] = v
         else:
             raise RuntimeError("Use track_abundance=True when constructing "
                                "the MinHash to use set_abundances.")

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -22,8 +22,6 @@ typedef uint64_t HashIntoType;
 
 typedef std::vector<HashIntoType> CMinHashType;
 
-typedef std::map<HashIntoType, uint64_t> CMinAbundanceType;
-
 class minhash_exception : public std::exception
 {
 public:
@@ -48,6 +46,7 @@ struct Counter {
   void push_back(const value_type &) { ++count; }
   size_t count = 0;
 };
+
 
 class KmerMinHash
 {
@@ -76,10 +75,6 @@ public:
       }
     };
 
-    virtual void _shrink() {
-        // pass
-    }
-
     void check_compatible(const KmerMinHash& other) {
         if (ksize != other.ksize) {
             throw minhash_exception("different ksizes cannot be compared");
@@ -93,7 +88,7 @@ public:
         if (seed != other.seed) {
             throw minhash_exception("mismatch in seed; comparison fail");
         }
-	}
+    }
 
     virtual void add_hash(const HashIntoType h) {
       if (h <= max_hash) {
@@ -195,7 +190,7 @@ public:
                 return false;
             }
         }
-	return true;
+        return true;
     }
 
     std::string _revcomp(const std::string& kmer) const {
@@ -244,6 +239,7 @@ public:
           mins = CMinHashType(std::begin(merged), std::begin(merged) + num);
         }
     }
+
     virtual unsigned int count_common(const KmerMinHash& other) {
         check_compatible(other);
 
@@ -307,90 +303,97 @@ private:
 
 class KmerMinAbundance: public KmerMinHash {
  public:
-    CMinAbundanceType mins_abund;
-    HashIntoType max_mins;
+    CMinHashType abunds;
 
     KmerMinAbundance(unsigned int n, unsigned int k, bool prot, uint32_t seed,
                      HashIntoType mx) :
         KmerMinHash(n, k, prot, seed, mx) { };
 
     virtual void add_hash(HashIntoType h) {
-        if (max_hash && h > max_hash) {
-            return;
-        }
+      if (h <= max_hash) {
+        if (mins.size() == 0) {
+          mins.push_back(h);
+          abunds.push_back(1);
+          return;
+        } else if (mins.back() > h or mins.size() < num) {
+          auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
 
-        if (!num || mins_abund.size() < num) {
-            mins_abund[h] += 1;
-            max_mins = std::max(max_mins, h);
-            return;
-        }
-
-        if (num && h > max_mins) {
-            return;
-        } else {
-            if (mins_abund.find(h) != mins_abund.end()) {
-                mins_abund[h] += 1;
-            } else {
-                mins_abund.emplace(h, 1);
-                mins_abund.erase(max_mins);
-                max_mins = (*std::max_element(mins_abund.begin(),
-                                              mins_abund.end())).first;
+          // must still be growing, we know the list won't get too long
+          if (pos == mins.cend()) {
+            mins.push_back(h);
+            abunds.push_back(1);
+          } else if (*pos != h) {
+          // inserting somewhere in the middle, if this value isn't already
+          // in mins store it and shrink list if needed
+            mins.insert(pos, h);
+            abunds.insert(begin(abunds) + std::distance(begin(mins), pos), 1);
+            if (mins.size() > num) {
+              mins.pop_back();
+              abunds.pop_back();
             }
+          } else { // *pos == h
+            auto p = std::distance(begin(mins), pos);
+            abunds[p] += 1;
+          }
         }
-        _shrink();
-    }
-
-    virtual void _shrink() {
-        if (num == 0) {
-            return;
-        }
-        while (mins_abund.size() > num) {
-            mins_abund.erase(max_mins);
-            max_mins = (*std::max_element(mins_abund.begin(),
-                                          mins_abund.end())).first;
-        }
+      }
     }
 
     virtual void merge(const KmerMinAbundance& other) {
         check_compatible(other);
 
-        for (auto mi: other.mins_abund) {
-            mins_abund[mi.first] += mi.second;
-            max_mins = std::max(mi.first, max_mins);
+        CMinHashType merged_mins;
+        CMinHashType merged_abunds;
+        size_t max_size = other.mins.size() + mins.size();
+
+        merged_mins.reserve(max_size);
+        merged_abunds.reserve(max_size);
+
+        auto it1_m = mins.begin();
+        auto it2_m = other.mins.begin();
+        auto out_m = std::back_inserter(merged_mins);
+
+        auto it1_a = abunds.begin();
+        auto it2_a = other.abunds.begin();
+        auto out_a = std::back_inserter(merged_abunds);
+
+        for (; it1_m != mins.end(); ++out_m, ++out_a) {
+            if (it2_m == other.mins.end()) {
+                std::copy(it1_m, mins.end(), out_m);
+                std::copy(it1_a, abunds.end(), out_a);
+                break;
+            }
+            if (*it2_m < *it1_m) {
+                *out_m = *it2_m;
+                *out_a = *it2_a;
+                ++it2_m;
+                ++it2_a;
+            } else if (*it2_m == *it1_m) {
+                *out_m = *it1_m;
+                *out_a = *it1_a + *it2_a;
+                ++it1_m; ++it1_a;
+                ++it2_m; ++it2_a;
+            } else {
+                *out_m = *it1_m;
+                *out_a = *it1_a;
+                ++it1_m;
+                ++it1_a;
+            }
         }
-        _shrink();
-    }
+        std::copy(it2_m, other.mins.end(), out_m);
+        std::copy(it2_a, other.abunds.end(), out_a);
 
-    virtual unsigned int count_common(const KmerMinAbundance& other) {
-        std::set<HashIntoType> combined;
-
-		check_compatible(other);
-
-        for (auto mi: mins_abund) {
-            combined.insert(mi.first);
+        if (merged_mins.size() < num) {
+          mins = merged_mins;
+          abunds = merged_abunds;
+        } else {
+          mins = CMinHashType(std::begin(merged_mins), std::begin(merged_mins) + num);
+          abunds = CMinHashType(std::begin(merged_abunds), std::begin(merged_abunds) + num);
         }
-        for (auto mi: other.mins_abund) {
-            combined.insert(mi.first);
-        }
-        return mins_abund.size() + other.mins_abund.size() - combined.size();
-    }
-
-    virtual unsigned int count_common(const KmerMinHash& other) {
-        std::set<HashIntoType> combined;
-
-		check_compatible(other);
-
-        for (auto mi: mins_abund) {
-            combined.insert(mi.first);
-        }
-        for (auto mi: other.mins) {
-            combined.insert(mi);
-        }
-        return mins_abund.size() + other.mins.size() - combined.size();
     }
 
     virtual size_t size() {
-        return mins_abund.size();
+        return mins.size();
     }
 
 };


### PR DESCRIPTION
## Plan
- [ ] stop using `mins` directly. Since virtual inheritance only works for methods (and not members), this was creating a lot of weird boilerplate in Cython. 
  - [x] The stopgap measure is to call `mins_abund` when using `KmerMinAbundance`, but this is still kinda ugly.
  - [ ] In the future, use iterators to access `hashes`, `abundances`, or pairs of `(hash, abundance)`. `count_common` doesn't need to be implemented in `KmerMinAbundance` if we do this, since the base `KmeMinHash::count_common` can iterate over the hashes only.
  - [ ] Expose iterators for Cython, and avoid accessing `mins` and `abunds` directly.
- [x] Avoid checking if MinHash are compatible with copy-and-paste code, create a method `check_compatible` and call it instead.
- [x] Keep abundances as another `vector`, instead of using a `map`? Need a bit more of bookkeeping, but avoid duplicating data between `mins` and `mins_abund`
- [x] Remove `_shrink` from `KmerMinAbundance`, check this on `add_hash` (like @betatim did for `KmerMinHash`.

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
