### PR TITLE
[MRG] Fix segfault when using --track-abundance

### DIFF
--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -99,6 +99,9 @@ cdef class MinHash(object):
         elif scaled:
             max_hash = get_max_hash_for_scaled(scaled)
 
+        if max_hash and n:
+            raise ValueError('cannot set both n and max_hash')
+
         cdef KmerMinHash *mh = NULL
         if track_abundance:
             mh = new KmerMinAbundance(n, ksize, is_protein, seed, max_hash)

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -7,7 +7,6 @@
 #include <queue>
 #include <exception>
 #include <string>
-#include <iostream>
 
 #include "../third-party/smhasher/MurmurHash3.h"
 

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -159,22 +159,16 @@ def test_max_hash_and_scaled_error(track_abundance):
                      scaled=5)
 
 
-def test_max_hash_with_limit(track_abundance):
-    # test behavior with max_hash and a limit (not sure sensible use case...)
-    mh = MinHash(2, 4, track_abundance=track_abundance, max_hash=35)
+def test_max_hash_cannot_limit(track_abundance):
+    # make sure you can't set both max_n and max_hash.
+    with pytest.raises(ValueError):
+        mh = MinHash(2, 4, track_abundance=track_abundance, max_hash=35)
 
-    mh.add_hash(40)
-    assert mh.get_mins() == []
 
-    mh.add_hash(36)
-    assert mh.get_mins() == []
-
-    mh.add_hash(20)
-    mh.add_hash(30)
-    assert mh.get_mins() == [20, 30]
-
-    mh.add_hash(10)
-    assert mh.get_mins() == [10, 20]
+def test_scaled(track_abundance):
+    # make sure you can't set both max_n and scaled.
+    with pytest.raises(ValueError):
+        mh = MinHash(2, 4, track_abundance=track_abundance, scaled=2)
 
 
 def test_basic_dna_bad(track_abundance):
@@ -366,8 +360,8 @@ def test_mh_count_common_diff_protein(track_abundance):
 
 
 def test_mh_count_common_diff_maxhash(track_abundance):
-    a = MinHash(20, 5, False, track_abundance=track_abundance, max_hash=1)
-    b = MinHash(20, 5, True, track_abundance=track_abundance, max_hash=2)
+    a = MinHash(0, 5, False, track_abundance=track_abundance, max_hash=1)
+    b = MinHash(0, 5, True, track_abundance=track_abundance, max_hash=2)
 
     with pytest.raises(ValueError):
         a.count_common(b)
@@ -586,8 +580,8 @@ def test_mh_compare_diff_seed(track_abundance):
 
 
 def test_mh_compare_diff_max_hash(track_abundance):
-    a = MinHash(20, 5, track_abundance=track_abundance, max_hash=5)
-    b = MinHash(20, 5, track_abundance=track_abundance, max_hash=10)
+    a = MinHash(0, 5, track_abundance=track_abundance, max_hash=5)
+    b = MinHash(0, 5, track_abundance=track_abundance, max_hash=10)
 
     with pytest.raises(ValueError):
         a.compare(b)
@@ -610,8 +604,8 @@ def test_mh_concat_diff_ksize(track_abundance):
 
 
 def test_mh_concat_diff_max_hash(track_abundance):
-    a = MinHash(20, 5, track_abundance=track_abundance, max_hash=5)
-    b = MinHash(20, 5, track_abundance=track_abundance, max_hash=10)
+    a = MinHash(0, 5, track_abundance=track_abundance, max_hash=5)
+    b = MinHash(0, 5, track_abundance=track_abundance, max_hash=10)
 
     with pytest.raises(ValueError):
         a += b
@@ -746,7 +740,7 @@ def test_set_abundance():
 
 def test_reviving_minhash():
     # simulate reading a MinHash from disk
-    mh = MinHash(4294967295, 21, max_hash=184467440737095520, seed=42,
+    mh = MinHash(0, 21, max_hash=184467440737095520, seed=42,
                  track_abundance=False)
     mins = (28945103950853965, 74690756200987412, 82962372765557409,
             93503551367950366, 106923350319729608, 135116761470196737,
@@ -817,7 +811,7 @@ def test_mh_copy_and_clear(track_abundance):
 
 def test_mh_copy_and_clear_with_max_hash(track_abundance):
     # test basic creation of new, empty MinHash w/max_hash param set
-    a = MinHash(20, 10, track_abundance=track_abundance, max_hash=20)
+    a = MinHash(0, 10, track_abundance=track_abundance, max_hash=20)
     for i in range(0, 40, 2):
         a.add_hash(i)
 
@@ -835,7 +829,7 @@ def test_mh_copy_and_clear_with_max_hash(track_abundance):
 
 def test_scaled_property(track_abundance):
     scaled = 10000
-    a = MinHash(20, 10, track_abundance=track_abundance,
+    a = MinHash(0, 10, track_abundance=track_abundance,
                 max_hash=round(2**64 / scaled))
     assert a.scaled == scaled
 
@@ -854,7 +848,7 @@ def test_mh_subtract(track_abundance):
 
 
 def test_pickle_max_hash(track_abundance):
-    a = MinHash(20, 10, track_abundance=track_abundance, max_hash=20)
+    a = MinHash(0, 10, track_abundance=track_abundance, max_hash=20)
     for i in range(0, 40, 2):
         a.add_hash(i)
 
@@ -873,7 +867,7 @@ def test_pickle_max_hash(track_abundance):
 
 
 def test_pickle_scaled(track_abundance):
-    a = MinHash(20, 10, track_abundance=track_abundance, scaled=922337203685477632)
+    a = MinHash(0, 10, track_abundance=track_abundance, scaled=922337203685477632)
     for i in range(0, 40, 2):
         a.add_hash(i)
 

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -901,7 +901,6 @@ def test_minhash_abund_add():
 
 
 def test_minhash_abund_capacity_increase():
-    return
     # this targets bug #319, a segfault caused by invalidation of
     # std::vector iterators upon vector resizing.
 

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -883,3 +883,32 @@ def test_pickle_scaled(track_abundance):
     assert len(b.get_mins()) == 11
     assert a.scaled == b.scaled
     assert b.scaled != 0
+
+
+def test_minhash_abund_add():
+    # this targets part of bug #319, a segfault caused by invalidation of
+    # std::vector iterators upon vector resizing - in this case, there
+    # was also a bug in inserting into the middle of mins when scaled was set.
+
+    a = MinHash(0, 10, track_abundance=True, max_hash=5000)
+
+    n = 0
+    for i in range(10, 0, -1):
+        a.add_hash(i)
+        n += 1
+        assert len(a.get_mins()) == n
+        print(len(a.get_mins()))
+
+
+def test_minhash_abund_capacity_increase():
+    return
+    # this targets bug #319, a segfault caused by invalidation of
+    # std::vector iterators upon vector resizing.
+
+    # this should set capacity to 1000 - see KmerMinHash constructor call
+    # to 'reserve' when n > 0 for specific parameter.
+    a = MinHash(0, 10, track_abundance=True, max_hash=5000)
+
+    # 1001 is dependent on the value passed to reserve (currently 1000).
+    for i in range(1001, 0, -1):
+        a.add_hash(i)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -48,7 +48,7 @@ def test_roundtrip_empty(track_abundance):
 
 
 def test_roundtrip_max_hash(track_abundance):
-    e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance,
+    e = sourmash_lib.MinHash(n=0, ksize=20, track_abundance=track_abundance,
                              max_hash=10)
     e.add_hash(5)
     sig = SourmashSignature('titus@idyll.org', e)


### PR DESCRIPTION
This fixes #319, as well as an associated bug when inserting new hashes into the middle of the sketch. #319 was a segfault caused by invalidation of iterators when increasing the capacity of a vector.

Two new tests were added targeting both bugs; see the bottom of `test__minhash.py`.

As part of this PR, I altered the behavior to no longer allow bounded sketches with `max_hash` or `scaled`, and adjusted tests to match. Only one explicit test existed for this behavior and the note on the test said `not sure sensible use case...` so I don't feel guilty about this.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
