### PR TITLE
[MRG] fix reporting of bad DNA ch

### DIFF
--- a/sourmash_lib/kmer_min_hash.hh
+++ b/sourmash_lib/kmer_min_hash.hh
@@ -131,7 +131,7 @@ public:
                         continue;
                     } else {
                         std::string msg = "invalid DNA character in input: ";
-                        msg += seq[i];
+                        msg += seq[i + ksize - 1];
                         throw minhash_exception(msg);
                     }
                 }

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -175,8 +175,11 @@ def test_basic_dna_bad(track_abundance):
     # test behavior on bad DNA
     mh = MinHash(1, 4, track_abundance=track_abundance)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         mh.add_sequence('ATGR')
+    print(e)
+
+    assert 'invalid DNA character in input: R' in str(e)
 
 
 def test_basic_dna_bad_2(track_abundance):


### PR DESCRIPTION
The exception raised by `MinHash.add_sequence` on bad DNA contains the wrong character.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
