### PR TITLE
[MRG] fix rounding error in get_scaled_for_max_hash

### DIFF
--- a/sourmash_lib/_minhash.pyx
+++ b/sourmash_lib/_minhash.pyx
@@ -41,7 +41,7 @@ def get_max_hash_for_scaled(scaled):
 def get_scaled_for_max_hash(max_hash):
     if max_hash == 0:
         return 0
-    return int(get_minhash_max_hash() / max_hash)
+    return int(round(get_minhash_max_hash() / max_hash, 0))
 
 
 cdef bytes to_bytes(s):

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -152,6 +152,13 @@ def test_scaled(track_abundance):
     assert mh.get_mins() == [10, 20, 30]
 
 
+def test_max_hash_conversion():
+    SCALED=100000
+    max_hash = get_max_hash_for_scaled(SCALED)
+    new_scaled = get_scaled_for_max_hash(max_hash)
+    assert new_scaled == SCALED
+
+
 def test_max_hash_and_scaled_error(track_abundance):
     # test behavior when supplying both max_hash and scaled
     with pytest.raises(ValueError):


### PR DESCRIPTION
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
