### PR TITLE
[MRG] upgrade `sourmash compare` to do downsampling, ksize checks, and more.

### DIFF
--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -286,19 +286,24 @@ def compare(args):
     parser.add_argument('--ignore-abundance', action='store_true',
                         help='do NOT use k-mer abundances if present')
     sourmash_args.add_ksize_arg(parser, DEFAULT_LOAD_K)
+    sourmash_args.add_moltype_args(parser)
     parser.add_argument('--csv', type=argparse.FileType('w'),
                         help='save matrix in CSV format (with column headers)')
+    parser.add_argument('-q', '--quiet', action='store_true',
+                        help='suppress non-error output')
     args = parser.parse_args(args)
+    set_quiet(args.quiet)
+    moltype = sourmash_args.calculate_moltype(args)
 
     # load in the various signatures
     siglist = []
     for filename in args.signatures:
         notify('loading {}', filename, end='\r')
-        loaded = sig.load_signatures(filename, select_ksize=args.ksize)
+        loaded = sig.load_signatures(filename, select_ksize=args.ksize,
+                                     select_moltype=moltype)
         loaded = list(loaded)
         if not loaded:
-            notify('\nwarning: no signatures loaded at given ksize from {}',
-                   filename)
+            notify('\nwarning: no signatures loaded at given ksize/molecule type from {}', filename)
         siglist.extend(loaded)
 
     notify(' '*79, end='\r')

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -304,6 +304,19 @@ def compare(args):
     notify(' '*79, end='\r')
     notify('loaded {} signatures total.'.format(len(siglist)))
 
+    # check ksizes and type
+    ksizes = set([s.minhash.ksize for s in siglist])
+    if len(ksizes) > 1:
+        error('multiple k-mer sizes loaded; please specify one with -k.')
+        ksizes = sorted(ksizes)
+        error('(saw k-mer sizes {})'.format(', '.join(map(str, ksizes))))
+        sys.exit(-1)
+
+    moltypes = set([sourmash_args.get_moltype(x) for x in siglist])
+    if len(moltypes) > 1:
+        error('multiple molecule types loaded; please specify --dna, --protein')
+        sys.exit(-1)
+
     # check to make sure they're potentially compatible - either using
     # max_hash/scaled, or not.
     scaled_sigs = [s.minhash.max_hash for s in siglist]
@@ -337,7 +350,7 @@ def compare(args):
             name_num = '{}-{}'.format(i, E.name())
             if len(name_num) > 20:
                 name_num = name_num[:17] + '...'
-            print_results('{}\t{}'.format(name_num, D[i, :, ],))
+            print_results('{:20s}\t{}'.format(name_num, D[i, :, ],))
 
         labeltext.append(E.name())
 

--- a/sourmash_lib/logging.py
+++ b/sourmash_lib/logging.py
@@ -2,24 +2,29 @@ from __future__ import print_function
 import sys
 from io import StringIO
 
-def print_results(s, *args, **kwargs):
-    print(s.format(*args, **kwargs), file=sys.stdout)
-    sys.stdout.flush()
-
-
 _quiet = False
 def set_quiet(val):
     global _quiet
     _quiet = bool(val)
 
 
+def print_results(s, *args, **kwargs):
+    if _quiet:
+        return
+
+    print(s.format(*args, **kwargs), file=sys.stdout)
+    sys.stdout.flush()
+
+
 def notify(s, *args, **kwargs):
     "A simple logging function => stderr."
-    if not _quiet:
-        print(s.format(*args, **kwargs), file=sys.stderr,
-              end=kwargs.get('end', u'\n'))
-        if kwargs.get('flush'):
-            sys.stderr.flush()
+    if _quiet:
+        return
+
+    print(s.format(*args, **kwargs), file=sys.stderr,
+          end=kwargs.get('end', u'\n'))
+    if kwargs.get('flush'):
+        sys.stderr.flush()
 
 
 def error(s, *args, **kwargs):

--- a/sourmash_lib/sourmash_args.py
+++ b/sourmash_lib/sourmash_args.py
@@ -161,6 +161,8 @@ def get_ksize(tree):
 
 
 def load_sbts_and_sigs(filenames, query_ksize, query_moltype):
+    n_signatures = 0
+    n_databases = 0
     databases = []
     for sbt_or_sigfile in filenames:
         try:
@@ -172,7 +174,8 @@ def load_sbts_and_sigs(filenames, query_ksize, query_moltype):
                 sys.exit(-1)
 
             databases.append((tree, sbt_or_sigfile, True))
-            notify('loaded SBT {}', sbt_or_sigfile)
+            notify('loaded SBT {}', sbt_or_sigfile, end='\r')
+            n_databases += 1
         except (ValueError, EnvironmentError):
             # not an SBT - try as a .sig
 
@@ -183,9 +186,13 @@ def load_sbts_and_sigs(filenames, query_ksize, query_moltype):
                 siglist = list(siglist)
                 databases.append((list(siglist), sbt_or_sigfile, False))
                 notify('loaded {} signatures from {}', len(siglist),
-                       sbt_or_sigfile)
+                       sbt_or_sigfile, end='\r')
+                n_signatures += len(siglist)
             except EnvironmentError:
                 error("file '{}' does not exist", sbt_or_sigfile)
                 sys.exit(-1)
+    notify(' '*79, end='\r')
+    notify('loaded {} signatures and {} databases total.'.format(n_signatures,
+                                                                 n_databases))
 
     return databases

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -573,6 +573,34 @@ def test_do_compare_output_csv():
             assert lines[1:] == ['1.0,0.93\n', '0.93,1.0\n']
 
 
+def test_do_compare_downsample():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '--scaled', '200',
+                                            '-k', '31', testdata1],
+                                           in_directory=location)
+
+
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '--scaled', '100',
+                                            '-k', '31', testdata2],
+                                           in_directory=location)
+
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare', 'short.fa.sig',
+                                            'short2.fa.sig', '--csv', 'xxx'],
+                                           in_directory=location)
+
+        with open(os.path.join(location, 'xxx')) as fp:
+            lines = fp.readlines()
+            assert len(lines) == 3
+            assert lines[1].startswith('1.0,0.6666')
+            assert lines[2].startswith('0.6666')
+
+
 def test_do_plot_comparison():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -553,6 +553,25 @@ def test_do_sourmash_check_knowngood_protein_comparisons():
         assert sig2_trans.similarity(good_trans) == 1.0
 
 
+def test_do_compare_quiet():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '-k', '31',
+                                            testdata1, testdata2],
+                                           in_directory=location)
+
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare', 'short.fa.sig',
+                                            'short2.fa.sig', '--csv', 'xxx',
+                                            '-q'],
+                                           in_directory=location)
+        assert not out
+        assert not err
+
+
 def test_do_compare_output_csv():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')
@@ -793,6 +812,65 @@ def test_compare_deduce_molecule():
                                            in_directory=location)
         print(status, out, err)
         assert 'min similarity in matrix: 0.91' in out
+
+
+def test_compare_choose_molecule_dna():
+    # choose molecule type
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '-k', '30',
+                                            '--dna', '--protein',
+                                            testdata1, testdata2],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare', '--dna', 'short.fa.sig',
+                                            'short2.fa.sig'],
+                                           in_directory=location)
+        print(status, out, err)
+        assert 'min similarity in matrix: 0.938' in out
+
+
+def test_compare_choose_molecule_protein():
+    # choose molecule type
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '-k', '30',
+                                            '--dna', '--protein',
+                                            testdata1, testdata2],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare', '--protein', 'short.fa.sig',
+                                            'short2.fa.sig'],
+                                           in_directory=location)
+        print(status, out, err)
+        assert 'min similarity in matrix: 0.91' in out
+
+
+def test_compare_no_choose_molecule_fail():
+    # choose molecule type
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', '-k', '30',
+                                            '--dna', '--protein',
+                                            testdata1, testdata2],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare', 'short.fa.sig',
+                                            'short2.fa.sig'],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        assert 'multiple molecule types loaded; please specify' in err
+        assert status != 0
 
 
 def test_compare_deduce_ksize():

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -588,6 +588,19 @@ def test_do_compare_downsample():
                                             '-k', '31', testdata2],
                                            in_directory=location)
 
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare', 'short.fa.sig',
+                                            'short2.fa.sig', '--csv', 'xxx'],
+                                           in_directory=location)
+
+        print(status, out, err)
+        assert 'downsampling to scaled value of 200' in err
+        with open(os.path.join(location, 'xxx')) as fp:
+            lines = fp.readlines()
+            assert len(lines) == 3
+            assert lines[1].startswith('1.0,0.6666')
+            assert lines[2].startswith('0.6666')
+
 
 def test_do_compare_output_multiple_k():
     with utils.TempDirectory() as location:


### PR DESCRIPTION
Updates to `sourmash compare` --

* downsample to lowest `scaled` value if `max_hash` is set. (fixes #285)
* error out with informative messages if multiple k-mer sizes or molecule types are present.
* add `--dna` and `--protein` arguments (fixes #168);
* fixes `sourmash compute` output annoyance (fixes #286);

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
