### PR TITLE
[MRG] fix a segfault in the 'MinHash.similarity' code when mixing --track-abundance and flat signatures

### DIFF
--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -339,7 +339,9 @@ cdef class MinHash(object):
         See https://en.wikipedia.org/wiki/Cosine_similarity
         """
 
-        if not self.track_abundance or ignore_abundance:
+        # if either signature is flat, calculate Jaccard only.
+        if not (self.track_abundance and other.track_abundance) or \
+          ignore_abundance:
             return self.jaccard(other)
         else:
             # can we merge? if not, raise exception.

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -911,3 +911,22 @@ def test_minhash_abund_capacity_increase():
     # 1001 is dependent on the value passed to reserve (currently 1000).
     for i in range(1001, 0, -1):
         a.add_hash(i)
+
+
+def test_minhash_abund_merge_flat():
+    # this targets a segfault caused by trying to compute similarity
+    # of a signature with abundance and a signature without abundance.
+    # the correct behavior for now is to calculate simple Jaccard,
+    # i.e. 'flatten' both of them.
+    a = MinHash(0, 10, track_abundance=True, max_hash=5000)
+    b = MinHash(0, 10, max_hash=5000)
+
+    for i in range(0, 10, 2):
+        a.add_hash(i)
+
+    for j in range(0, 10, 3):
+        b.add_hash(i)
+
+    # these crashed, previously.
+    assert a.similarity(b) == 0.2
+    assert b.similarity(a) == 0.2

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -930,3 +930,21 @@ def test_minhash_abund_merge_flat():
     # these crashed, previously.
     assert a.similarity(b) == 0.2
     assert b.similarity(a) == 0.2
+
+
+def test_minhash_abund_merge_flat_2():
+    return # currently crashes.
+
+    # this targets a segfault caused by trying to merge
+    # a signature with abundance and a signature without abundance.
+
+    a = MinHash(0, 10, track_abundance=True, max_hash=5000)
+    b = MinHash(0, 10, max_hash=5000)
+
+    for i in range(0, 10, 2):
+        a.add_hash(i)
+
+    for j in range(0, 10, 3):
+        b.add_hash(i)
+
+    a.merge(b)


### PR DESCRIPTION
This is a partial bug fix for a segfault when computing `similarity` between two `MinHash` objects, one created with `track_abundance=True` and one without.  The underlying cause of the crash is in the `merge` function, discussed in #346, but this crash is reachable from the command line and moreover is getting in the way of another PR so I am fixing it first!

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
