### PR TITLE
[MRG] Cast to the proper type on merge with track_abundance

### DIFF
--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -376,7 +376,8 @@ cdef class MinHash(object):
     def __iadd__(self, MinHash other):
         cdef KmerMinAbundance *mh = <KmerMinAbundance*>address(deref(self._this))
         cdef KmerMinAbundance *other_mh = <KmerMinAbundance*>address(deref(other._this))
-        if self.track_abundance:
+
+        if self.track_abundance and other.track_abundance:
             deref(mh).merge(deref(other_mh))
         else:
             deref(self._this).merge(deref(other._this))

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -393,9 +393,9 @@ class KmerMinAbundance: public KmerMinHash {
                 ++it1_a;
             }
         }
-        /* we reached the end of mins,
-           so just copy the remainder of other.mins to the output
-           (other.mins might be empty, so this won't do anything */
+        /* we reached the end of mins/abunds,
+           so just copy the remainder of other to the output
+           (other might already be at the end, in this case nothing happens) */
         std::copy(it2_m, other.mins.end(), out_m);
         std::copy(it2_a, other.abunds.end(), out_a);
 

--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -364,27 +364,38 @@ class KmerMinAbundance: public KmerMinHash {
 
         for (; it1_m != mins.end(); ++out_m, ++out_a) {
             if (it2_m == other.mins.end()) {
+                /* we reached the end of other.mins,
+                   so just copy the remainder of mins to the output */
                 std::copy(it1_m, mins.end(), out_m);
                 std::copy(it1_a, abunds.end(), out_a);
                 break;
             }
             if (*it2_m < *it1_m) {
+                /* other.mins is smaller than mins,
+                   so copy it to output and advance other.mins iterators */
                 *out_m = *it2_m;
                 *out_a = *it2_a;
                 ++it2_m;
                 ++it2_a;
             } else if (*it2_m == *it1_m) {
+                /* same value in both mins, so sums the abundances
+                   on the output and advances all iterators */
                 *out_m = *it1_m;
                 *out_a = *it1_a + *it2_a;
                 ++it1_m; ++it1_a;
                 ++it2_m; ++it2_a;
             } else {
+                /* mins is smaller than other.mins,
+                   so copy it to output and advance the mins iterators */
                 *out_m = *it1_m;
                 *out_a = *it1_a;
                 ++it1_m;
                 ++it1_a;
             }
         }
+        /* we reached the end of mins,
+           so just copy the remainder of other.mins to the output
+           (other.mins might be empty, so this won't do anything */
         std::copy(it2_m, other.mins.end(), out_m);
         std::copy(it2_a, other.abunds.end(), out_a);
 

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -933,8 +933,6 @@ def test_minhash_abund_merge_flat():
 
 
 def test_minhash_abund_merge_flat_2():
-    return # currently crashes.
-
     # this targets a segfault caused by trying to merge
     # a signature with abundance and a signature without abundance.
 


### PR DESCRIPTION
Fixes #346 

`__iadd__` (the implementation for `merge`) was casting improperly to `KmerMinAbundance` when not tracking abundance in one of the operands, causing C++ to pick the wrong method. Just needed to check if both operands track abundance, and everything works properly.

(Fixing this was easier than expected.)

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
