### PR TITLE
[MRG] Fix repair and combine errors

### DIFF
--- a/sourmash_lib/sbt.py
+++ b/sourmash_lib/sbt.py
@@ -621,14 +621,12 @@ class SBT(object):
         for level in range(1, levels + 1):
             for tree in (larger, smaller):
                 for pos in range(n_previous, n_next):
-                    if tree.nodes[pos] is not None:
+                    if tree.nodes.get(pos, None) is not None:
                         new_node = copy(tree.nodes[pos])
                         if isinstance(new_node, Node):
                             # An internal node, we need to update the name
                             new_node.name = "internal.{}".format(current_pos)
                         new_nodes[current_pos] = new_node
-                    else:
-                        del tree.nodes[pos]
                     current_pos += 1
             n_previous = n_next
             n_next = n_previous + int(self.d ** level)

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -456,7 +456,7 @@ def test_tree_repair():
                                                  to_search, 0.1)}
 
     assert results_repair == results_cur
-    assert len(results_repair) == 4
+    assert len(results_repair) == 2
 
 
 def test_tree_repair_add_node():

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -285,8 +285,8 @@ def test_sbt_combine(n_children):
 
     # check if adding a new node will use the next empty position
     next_empty = 0
-    for n, d in tree_1.nodes.items():
-        if d is None:
+    for n, d in enumerate(tree_1.nodes):
+        if n != d:
             next_empty = n
             break
     if not next_empty:


### PR DESCRIPTION
These were preventing #380 from being merged. The issue was that `max_n_below` wasn't being propagated on `repair`, and also the `combine` test was a bit too dumb and broke when I stopped depending on some defaultdict behavior.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?