### PR TITLE
[MRG] make len(minhash), minhash.num, and minhash.max_hash => sensible.

### DIFF
--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -219,7 +219,7 @@ cdef class MinHash(object):
         return deref(self._this).count_common(deref(other._this))
 
     def downsample_n(self, new_num):
-        if self.num < new_num:
+        if self.num and self.num < new_num:
             raise ValueError('new sample n is higher than current sample n')
 
         a = MinHash(new_num, deref(self._this).ksize,

--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -167,7 +167,7 @@ cdef class MinHash(object):
         self.add_many(other.get_mins())
 
     def __len__(self):
-        return deref(self._this).num
+        return deref(self._this).mins.size()
 
     cpdef get_mins(self, bool with_abundance=False):
         cdef KmerMinAbundance *mh = <KmerMinAbundance*>address(deref(self._this))

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -150,9 +150,11 @@ def compute(args):
     def make_minhashes():
         seed = args.seed
         max_hash = 0
-        if args.scaled and args.scaled > 1:
+        if args.scaled and args.scaled == 1:
+            max_hash = sourmash_lib.MAX_HASH - 1
+        elif args.scaled and args.scaled > 1:
             max_hash = sourmash_lib.MAX_HASH / float(args.scaled)
-            max_hash = int(round(max_hash, 0))
+            max_hash = round(max_hash, 0)
 
         # one minhash for each ksize
         Elist = []
@@ -890,8 +892,8 @@ def gather(args):
 
 
     # define a function to build new signature object from set of mins
-    def build_new_signature(mins):
-        e = sourmash_lib.MinHash(ksize=query_ksize, n=len(mins))
+    def build_new_signature(mins, template_sig):
+        e = template_sig.minhash.copy_and_clear()
         e.add_many(mins)
         return sig.SourmashSignature('', e)
 
@@ -910,7 +912,7 @@ def gather(args):
 
     # construct a new query that doesn't have the max_hash attribute set.
     new_mins = query.minhash.get_hashes()
-    query = build_new_signature(new_mins)
+    query = build_new_signature(new_mins, orig_query)
 
     sum_found = 0.
     found = []
@@ -991,7 +993,7 @@ def gather(args):
 
         # construct a new query, minus the previous one.
         query_mins -= set(found_mins)
-        query = build_new_signature(query_mins)
+        query = build_new_signature(query_mins, orig_query)
 
     # basic reporting
     print_results('\nfound {} matches total;', len(found))

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -91,7 +91,7 @@ public:
           mins.push_back(h);
           return;
         }
-        else if (h < max_hash or mins.back() > h or mins.size() < num) {
+        else if (h <= max_hash or mins.back() > h or mins.size() < num) {
           auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
 
           // must still be growing, we know the list won't get too long
@@ -310,7 +310,7 @@ class KmerMinAbundance: public KmerMinHash {
           mins.push_back(h);
           abunds.push_back(1);
           return;
-        } else if (h < max_hash or mins.back() > h or mins.size() < num) {
+        } else if (h <= max_hash or mins.back() > h or mins.size() < num) {
           auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
 
           // must still be growing, we know the list won't get too long

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -86,7 +86,7 @@ public:
     }
 
     virtual void add_hash(const HashIntoType h) {
-      if ((max_hash and h <= max_hash) or !max_hash) {
+      if ((max_hash and h <= max_hash) or not max_hash) {
         if (mins.size() == 0) {
           mins.push_back(h);
           return;
@@ -305,7 +305,7 @@ class KmerMinAbundance: public KmerMinHash {
         KmerMinHash(n, k, prot, seed, mx) { };
 
     virtual void add_hash(HashIntoType h) {
-      if ((max_hash and h <= max_hash) or !max_hash) {
+      if ((max_hash and h <= max_hash) or not max_hash) {
         if (mins.size() == 0) {
           mins.push_back(h);
           abunds.push_back(1);

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -60,12 +60,7 @@ public:
 
     KmerMinHash(unsigned int n, unsigned int k, bool prot, uint32_t s,
                 HashIntoType mx)
-        : // overflow num to represent "no maximum"
-          num(n > 0 ? n : -1),
-          ksize(k), is_protein(prot), seed(s),
-          // overflow max_hash to represent "no maximum", this simplifies
-          // the comparison in add_hash()
-          max_hash(mx > 0 ? mx : -1) {
+        : num(n), ksize(k), is_protein(prot), seed(s), max_hash(mx) {
       if (n > 0) {
         mins.reserve(num + 1);
       }
@@ -91,12 +86,12 @@ public:
     }
 
     virtual void add_hash(const HashIntoType h) {
-      if (h <= max_hash) {
+      if ((max_hash and h <= max_hash) or !max_hash) {
         if (mins.size() == 0) {
           mins.push_back(h);
           return;
         }
-        else if (mins.back() > h or mins.size() < num) {
+        else if (h < max_hash or mins.back() > h or mins.size() < num) {
           auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
 
           // must still be growing, we know the list won't get too long
@@ -107,7 +102,7 @@ public:
           // in mins store it and shrink list if needed
           else if (*pos != h) {
             mins.insert(pos, h);
-            if (mins.size() > num) {
+            if (num and mins.size() > num) {
               mins.pop_back();
             }
           }
@@ -232,7 +227,7 @@ public:
         std::set_union(other.mins.begin(), other.mins.end(),
                        mins.begin(), mins.end(),
                        std::back_inserter(merged));
-        if (merged.size() < num) {
+        if (merged.size() < num or !num) {
           mins = merged;
         }
         else {
@@ -310,12 +305,12 @@ class KmerMinAbundance: public KmerMinHash {
         KmerMinHash(n, k, prot, seed, mx) { };
 
     virtual void add_hash(HashIntoType h) {
-      if (h <= max_hash) {
+      if ((max_hash and h <= max_hash) or !max_hash) {
         if (mins.size() == 0) {
           mins.push_back(h);
           abunds.push_back(1);
           return;
-        } else if (mins.back() > h or mins.size() < num) {
+        } else if (h < max_hash or mins.back() > h or mins.size() < num) {
           auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
 
           // must still be growing, we know the list won't get too long

--- a/sourmash_lib/sbtmh.py
+++ b/sourmash_lib/sbtmh.py
@@ -112,12 +112,11 @@ class SearchMinHashesFindBestIgnoreMaxHash(object):
         mins = sig.minhash.get_mins()
 
         if isinstance(node, SigLeaf):
-            old_est = node.data.minhash
-            E = MinHash(ksize=old_est.ksize, n=old_est.num)
-            for m in old_est.get_mins():
-                E.add_hash(m)
+            max_scaled = max(node.data.minhash.scaled, sig.minhash.scaled)
 
-            matches = E.count_common(sig.minhash)
+            mh1 = node.data.minhash.downsample_scaled(max_scaled)
+            mh2 = sig.minhash.downsample_scaled(max_scaled)
+            matches = mh1.count_common(mh2)
         else:  # Node or Leaf, Nodegraph by minhash comparison
             matches = sum(1 for value in mins if node.data.get(value))
 

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -76,7 +76,7 @@ class SourmashSignature(object):
 
         sketch = {}
         sketch['ksize'] = int(minhash.ksize)
-        sketch['num'] = len(minhash)
+        sketch['num'] = minhash.num
         sketch['max_hash'] = int(minhash.max_hash)
         sketch['seed'] = int(minhash.seed)
         if self.minhash.track_abundance:

--- a/sourmash_lib/signature_json.py
+++ b/sourmash_lib/signature_json.py
@@ -70,7 +70,7 @@ def _json_next_signature(iterable,
     ksize = d['ksize']
     mins = d['mins']
     n = d['num']
-    if n == 4294967295:               # load legacy signatures where n == -1
+    if n == 0xffffffff:               # load legacy signatures where n == -1
         n = 0
     max_hash = d.get('max_hash', 0)
     seed = d.get('seed', sourmash_lib.DEFAULT_SEED)

--- a/sourmash_lib/signature_json.py
+++ b/sourmash_lib/signature_json.py
@@ -70,6 +70,8 @@ def _json_next_signature(iterable,
     ksize = d['ksize']
     mins = d['mins']
     n = d['num']
+    if n == 4294967295:                   # @CTB legacy load hack
+        n = 0
     max_hash = d.get('max_hash', 0)
     seed = d.get('seed', sourmash_lib.DEFAULT_SEED)
 

--- a/sourmash_lib/signature_json.py
+++ b/sourmash_lib/signature_json.py
@@ -70,7 +70,7 @@ def _json_next_signature(iterable,
     ksize = d['ksize']
     mins = d['mins']
     n = d['num']
-    if n == 4294967295:                   # @CTB legacy load hack
+    if n == 4294967295:               # load legacy signatures where n == -1
         n = 0
     max_hash = d.get('max_hash', 0)
     seed = d.get('seed', sourmash_lib.DEFAULT_SEED)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -118,17 +118,6 @@ def test_size_limit(track_abundance):
     assert mh.get_mins() == [5, 10, 20]
 
 
-def test_size_limit_none(track_abundance):
-    # test behavior with size limit of 0 (=> no size limit)
-    mh = MinHash(0, 4, track_abundance=track_abundance)
-    mh.add_hash(10)
-    mh.add_hash(20)
-    mh.add_hash(30)
-    assert mh.get_mins() == [10, 20, 30]
-    mh.add_hash(5) # -> should retain all, b/c size limit is 0
-    assert mh.get_mins() == [5, 10, 20, 30]
-
-
 def test_max_hash(track_abundance):
     # test behavior with max_hash
     mh = MinHash(0, 4, track_abundance=track_abundance, max_hash=35)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -12,6 +12,7 @@ import json
 import csv
 
 from . import sourmash_tst_utils as utils
+import sourmash_lib
 from sourmash_lib import MinHash
 try:
     import matplotlib
@@ -375,7 +376,7 @@ def test_do_sourmash_compute_with_scaled_1():
 
         max_hashes = [ x.minhash.max_hash for x in siglist ]
         assert len(max_hashes) == 2
-        assert set(max_hashes) == { 0 }
+        assert set(max_hashes) == { sourmash_lib.MAX_HASH - 1 }
 
 
 def test_do_sourmash_compute_with_scaled_2():


### PR DESCRIPTION
This PR makes `len(minhash)` equal to `len(minhash.get_mins()`, and also makes sure that `num=0` when max_hash is set and `max_hash=0` when it is not set - fixes #214.  Associated changes and refactoring occurred as well, including the removal of a test for unwanted behavior around num=0, and some code for legacy loading of signatures where n was saved as -1 (== 4294967295).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
