### PR TITLE
Faster compare by exploiting symmetry

### DIFF
--- a/sourmash_lib/commands.py
+++ b/sourmash_lib/commands.py
@@ -376,7 +376,11 @@ def compare(args):
     labeltext = []
     for i, E in enumerate(siglist):
         for j, E2 in enumerate(siglist):
-            D[i][j] = E.similarity(E2, args.ignore_abundance)
+            if i < j:
+                continue
+            similarity = E.similarity(E2, args.ignore_abundance)
+            D[i][j] = similarity
+            D[j][i] = similarity
 
         if len(siglist) < 30:
             # for small matrices, pretty-print some output

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -36,6 +36,7 @@
 from __future__ import print_function
 from __future__ import absolute_import, unicode_literals
 
+import math
 import pickle
 
 import pytest
@@ -43,7 +44,8 @@ import pytest
 from sourmash_lib._minhash import (MinHash, hash_murmur, dotproduct,
                                    get_scaled_for_max_hash,
                                    get_max_hash_for_scaled)
-import math
+from . import sourmash_tst_utils as utils
+from sourmash_lib import signature
 
 # add:
 # * get default params from Python
@@ -949,3 +951,27 @@ def test_minhash_abund_merge_flat_2():
         b.add_hash(i)
 
     a.merge(b)
+
+
+def test_distance_matrix(track_abundance):
+    import numpy
+
+    siglist = [next(signature.load_signatures(utils.get_test_data(f)))
+               for f in utils.SIG_FILES]
+
+    D1 = numpy.zeros([len(siglist), len(siglist)])
+    D2 = numpy.zeros([len(siglist), len(siglist)])
+
+    for i, E in enumerate(siglist):
+        for j, E2 in enumerate(siglist):
+            if i < j:
+                continue
+            similarity = E.similarity(E2, track_abundance)
+            D2[i][j] = similarity
+            D2[j][i] = similarity
+
+    for i, E in enumerate(siglist):
+        for j, E2 in enumerate(siglist):
+            D1[i][j] = E.similarity(E2, track_abundance)
+
+    assert numpy.array_equal(D1, D2)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -588,6 +588,33 @@ def test_do_sourmash_check_knowngood_protein_comparisons():
         assert sig2_trans.similarity(good_trans) == 1.0
 
 
+def test_do_basic_compare():
+    import numpy
+    with utils.TempDirectory() as location:
+        testsigs = utils.get_test_data('genome-s1*.sig')
+        testsigs = glob.glob(testsigs)
+
+        args = ['compare', '-o', 'cmp', '-k', '21', '--dna'] + testsigs
+        status, out, err = utils.runscript('sourmash', args,
+                                           in_directory=location)
+
+        cmp_outfile = os.path.join(location, 'cmp')
+        assert os.path.exists(cmp_outfile)
+        cmp_out = numpy.load(cmp_outfile)
+
+        sigs = []
+        for fn in testsigs:
+            sigs.append(sourmash_lib.load_one_signature(fn, ksize=21,
+                                                        select_moltype='dna'))
+
+        cmp_calc = numpy.zeros([len(sigs), len(sigs)])
+        for i, si in enumerate(sigs):
+            for j, sj in enumerate(sigs):
+                cmp_calc[i][j] = si.similarity(sj)
+
+        assert (cmp_out == cmp_calc).all()
+
+
 def test_do_compare_quiet():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')


### PR DESCRIPTION
Fixes #358

Since the distance is symmetrical (`E1.compare(E2) == E2.compare(E1)`)
we only need to calculate the top half of the matrix and mirror it.