### PR TITLE
[MRG] remove 'email' and 'type' from signatures.

### DIFF
--- a/doc/api-example.rst
+++ b/doc/api-example.rst
@@ -84,8 +84,7 @@ Saving and loading signature files
 ----------------------------------
 
 >>> from sourmash_lib import signature
->>> sig1 = signature.SourmashSignature('titus@idyll.org', minhashes[0],
-...                                    name=genomes[0][:20])
+>>> sig1 = signature.SourmashSignature(minhashes[0], name=genomes[0][:20])
 >>> with open('/tmp/genome1.sig', 'wt') as fp:
 ...   signature.save_signatures([sig1], fp)
 

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -79,8 +79,6 @@ def compute(args):
                         help='recompute signatures even if the file exists (default: False)')
     parser.add_argument('-o', '--output', type=argparse.FileType('wt'),
                         help='output computed signatures to this file')
-    parser.add_argument('--email', type=str, default='',
-                        help='set e-mail address of the signature creator (default: empty)')
     parser.add_argument('--singleton', action='store_true',
                         help='compute a signature for each sequence record individually (default: False)')
     parser.add_argument('--merge', '--name', type=str, default='', metavar="MERGED",
@@ -193,8 +191,8 @@ def compute(args):
             else:
                 E.add_sequence(seq, not check_sequence)
 
-    def build_siglist(email, Elist, filename, name=None):
-        return [ sig.SourmashSignature(email, E, filename=filename,
+    def build_siglist(Elist, filename, name=None):
+        return [ sig.SourmashSignature(E, filename=filename,
                                        name=name) for E in Elist ]
 
     def save_siglist(siglist, output_fp, filename=None):
@@ -229,8 +227,7 @@ def compute(args):
                     add_seq(Elist, record.sequence,
                             args.input_is_protein, args.check_sequence)
 
-                    siglist += build_siglist(args.email, Elist, filename,
-                                             name=record.name)
+                    siglist += build_siglist(Elist, filename, name=record.name)
 
                 notify('calculated {} signatures for {} sequences in {}'.\
                           format(len(siglist), n + 1, filename))
@@ -253,7 +250,7 @@ def compute(args):
                             args.input_is_protein, args.check_sequence)
                 notify('')
 
-                sigs = build_siglist(args.email, Elist, filename, name)
+                sigs = build_siglist(Elist, filename, name)
                 if args.output:
                     siglist += sigs
                 else:
@@ -281,8 +278,7 @@ def compute(args):
                 add_seq(Elist, record.sequence,
                         args.input_is_protein, args.check_sequence)
 
-        siglist = build_siglist(args.email, Elist, filename,
-                                name=args.merge)
+        siglist = build_siglist(Elist, filename, name=args.merge)
         notify('calculated {} signatures for {} sequences taken from {}'.\
                format(len(siglist), n + 1, " ".join(args.filenames)))
         # at end, save!
@@ -470,7 +466,6 @@ def import_csv(args):
     p.add_argument('mash_csvfile')
     p.add_argument('-o', '--output', type=argparse.FileType('wt'),
                    default=sys.stdout, help='(default: stdout)')
-    p.add_argument('--email', type=str, default='', help='(default: %(default)s)')
     args = p.parse_args(args)
 
     with open(args.mash_csvfile, 'r') as fp:
@@ -492,7 +487,7 @@ def import_csv(args):
 
             e = sourmash_lib.MinHash(len(hashes), ksize)
             e.add_many(hashes)
-            s = sig.SourmashSignature(args.email, e, filename=name)
+            s = sig.SourmashSignature(e, filename=name)
             siglist.append(s)
             notify('loaded signature: {} {}', name, s.md5sum()[:8])
 
@@ -930,7 +925,7 @@ def gather(args):
     def build_new_signature(mins, template_sig):
         e = template_sig.minhash.copy_and_clear()
         e.add_many(mins)
-        return sig.SourmashSignature('', e)
+        return sig.SourmashSignature(e)
 
     # xxx
     def format_bp(bp):
@@ -1068,7 +1063,7 @@ def gather(args):
             e = sourmash_lib.MinHash(ksize=query_ksize, n=0,
                                      max_hash=new_max_hash)
             e.add_many(query.minhash.get_mins())
-            sig.save_signatures([ sig.SourmashSignature('', e) ],
+            sig.save_signatures([ sig.SourmashSignature(e) ],
                                 args.output_unassigned)
 
 
@@ -1127,7 +1122,7 @@ def watch(args):
 
     E = sourmash_lib.MinHash(ksize=ksize, n=args.num_hashes,
                              is_protein=is_protein)
-    streamsig = sig.SourmashSignature('', E, filename='stdin',
+    streamsig = sig.SourmashSignature(E, filename='stdin',
                                       name=args.name)
 
     notify('Computing signature for k={}, {} from stdin',

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -19,11 +19,9 @@ SIGNATURE_VERSION=0.4
 class SourmashSignature(object):
     "Main class for signature information."
 
-    def __init__(self, email, minhash, name='', filename=''):
+    def __init__(self, minhash, name='', filename=''):
         self.d = {}
         self.d['class'] = 'sourmash_signature'
-        self.d['type'] = 'mrnaseq'
-        self.d['email'] = email
         if name:
             self.d['name'] = name
         if filename:
@@ -94,8 +92,7 @@ class SourmashSignature(object):
 
         e['signature'] = sketch
 
-        return self.d.get('email'), self.d.get('name'), \
-            self.d.get('filename'), sketch
+        return self.d.get('name'), self.d.get('filename'), sketch
 
     def similarity(self, other, ignore_abundance=False, downsample=False):
         "Compute similarity with the other MinHash signature."

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -38,8 +38,9 @@ class SourmashSignature(object):
         return m.hexdigest()
 
     def __eq__(self, other):
-        for k in self.d:
-            if self.d[k] != other.d[k]:
+        allkeys = set(self.d.keys()).union(set(other.d.keys()))
+        for k in allkeys:
+            if self.d.get(k) != other.d.get(k):
                 return False
             
         return self.minhash == other.minhash

--- a/sourmash_lib/signature_json.py
+++ b/sourmash_lib/signature_json.py
@@ -33,7 +33,6 @@ def _json_next_atomic_array(iterable, prefix_item = 'item', ijson = ijson):
 
 
 def _json_next_signature(iterable,
-                         email = None,
                          name = None,
                          filename = None,
                          ignore_md5sum=False,
@@ -41,7 +40,6 @@ def _json_next_signature(iterable,
                          ijson = ijson):
     """Helper function to unpack and check one signature block only.
     - iterable: an iterable such the one returned by ijson.parse()
-    - email:
     - name:
     - filename:
     - ignore_md5sum:
@@ -98,7 +96,7 @@ def _json_next_signature(iterable,
         abundances = list(map(int, d['abundances']))
         e.set_abundances(dict(zip(mins, abundances)))
 
-    sig = SourmashSignature(email, e)
+    sig = SourmashSignature(e)
 
     if not ignore_md5sum:
         md5sum = d['md5sum']
@@ -137,7 +135,6 @@ def load_signature_json(iterable,
             assert event == 'start_array'
             while event != 'end_array':
                 sig = _json_next_signature(iterable,
-                                           email = None,
                                            name = None,
                                            filename = None,
                                            ignore_md5sum=ignore_md5sum,
@@ -151,9 +148,8 @@ def load_signature_json(iterable,
         d[key] = value
         prefix, event, value = next(iterable)
 
-    # email, name, and filename not assumed to be parsed before the 'signatures'
+    # name, and filename not assumed to be parsed before the 'signatures'
     for sig in signatures:
-        sig.d['email'] = d['email']
         if 'name' in d:
             sig.d['name'] = d['name']
         if 'filename' in d:
@@ -232,8 +228,8 @@ def save_signatures_json(siglist, fp=None, indent=4, sort_keys=True):
 
     top_records = {}
     for sig in siglist:
-        email, name, filename, sketch = sig._save()
-        k = (email, name, filename)
+        name, filename, sketch = sig._save()
+        k = (name, filename)
         x = top_records.get(k, [])
         x.append(sketch)
         top_records[k] = x
@@ -242,9 +238,8 @@ def save_signatures_json(siglist, fp=None, indent=4, sort_keys=True):
         return ""
 
     records = []
-    for (email, name, filename), sketches in top_records.items():
+    for (name, filename), sketches in top_records.items():
         record = {}
-        record['email'] = email
         if name:
             record['name'] = name
         if filename:
@@ -253,7 +248,6 @@ def save_signatures_json(siglist, fp=None, indent=4, sort_keys=True):
 
         record['version'] = SIGNATURE_VERSION
         record['class'] = 'sourmash_signature'
-        record['type'] = 'mrnaseq'
         record['hash_function'] = '0.murmur64'
 
         records.append(record)

--- a/sourmash_lib/signature_json.py
+++ b/sourmash_lib/signature_json.py
@@ -249,6 +249,7 @@ def save_signatures_json(siglist, fp=None, indent=4, sort_keys=True):
         record['version'] = SIGNATURE_VERSION
         record['class'] = 'sourmash_signature'
         record['hash_function'] = '0.murmur64'
+        record['email'] = ''
 
         records.append(record)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import sourmash_lib as sourmash
 
 def test_sourmash_signature_api():
     e = sourmash.MinHash(n=1, ksize=20)
-    sig = sourmash.SourmashSignature('', e)
+    sig = sourmash.SourmashSignature(e)
 
     s = sourmash.save_signatures([sig])
     sig_x1 = sourmash.load_one_signature(s)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -7,6 +7,60 @@ from sourmash_lib.signature import SourmashSignature, save_signatures, \
     load_signatures, load_one_signature
 
 
+def test_compare(track_abundance):
+    # same content, same name -> equal
+    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+    sig1 = SourmashSignature(e, name='foo')
+
+    f = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    f.add("AT" * 10)
+    sig2 = SourmashSignature(f, name='foo')
+
+    assert e == f
+
+
+def test_compare_ne(track_abundance):
+    # same content, different names -> different
+    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+    sig1 = SourmashSignature(e, name='foo')
+
+    f = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    f.add("AT" * 10)
+    sig2 = SourmashSignature(f, name='bar')
+
+    assert sig1 != sig2
+
+
+def test_compare_ne2(track_abundance):
+    # same content, different filename -> different
+    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+    sig1 = SourmashSignature(e, name='foo', filename='a')
+
+    f = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    f.add("AT" * 10)
+    sig2 = SourmashSignature(f, name='foo', filename='b')
+
+    assert sig1 != sig2
+    assert sig2 != sig1
+
+
+def test_compare_ne2_reverse(track_abundance):
+    # same content, different filename -> different
+    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+    sig1 = SourmashSignature(e, name='foo')
+
+    f = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    f.add("AT" * 10)
+    sig2 = SourmashSignature(f, name='foo', filename='b')
+
+    assert sig2 != sig1
+    assert sig1 != sig2
+
+
 def test_roundtrip(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add("AT" * 10)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -10,7 +10,7 @@ from sourmash_lib.signature import SourmashSignature, save_signatures, \
 def test_roundtrip(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add("AT" * 10)
-    sig = SourmashSignature('titus@idyll.org', e)
+    sig = SourmashSignature(e)
     s = save_signatures([sig])
     siglist = list(load_signatures(s))
     sig2 = siglist[0]
@@ -23,7 +23,7 @@ def test_roundtrip(track_abundance):
 def test_load_signature_select_ksize_nonint(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add("AT" * 10)
-    sig = SourmashSignature('titus@idyll.org', e)
+    sig = SourmashSignature(e)
     s = save_signatures([sig])
     siglist = list(load_signatures(s, select_ksize='20'))
     sig2 = siglist[0]
@@ -37,7 +37,7 @@ def test_roundtrip_empty(track_abundance):
     # edge case, but: empty minhash? :)
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
 
-    sig = SourmashSignature('titus@idyll.org', e)
+    sig = SourmashSignature(e)
     s = save_signatures([sig])
     siglist = list(load_signatures(s))
     sig2 = siglist[0]
@@ -51,7 +51,7 @@ def test_roundtrip_max_hash(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance,
                              max_hash=10)
     e.add_hash(5)
-    sig = SourmashSignature('titus@idyll.org', e)
+    sig = SourmashSignature(e)
     s = save_signatures([sig])
     siglist = list(load_signatures(s))
     sig2 = siglist[0]
@@ -67,27 +67,13 @@ def test_roundtrip_seed(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance,
                              seed=10)
     e.add_hash(5)
-    sig = SourmashSignature('titus@idyll.org', e)
+    sig = SourmashSignature(e)
     s = save_signatures([sig])
     siglist = list(load_signatures(s))
     sig2 = siglist[0]
     e2 = sig2.minhash
 
     assert e.seed == e2.seed
-
-    assert sig.similarity(sig2) == 1.0
-    assert sig2.similarity(sig) == 1.0
-
-
-def test_roundtrip_empty_email(track_abundance):
-    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    e.add("AT" * 10)
-    sig = SourmashSignature('', e)
-    s = save_signatures([sig])
-    print(s)
-    siglist = list(load_signatures(s))
-    sig2 = siglist[0]
-    e2 = sig2.minhash
 
     assert sig.similarity(sig2) == 1.0
     assert sig2.similarity(sig) == 1.0
@@ -107,8 +93,8 @@ def test_similarity_downsample(track_abundance):
     f.add_hash(5)                 # should be discarded due to max_hash
     assert len(f.get_mins()) == 1
 
-    ee = SourmashSignature('', e)
-    ff = SourmashSignature('', f)
+    ee = SourmashSignature(e)
+    ff = SourmashSignature(f)
 
     with pytest.raises(ValueError):       # mismatch in max_hash
         ee.similarity(ff)
@@ -120,42 +106,42 @@ def test_similarity_downsample(track_abundance):
 def test_md5(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add_hash(5)
-    sig = SourmashSignature('titus@idyll.org', e)
+    sig = SourmashSignature(e)
     print(sig._save())
     assert sig.md5sum() == 'eae27d77ca20db309e056e3d2dcd7d69', sig.md5sum()
 
 
 def test_name(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig = SourmashSignature('titus@idyll.org', e, name='foo')
+    sig = SourmashSignature(e, name='foo')
     assert sig.name() == 'foo'
 
 
 def test_name_2(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig = SourmashSignature('titus@idyll.org', e, filename='foo.txt')
+    sig = SourmashSignature(e, filename='foo.txt')
     assert sig.name() == 'foo.txt'
 
 
 def test_name_3(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig = SourmashSignature('titus@idyll.org', e, name='foo',
+    sig = SourmashSignature(e, name='foo',
                             filename='foo.txt')
     assert sig.name() == 'foo'
 
 
 def test_name_4(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig = SourmashSignature('titus@idyll.org', e)
+    sig = SourmashSignature(e)
     assert sig.name() == sig.md5sum()[:8]
 
 
 def test_save_load_multisig(track_abundance):
     e1 = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig1 = SourmashSignature('titus@idyll.org', e1)
+    sig1 = SourmashSignature(e1)
 
-    e2 = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig2 = SourmashSignature('titus2@idyll.org', e2)
+    e2 = sourmash_lib.MinHash(n=1, ksize=25, track_abundance=track_abundance)
+    sig2 = SourmashSignature(e2)
 
     x = save_signatures([sig1, sig2])
     y = list(load_signatures(x))
@@ -177,7 +163,7 @@ def test_load_one_fail_nosig(track_abundance):
 
 def test_load_one_succeed(track_abundance):
     e1 = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig1 = SourmashSignature('titus@idyll.org', e1)
+    sig1 = SourmashSignature(e1)
 
     x = save_signatures([sig1])
 
@@ -187,10 +173,10 @@ def test_load_one_succeed(track_abundance):
 
 def test_load_one_fail_multisig(track_abundance):
     e1 = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig1 = SourmashSignature('titus@idyll.org', e1)
+    sig1 = SourmashSignature(e1)
 
     e2 = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
-    sig2 = SourmashSignature('titus2@idyll.org', e2)
+    sig2 = SourmashSignature(e2)
 
     x = save_signatures([sig1, sig2])
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -48,14 +48,14 @@ def test_compare_ne2(track_abundance):
 
 
 def test_compare_ne2_reverse(track_abundance):
-    # same content, different filename -> different
+    # same content, one has filename, other does not -> different
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add("AT" * 10)
     sig1 = SourmashSignature(e, name='foo')
 
     f = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     f.add("AT" * 10)
-    sig2 = SourmashSignature(f, name='foo', filename='b')
+    sig2 = SourmashSignature(f, filename='b')
 
     assert sig2 != sig1
     assert sig1 != sig2

--- a/tests/test_signature_json.py
+++ b/tests/test_signature_json.py
@@ -25,7 +25,6 @@ def test__json_next_atomic_array():
 # integration test more than a unit test...
 def test__json_next_signature():
 
-    email = 'foo@bar.com'
     name = 'Foo Bar'
     filename = '/tmp/foobar'
 
@@ -40,7 +39,7 @@ def test__json_next_signature():
         s = unicode(s)
     it = ijson.parse(io.StringIO(s))
     # no MD5SUM
-    sig = _json_next_signature(it, email, name, filename,
+    sig = _json_next_signature(it, name, filename,
                                ignore_md5sum=True,
                                ijson=ijson)
 
@@ -55,19 +54,17 @@ def test__json_next_signature():
     if sys.version_info[0] < 3:
         s = unicode(s)
     it = ijson.parse(io.StringIO(s))
-    sig = _json_next_signature(it, email, name, filename,
+    sig = _json_next_signature(it, name, filename,
                                ignore_md5sum=False,
                                ijson=ijson)
 
 # integration test more than a unit test
 def test_load_signature_json():
-    email = 'foo@bar.com'
     name = 'Foo Bar'
     filename = '/tmp/foobar'
 
     minhash = (2,3,4,5,6)
-    t = OrderedDict((('email', email),
-                     ('name', name),
+    t = OrderedDict((('name', name),
                      ('filename', filename),
                      ('signatures',
                       (
@@ -88,12 +85,11 @@ def test_load_signature_json():
 def test_load_signaturesset_json_iter():
 
     t = list()
-    for email, name, filename in (('foo@foo.com', 'Foo', '/tmp/foo'),
-                                  ('bar@bar.com', 'Bar', '/tmp/bar')):
+    for name, filename in (('Foo', '/tmp/foo'),
+                           ('Bar', '/tmp/bar')):
         minhash = (2,3,4,5,6)
         t.append(OrderedDict((
             ('class', 'sourmash_signature'),
-            ('email', email),
             ('name', name),
             ('filename', filename),
             ('signatures',
@@ -117,10 +113,10 @@ def test_load_signaturesset_json_iter():
 
 def test_save_load_multisig_json():
     e1 = sourmash_lib.MinHash(n=1, ksize=20)
-    sig1 = SourmashSignature('lalala@land.org', e1)
+    sig1 = SourmashSignature(e1)
 
-    e2 = sourmash_lib.MinHash(n=1, ksize=20)
-    sig2 = SourmashSignature('lalala2@land.org', e2)
+    e2 = sourmash_lib.MinHash(n=1, ksize=25)
+    sig2 = SourmashSignature(e2)
 
     x = save_signatures_json([sig1, sig2])
     y = list(load_signatures_json(x))

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -1677,8 +1677,8 @@ def test_compare_with_abundance_1():
         E1.add_sequence('ATGGA')
         E2.add_sequence('ATGGA')
 
-        s1 = signature.SourmashSignature('', E1, filename='e1', name='e1')
-        s2 = signature.SourmashSignature('', E2, filename='e2', name='e2')
+        s1 = signature.SourmashSignature(E1, filename='e1', name='e1')
+        s2 = signature.SourmashSignature(E2, filename='e2', name='e2')
 
         signature.save_signatures([s1],
                                   open(os.path.join(location, 'e1.sig'), 'w'))
@@ -1705,8 +1705,8 @@ def test_compare_with_abundance_2():
         E1.add_sequence('ATGGA')
         E2.add_sequence('ATGGA')
 
-        s1 = signature.SourmashSignature('', E1, filename='e1', name='e1')
-        s2 = signature.SourmashSignature('', E2, filename='e2', name='e2')
+        s1 = signature.SourmashSignature(E1, filename='e1', name='e1')
+        s2 = signature.SourmashSignature(E2, filename='e2', name='e2')
 
         signature.save_signatures([s1],
                                   open(os.path.join(location, 'e1.sig'), 'w'))
@@ -1734,8 +1734,8 @@ def test_compare_with_abundance_3():
         E1.add_sequence('ATGGA')
         E2.add_sequence('ATGGA')
 
-        s1 = signature.SourmashSignature('', E1, filename='e1', name='e1')
-        s2 = signature.SourmashSignature('', E2, filename='e2', name='e2')
+        s1 = signature.SourmashSignature(E1, filename='e1', name='e1')
+        s2 = signature.SourmashSignature(E2, filename='e2', name='e2')
 
         signature.save_signatures([s1],
                                   open(os.path.join(location, 'e1.sig'), 'w'))


### PR DESCRIPTION
This is a wholesale removal of the 'email' and 'type' fields in signatures, both in the Python class and the JSON signature format.

- [x] make signatures backwards compatible by setting `e-mail = ''`

Fixes #292 #58. Also see #268.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
