### PR TITLE
[MRG] make SourmashSignature printable and hashable

### DIFF
--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -31,6 +31,17 @@ class SourmashSignature(object):
 
         self.minhash = minhash
 
+    def __hash__(self):
+        return hash(self.md5sum())
+
+    def __str__(self):
+        name = self.name()
+        md5pref = self.md5sum()[:8]
+        if name != md5pref:
+            return "SourmashSignature('{}', {})".format(name, md5pref)
+        return "SourmashSignature({})".format(md5pref)
+    __repr__ = __str__
+
     def md5sum(self):
         "Calculate md5 hash of the bottom sketch, specifically."
         m = hashlib.md5()

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -7,6 +7,33 @@ from sourmash_lib.signature import SourmashSignature, save_signatures, \
     load_signatures, load_one_signature
 
 
+def test_hashable(track_abundance):
+    # check: can we use signatures as keys in dictionaries and sets?
+    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+
+    sig = SourmashSignature('', e)
+
+    x = set()
+    x.add(sig)
+
+
+def test_str(track_abundance):
+    # signatures should be printable
+    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+
+    sig = SourmashSignature('', e)
+
+    print(sig)
+    assert str(sig) == 'SourmashSignature(59502a74)'
+    assert repr(sig) == 'SourmashSignature(59502a74)'
+
+    sig.d['name'] = 'fizbar'
+    assert str(sig) == 'SourmashSignature(\'fizbar\', 59502a74)'
+    assert repr(sig) == 'SourmashSignature(\'fizbar\', 59502a74)'
+
+
 def test_roundtrip(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add("AT" * 10)


### PR DESCRIPTION
Add `__str__`, `__repr__`, and `__hash__` to `SourmashSignature` objects.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
