### PR TITLE
[MRG] plot a random subsample with 'sourmash plot --subsample'.

### DIFF
--- a/doc/command-line.rst
+++ b/doc/command-line.rst
@@ -112,6 +112,8 @@ Options::
   --indices -- turn off index display on the plot.
   --vmax -- maximum value (default 1.0) for heatmap.
   --vmin -- minimum value (deafult 0.0) for heatmap.
+  --subsample=<N> -- plot a maximum of <N> samples, randomly chosen.
+  --subsample-seed=<seed> -- seed for pseudorandom number generator.
 
 Example figures:
 

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -469,7 +469,7 @@ def plot(args):
 
     # subsample?
     if args.subsample:
-        random.seed(args.subsample_seed)
+        random.seed(args.subsample_seed, version=1)
         sample_idx = list(range(len(labeltext)))
         random.shuffle(sample_idx)        # shuffle sample indices
         sample_idx = sample_idx[:args.subsample] # select --subsample n

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -469,7 +469,11 @@ def plot(args):
 
     # subsample?
     if args.subsample:
-        random.seed(args.subsample_seed, version=1)
+        try:                              # for py3, use py2-compatible seed.
+            random.seed(args.subsample_seed, version=1)
+        except TypeError:
+            random.seed(args.subsample_seed)
+
         sample_idx = list(range(len(labeltext)))
         random.shuffle(sample_idx)        # shuffle sample indices
         sample_idx = sample_idx[:args.subsample] # select --subsample n

--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -469,14 +469,11 @@ def plot(args):
 
     # subsample?
     if args.subsample:
-        try:                              # for py3, use py2-compatible seed.
-            random.seed(args.subsample_seed, version=1)
-        except TypeError:
-            random.seed(args.subsample_seed)
+        numpy.random.seed(args.subsample_seed)
 
         sample_idx = list(range(len(labeltext)))
-        random.shuffle(sample_idx)        # shuffle sample indices
-        sample_idx = sample_idx[:args.subsample] # select --subsample n
+        numpy.random.shuffle(sample_idx)
+        sample_idx = sample_idx[:args.subsample]
 
         np_idx = numpy.array(sample_idx)
         D = D[numpy.ix_(np_idx, np_idx)]

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -765,6 +765,58 @@ def test_do_plot_comparison_3():
         assert os.path.exists(os.path.join(location, "cmp.matrix.png"))
 
 
+def test_plot_subsample_1():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+        testdata2 = utils.get_test_data('genome-s11.fa.gz.sig')
+        testdata3 = utils.get_test_data('genome-s12.fa.gz.sig')
+        testdata4 = utils.get_test_data('genome-s10+s11.sig')
+        inp_sigs = [testdata1, testdata2, testdata3, testdata4]
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare'] + inp_sigs + \
+                                           ['-o', 'cmp', '-k', '21', '--dna'],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['plot', 'cmp',
+                                            '--subsample', '3'],
+                                           in_directory=location)
+
+        expected = """\
+0\ts10+s11
+1\tgenome-s10.fa.gz
+2\tgenome-s12.fa.gz"""
+        assert expected in out
+
+
+def test_plot_subsample_2():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+        testdata2 = utils.get_test_data('genome-s11.fa.gz.sig')
+        testdata3 = utils.get_test_data('genome-s12.fa.gz.sig')
+        testdata4 = utils.get_test_data('genome-s10+s11.sig')
+        inp_sigs = [testdata1, testdata2, testdata3, testdata4]
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare'] + inp_sigs + \
+                                           ['-o', 'cmp', '-k', '21', '--dna'],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['plot', 'cmp',
+                                            '--subsample', '3',
+                                            '--subsample-seed=2'],
+                                           in_directory=location)
+
+        print(out)
+        expected = """\
+0\tgenome-s11.fa.gz
+1\tgenome-s12.fa.gz
+2\ts10+s11"""
+        assert expected in out
+
+
 def test_search_sig_does_not_exist():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -783,9 +783,11 @@ def test_plot_subsample_1():
                                             '--subsample', '3'],
                                            in_directory=location)
 
+        print(out)
+
         expected = """\
 0\ts10+s11
-1\tgenome-s10.fa.gz
+1\tgenome-s11.fa.gz
 2\tgenome-s12.fa.gz"""
         assert expected in out
 
@@ -812,8 +814,8 @@ def test_plot_subsample_2():
         print(out)
         expected = """\
 0\tgenome-s11.fa.gz
-1\tgenome-s12.fa.gz
-2\ts10+s11"""
+1\tgenome-s10.fa.gz
+2\tgenome-s12.fa.gz"""
         assert expected in out
 
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -787,8 +787,8 @@ def test_plot_subsample_1():
 
         expected = """\
 0\ts10+s11
-1\tgenome-s11.fa.gz
-2\tgenome-s12.fa.gz"""
+1\tgenome-s12.fa.gz
+2\tgenome-s10.fa.gz"""
         assert expected in out
 
 
@@ -813,9 +813,9 @@ def test_plot_subsample_2():
 
         print(out)
         expected = """\
-0\tgenome-s11.fa.gz
-1\tgenome-s10.fa.gz
-2\tgenome-s12.fa.gz"""
+0\tgenome-s12.fa.gz
+1\ts10+s11
+2\tgenome-s11.fa.gz"""
         assert expected in out
 
 


### PR DESCRIPTION
This adds `--subsample <N>` and `--subsample-seed <R>` to `sourmash plot`, which will plot a randomly chosen subset of size N, chosen using Python's `random.shuffle`, seeded with `--subsample-seed`.  Note that the seed defaults to 1, which intentionally gives stable results when used with the same inputs.

Fixes #221.

Also fixes #334, detecting multiple ksizes/moltypes earlier.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
