### PR TITLE
select_ksize to ksize fix/issue #305

### DIFF
--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -312,7 +312,7 @@ def compare(args):
     siglist = []
     for filename in args.signatures:
         notify('loading {}', filename, end='\r')
-        loaded = sig.load_signatures(filename, select_ksize=args.ksize,
+        loaded = sig.load_signatures(filename, ksize=args.ksize,
                                      select_moltype=moltype)
         loaded = list(loaded)
         if not loaded:
@@ -508,7 +508,7 @@ def dump(args):
 
     for filename in args.filenames:
         notify('loading {}', filename)
-        siglist = sig.load_signatures(filename, select_ksize=args.ksize)
+        siglist = sig.load_signatures(filename, ksize=args.ksize)
         siglist = list(siglist)
         assert len(siglist) == 1
 
@@ -585,7 +585,7 @@ def index(args):
     ksizes = set()
     moltypes = set()
     for f in inp_files:
-        siglist = sig.load_signatures(f, select_ksize=args.ksize,
+        siglist = sig.load_signatures(f, ksize=args.ksize,
                                       select_moltype=moltype)
 
         # load all matching signatures in this file
@@ -647,7 +647,7 @@ def search(args):
 
     # set up the query.
     query = sourmash_args.load_query_signature(args.query,
-                                               select_ksize=args.ksize,
+                                               ksize=args.ksize,
                                                select_moltype=moltype)
     query_moltype = sourmash_args.get_moltype(query)
     query_ksize = query.minhash.ksize
@@ -859,7 +859,7 @@ def gather(args):
 
     # load the query signature & figure out all the things
     query = sourmash_args.load_query_signature(args.query,
-                                               select_ksize=args.ksize,
+                                               ksize=args.ksize,
                                                select_moltype=moltype)
     query_moltype = sourmash_args.get_moltype(query)
     query_ksize = query.minhash.ksize

--- a/sourmash_lib/signature.py
+++ b/sourmash_lib/signature.py
@@ -43,7 +43,7 @@ class SourmashSignature(object):
         for k in self.d:
             if self.d[k] != other.d[k]:
                 return False
-            
+
         return self.minhash == other.minhash
 
     def name(self):
@@ -163,7 +163,7 @@ def _guess_open(filename):
     return sigfile
 
 
-def load_signatures(data, select_ksize=None, select_moltype=None,
+def load_signatures(data, ksize=None, select_moltype=None,
                     ignore_md5sum=False):
     """Load a JSON string with signatures into classes.
 
@@ -171,8 +171,8 @@ def load_signatures(data, select_ksize=None, select_moltype=None,
 
     Note, the order is not necessarily the same as what is in the source file.
     """
-    if select_ksize:
-        select_ksize = int(select_ksize)
+    if ksize:
+        ksize = int(ksize)
 
     if not data:
         return
@@ -190,7 +190,7 @@ def load_signatures(data, select_ksize=None, select_moltype=None,
         # JSON format
         for sig in signature_json.load_signatures_json(data,
                                                      ignore_md5sum=ignore_md5sum):
-            if not select_ksize or select_ksize == sig.minhash.ksize:
+            if not ksize or ksize == sig.minhash.ksize:
                 if not select_moltype or \
                      sig.minhash.is_molecule_type(select_moltype):
                     yield sig
@@ -202,9 +202,9 @@ def load_signatures(data, select_ksize=None, select_moltype=None,
             data.close()
 
 
-def load_one_signature(data, select_ksize=None, select_moltype=None,
+def load_one_signature(data, ksize=None, select_moltype=None,
                        ignore_md5sum=False):
-    sigiter = load_signatures(data, select_ksize=select_ksize,
+    sigiter = load_signatures(data, ksize=ksize,
                               select_moltype=select_moltype,
                               ignore_md5sum=ignore_md5sum)
 

--- a/sourmash_lib/signature_json.py
+++ b/sourmash_lib/signature_json.py
@@ -162,10 +162,10 @@ def load_signature_json(iterable,
     return d
 
 
-def load_signatureset_json_iter(data, select_ksize=None, ignore_md5sum=False, ijson=ijson):
+def load_signatureset_json_iter(data, ksize=None, ignore_md5sum=False, ijson=ijson):
     """
     - data: file handle (or file handle-like) object
-    - select_ksize:
+    - ksize:
     - ignore_md5sum:
     - ijson: ijson backend
     """
@@ -183,7 +183,7 @@ def load_signatureset_json_iter(data, select_ksize=None, ignore_md5sum=False, ij
                                       prefix_item = 'item.signatures.item.mins.item',
                                       ignore_md5sum=ignore_md5sum,
                                       ijson=ijson)
-            if not select_ksize or select_ksize == sig.minhash.ksize:
+            if not ksize or ksize == sig.minhash.ksize:
                 yield sig
         except ValueError:
             # possible end of the array of signatures
@@ -192,10 +192,10 @@ def load_signatureset_json_iter(data, select_ksize=None, ignore_md5sum=False, ij
             break
         n += 1
 
-def load_signatures_json(data, select_ksize=None, ignore_md5sum=True, ijson=ijson):
+def load_signatures_json(data, ksize=None, ignore_md5sum=True, ijson=ijson):
     """
     - data: file handle (or file handle-like) object
-    - select_ksize:
+    - ksize:
     - ignore_md5sum:
     - ijson: ijson backend
     """
@@ -207,7 +207,7 @@ def load_signatures_json(data, select_ksize=None, ignore_md5sum=True, ijson=ijso
             data = unicode(data)
         data = io.StringIO(data)
 
-    it = load_signatureset_json_iter(data, select_ksize=select_ksize,
+    it = load_signatureset_json_iter(data, ksize=ksize,
                                      ignore_md5sum=ignore_md5sum,
                                      ijson=ijson)
 

--- a/sourmash_lib/sourmash_args.py
+++ b/sourmash_lib/sourmash_args.py
@@ -77,13 +77,13 @@ def calculate_moltype(args, default=None):
     return moltype
 
 
-def load_query_signature(filename, select_ksize, select_moltype):
+def load_query_signature(filename, ksize, select_moltype):
     sl = signature.load_signatures(filename,
-                                   select_ksize=select_ksize,
+                                   ksize=ksize,
                                    select_moltype=select_moltype)
     sl = list(sl)
 
-    if len(sl) and select_ksize is None:
+    if len(sl) and ksize is None:
         ksizes = set([ ss.minhash.ksize for ss in sl ])
         if len(ksizes) == 1:
             ksize = ksizes.pop()
@@ -92,8 +92,8 @@ def load_query_signature(filename, select_ksize, select_moltype):
         elif DEFAULT_LOAD_K in ksizes:
             sl = [ ss for ss in sl if ss.minhash.ksize == DEFAULT_LOAD_K ]
             notify('selecting default query k={}.', DEFAULT_LOAD_K)
-        elif select_ksize:
-            notify('selecting specified query k={}', select_ksize)
+        elif ksize:
+            notify('selecting specified query k={}', ksize)
 
     if len(sl) != 1:
         error('When loading query from "{}"', filename)
@@ -105,10 +105,10 @@ def load_query_signature(filename, select_ksize, select_moltype):
 
 
 class LoadSingleSignatures(object):
-    def __init__(self, filelist,  select_ksize=None, select_moltype=None,
+    def __init__(self, filelist,  ksize=None, select_moltype=None,
                  ignore_files=set()):
         self.filelist = filelist
-        self.select_ksize = select_ksize
+        self.ksize = ksize
         self.select_moltype = select_moltype
         self.ignore_files = ignore_files
 
@@ -124,7 +124,7 @@ class LoadSingleSignatures(object):
                 continue
 
             sl = signature.load_signatures(filename,
-                                           select_ksize=self.select_ksize,
+                                           ksize=self.ksize,
                                            select_moltype=self.select_moltype)
             sl = list(sl)
             if len(sl) == 0:
@@ -181,7 +181,7 @@ def load_sbts_and_sigs(filenames, query_ksize, query_moltype):
 
             try:
                 siglist = sig.load_signatures(sbt_or_sigfile,
-                                              select_ksize=query_ksize,
+                                              ksize=query_ksize,
                                               select_moltype=query_moltype)
                 siglist = list(siglist)
                 databases.append((list(siglist), sbt_or_sigfile, False))

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -47,12 +47,12 @@ def test_roundtrip(track_abundance):
     assert sig2.similarity(sig) == 1.0
 
 
-def test_load_signature_select_ksize_nonint(track_abundance):
+def test_load_signature_ksize_nonint(track_abundance):
     e = sourmash_lib.MinHash(n=1, ksize=20, track_abundance=track_abundance)
     e.add("AT" * 10)
     sig = SourmashSignature('titus@idyll.org', e)
     s = save_signatures([sig])
-    siglist = list(load_signatures(s, select_ksize='20'))
+    siglist = list(load_signatures(s, ksize='20'))
     sig2 = siglist[0]
     e2 = sig2.minhash
 


### PR DESCRIPTION
Changed all arguments of 'select_ksize' to 'ksize' in sourmash/lib. Fixes issue #305 


- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
