### PR TITLE
[MRG] Use a build matrix and be explicit about python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,30 @@ branches:
   only:
     - master
 
-env:
-  - TOX_ENV=py27
-  - TOX_ENV=py35
-  - TOX_ENV=py36
+matrix:
+  fast_finish: true
+  include:
+
+    - os: linux
+      python: "2.7"
+      sudo: required
+      dist: trusty
+      env:
+        - TOX_ENV=py27
+
+    - os: linux
+      python: "3.5"
+      sudo: required
+      dist: trusty
+      env:
+        - TOX_ENV=py35
+
+    - os: linux
+      python: "3.6"
+      sudo: required
+      dist: trusty
+      env:
+        - TOX_ENV=py36
 
 install:
 - pip install tox


### PR DESCRIPTION
Our travis config assumed different Python versions were installed, which doesn't seem to be true anymore (see https://travis-ci.org/dib-lab/sourmash/jobs/274623549). This PR fixes it by being explicit about which Python version to use.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
