### PR TITLE
[MRG] Fix a problem with non-int select_ksize parameters to load_signature

### DIFF
--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -171,6 +171,9 @@ def load_signatures(data, select_ksize=None, select_moltype=None,
 
     Note, the order is not necessarily the same as what is in the source file.
     """
+    if select_ksize:
+        select_ksize = int(select_ksize)
+
     if not data:
         return
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -20,6 +20,19 @@ def test_roundtrip(track_abundance):
     assert sig2.similarity(sig) == 1.0
 
 
+def test_load_signature_select_ksize_nonint(track_abundance):
+    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+    sig = SourmashSignature('titus@idyll.org', e)
+    s = save_signatures([sig])
+    siglist = list(load_signatures(s, select_ksize='20'))
+    sig2 = siglist[0]
+    e2 = sig2.minhash
+
+    assert sig.similarity(sig2) == 1.0
+    assert sig2.similarity(sig) == 1.0
+
+
 def test_roundtrip_empty(track_abundance):
     # edge case, but: empty minhash? :)
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)


### PR DESCRIPTION
In `load_signatures` and `load_one_signature`, convert `select_ksize` to an int value explicitly.

(This is a silly little problem that tripped me up in another project; thought it was worth fixing.)

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
