### PR TITLE
[MRG] Updates and improvements and simplifications to the sourmash Python API

### DIFF
--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -30,7 +30,7 @@ pip install -U pip
 pip install -U Cython
 pip install -U jupyter jupyter_client ipython pandas matplotlib scipy scikit-learn khmer
 
-pip install https://github.com/dib-lab/sourmash/archive/master.zip
+pip install -U https://github.com/dib-lab/sourmash/archive/master.zip
 
 ```
 

--- a/sourmash_lib/__init__.py
+++ b/sourmash_lib/__init__.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 import re
 import math
 from ._minhash import (MinHash, get_minhash_default_seed, get_minhash_max_hash)
+from .signature import (load_signatures, load_one_signature, SourmashSignature,
+                        save_signatures)
 import os
 
 # retrieve VERSION from sourmash_lib/VERSION.

--- a/sourmash_lib/__init__.py
+++ b/sourmash_lib/__init__.py
@@ -5,10 +5,12 @@ An implementation of a MinHash bottom sketch, applied to k-mers in DNA.
 from __future__ import print_function
 import re
 import math
+import os
+
 from ._minhash import (MinHash, get_minhash_default_seed, get_minhash_max_hash)
 from .signature import (load_signatures, load_one_signature, SourmashSignature,
                         save_signatures)
-import os
+from .sbtmh import load_sbt_index, search_sbt_index, create_sbt_index
 
 # retrieve VERSION from sourmash_lib/VERSION.
 thisdir = os.path.dirname(__file__)

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -99,7 +99,6 @@ cdef class MinHash(object):
         elif scaled:
             max_hash = get_max_hash_for_scaled(scaled)
 
-
         cdef KmerMinHash *mh = NULL
         if track_abundance:
             mh = new KmerMinAbundance(n, ksize, is_protein, seed, max_hash)
@@ -231,8 +230,6 @@ cdef class MinHash(object):
     @property
     def max_hash(self):
         mm = deref(self._this).max_hash
-        if mm == 18446744073709551615:
-            mm = 0
 
         return mm
 

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -91,8 +91,7 @@ cdef class MinHash(object):
                        bool track_abundance=False,
                        uint32_t seed=MINHASH_DEFAULT_SEED,
                        HashIntoType max_hash=0,
-                       HashIntoType scaled=0,
-                       mins=None):
+                       mins=None, HashIntoType scaled=0):
         self.track_abundance = track_abundance
 
         if max_hash and scaled:
@@ -159,8 +158,8 @@ cdef class MinHash(object):
                 self.track_abundance,
                 deref(self._this).seed,
                 deref(self._this).max_hash,
-                0,
-                self.get_mins(with_abundance=self.track_abundance)))
+                self.get_mins(with_abundance=self.track_abundance),
+                0))
 
     def __richcmp__(self, other, op):
         if op == 2:

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -32,6 +32,9 @@ def get_minhash_max_hash():
 def get_max_hash_for_scaled(scaled):
     if scaled == 0:
         return 0
+    elif scaled == 1:
+        return get_minhash_max_hash()
+
     return int(round(get_minhash_max_hash() / scaled, 0))
 
 
@@ -87,7 +90,8 @@ cdef class MinHash(object):
                        bool is_protein=False,
                        bool track_abundance=False,
                        uint32_t seed=MINHASH_DEFAULT_SEED,
-                       HashIntoType max_hash=0, HashIntoType scaled=0,
+                       HashIntoType max_hash=0,
+                       HashIntoType scaled=0,
                        mins=None):
         self.track_abundance = track_abundance
 

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -29,6 +29,18 @@ def get_minhash_max_hash():
     return MINHASH_MAX_HASH
 
 
+def get_max_hash_for_scaled(scaled):
+    if scaled == 0:
+        return 0
+    return int(round(get_minhash_max_hash() / scaled, 0))
+
+
+def get_scaled_for_max_hash(max_hash):
+    if max_hash == 0:
+        return 0
+    return int(get_minhash_max_hash() / max_hash)
+
+
 cdef bytes to_bytes(s):
     if not isinstance(s, (basestring, bytes)):
         raise TypeError("Requires a string-like sequence")
@@ -75,9 +87,15 @@ cdef class MinHash(object):
                        bool is_protein=False,
                        bool track_abundance=False,
                        uint32_t seed=MINHASH_DEFAULT_SEED,
-                       HashIntoType max_hash=0,
+                       HashIntoType max_hash=0, HashIntoType scaled=0,
                        mins=None):
         self.track_abundance = track_abundance
+
+        if max_hash and scaled:
+            raise ValueError('cannot set both max_hash and scaled')
+        elif scaled:
+            max_hash = get_max_hash_for_scaled(scaled)
+
 
         cdef KmerMinHash *mh = NULL
         if track_abundance:
@@ -137,6 +155,7 @@ cdef class MinHash(object):
                 self.track_abundance,
                 deref(self._this).seed,
                 deref(self._this).max_hash,
+                0,
                 self.get_mins(with_abundance=self.track_abundance)))
 
     def __richcmp__(self, other, op):
@@ -194,7 +213,9 @@ cdef class MinHash(object):
 
     @property
     def scaled(self):
-        return int(get_minhash_max_hash() / self.max_hash)
+        if self.max_hash:
+            return get_scaled_for_max_hash(self.max_hash)
+        return 0
 
     @property
     def is_protein(self):
@@ -235,7 +256,7 @@ cdef class MinHash(object):
     def downsample_max_hash(self, *others):
         max_hashes = [ x.max_hash for x in others ]
         new_max_hash = min(self.max_hash, *max_hashes)
-        new_scaled = int(get_minhash_max_hash() / new_max_hash)
+        new_scaled = get_scaled_for_max_hash(new_max_hash)
 
         return self.downsample_scaled(new_scaled)
 
@@ -244,12 +265,11 @@ cdef class MinHash(object):
         if max_hash is None:
             raise ValueError('no max_hash available - cannot downsample')
 
-        old_scaled = int(get_minhash_max_hash() / self.max_hash)
+        old_scaled = get_scaled_for_max_hash(self.max_hash)
         if old_scaled > new_num:
             raise ValueError('new scaled is lower than current sample scaled')
 
-        new_max_hash = get_minhash_max_hash() / float(new_num)
-        new_max_hash = int(round(new_max_hash, 0))
+        new_max_hash = get_max_hash_for_scaled(new_num)
 
         a = MinHash(0, deref(self._this).ksize,
                     deref(self._this).is_protein, self.track_abundance,

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -97,6 +97,7 @@ def compute(args):
     parser.add_argument('--randomize', action='store_true',
                         help='shuffle the list of input filenames randomly')
 
+
     args = parser.parse_args(args)
     set_quiet(args.quiet)
 
@@ -165,12 +166,6 @@ def compute(args):
 
     def make_minhashes():
         seed = args.seed
-        max_hash = 0
-        if args.scaled and args.scaled == 1:
-            max_hash = sourmash_lib.MAX_HASH - 1
-        elif args.scaled and args.scaled > 1:
-            max_hash = sourmash_lib.MAX_HASH / float(args.scaled)
-            max_hash = round(max_hash, 0)
 
         # one minhash for each ksize
         Elist = []

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -6,6 +6,7 @@ import os
 import os.path
 import sys
 from collections import namedtuple
+import random
 
 import screed
 import sourmash_lib
@@ -93,6 +94,8 @@ def compute(args):
     parser.add_argument('--seed', type=int,
                         help='seed used by MurmurHash (default: 42)',
                         default=sourmash_lib.DEFAULT_SEED)
+    parser.add_argument('--randomize', action='store_true',
+                        help='shuffle the list of input filenames randomly')
 
     args = parser.parse_args(args)
     set_quiet(args.quiet)
@@ -117,6 +120,10 @@ def compute(args):
             args.num_hashes = 0
 
     notify('computing signatures for files: {}', ", ".join(args.filenames))
+
+    if args.randomize:
+        notify('randomizing file list because of --randomize')
+        random.shuffle(args.filenames)
 
     # get list of k-mer sizes for which to compute sketches
     ksizes = args.ksizes

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -1,8 +1,35 @@
 from __future__ import print_function
 from __future__ import division
 
-from .sbt import Leaf
+from .sbt import Leaf, SBT, GraphFactory
 from . import _minhash, MinHash
+
+
+def load_sbt_index(filename):
+    "Load and return an SBT index."
+    return SBT.load(filename, leaf_loader=SigLeaf.load)
+
+
+def create_sbt_index(bloom_filter_size=1e5):
+    "Create an empty SBT index."
+    factory = GraphFactory(1, bloom_filter_size, 4)
+    tree = SBT(factory)
+    return tree
+
+
+def search_sbt_index(tree, query, threshold):
+    """\
+    Search an SBT index `tree` with signature `query` for matches above
+    `threshold`.
+
+    Usage:
+
+        for match_sig, similarity in search_sbt_index(tree, query, threshold):
+           ...
+    """
+    for leaf in tree.find(search_minhashes, query, threshold):
+        similarity = query.similarity(leaf.data)
+        yield leaf.data, similarity
 
 
 class SigLeaf(Leaf):

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -77,7 +77,7 @@ class SourmashSignature(object):
         sketch = {}
         sketch['ksize'] = int(minhash.ksize)
         sketch['num'] = minhash.num
-        sketch['max_hash'] = int(minhash.max_hash)
+        sketch['max_hash'] = minhash.max_hash
         sketch['seed'] = int(minhash.seed)
         if self.minhash.track_abundance:
             values = minhash.get_mins(with_abundance=True)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -38,7 +38,9 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 
-from sourmash_lib._minhash import MinHash, hash_murmur, dotproduct
+from sourmash_lib._minhash import (MinHash, hash_murmur, dotproduct,
+                                   get_scaled_for_max_hash,
+                                   get_max_hash_for_scaled)
 import math
 
 # add:
@@ -140,6 +142,30 @@ def test_max_hash(track_abundance):
     assert mh.get_mins() == [10, 20, 30]
     mh.add_hash(36)
     assert mh.get_mins() == [10, 20, 30]
+
+
+def test_scaled(track_abundance):
+    # test behavior with scaled (alt to max_hash)
+    scaled = get_scaled_for_max_hash(35)
+    print('XX', scaled, get_max_hash_for_scaled(scaled))
+    mh = MinHash(0, 4, track_abundance=track_abundance, scaled=scaled)
+    assert mh.max_hash == 35
+
+    mh.add_hash(10)
+    mh.add_hash(20)
+    mh.add_hash(30)
+    assert mh.get_mins() == [10, 20, 30]
+    mh.add_hash(40)
+    assert mh.get_mins() == [10, 20, 30]
+    mh.add_hash(36)
+    assert mh.get_mins() == [10, 20, 30]
+
+
+def test_max_hash_and_scaled_error(track_abundance):
+    # test behavior when supplying both max_hash and scaled
+    with pytest.raises(ValueError):
+        mh = MinHash(0, 4, track_abundance=track_abundance, max_hash=35,
+                     scaled=5)
 
 
 def test_max_hash_with_limit(track_abundance):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,6 @@ def test_sourmash_signature_api():
     s = sourmash.save_signatures([sig])
     sig_x1 = sourmash.load_one_signature(s)
     sig_x2 = list(sourmash.load_signatures(s))[0]
-    
+
     assert sig_x1 == sig
     assert sig_x2 == sig

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,15 @@
+from __future__ import print_function, unicode_literals
+
+import sourmash_lib as sourmash
+
+
+def test_sourmash_signature_api():
+    e = sourmash.MinHash(n=1, ksize=20)
+    sig = sourmash.SourmashSignature('', e)
+
+    s = sourmash.save_signatures([sig])
+    sig_x1 = sourmash.load_one_signature(s)
+    sig_x2 = list(sourmash.load_signatures(s))[0]
+    
+    assert sig_x1 == sig
+    assert sig_x2 == sig

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1757,7 +1757,7 @@ def test_gather_file_output():
         with open(os.path.join(location, 'foo.out')) as f:
             output = f.read()
             print((output,))
-            assert '910.0,1.0,1.0' in output
+            assert '910,1.0,1.0' in output
 
 
 def test_gather_metagenome():

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -376,7 +376,7 @@ def test_do_sourmash_compute_with_scaled_1():
 
         max_hashes = [ x.minhash.max_hash for x in siglist ]
         assert len(max_hashes) == 2
-        assert set(max_hashes) == { sourmash_lib.MAX_HASH - 1 }
+        assert set(max_hashes) == { sourmash_lib.MAX_HASH }
 
 
 def test_do_sourmash_compute_with_scaled_2():


### PR DESCRIPTION
A few useful changes to the Python API, partially addressing #308.

* `load_signatures`, `load_one_signature`, `SourmashSignature`, and `save_signatures` are now available at the top-level in the package (addresses #305);
* added two new convenience functions, `get_max_hash_for_scaled` and `get_scaled_for_max_hash`, to `_minhash` module;
* `MinHash` constructor now takes EITHER `max_hash` OR `scaled` values (fixes #321);
* fixes some minor tutorial issues (fixes #290, #287);
* basic checks on `sourmash compute --scaled` value (fixes #291);
* provided nicer API for search (fixes #308);
* added `--randomize` to `sourmash compute` (fixes #322);

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
