### PR TITLE
[MRG] Add --force flag to 'sourmash index'

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -627,6 +627,8 @@ def index(args):
                         help='add signatures to an existing SBT.')
     parser.add_argument('-x', '--bf-size', type=float, default=1e5,
                         help='Bloom filter size used for internal nodes.')
+    parser.add_argument('-f', '--force', action='store_true',
+                        help='Try loading all files with --traverse-directory')
     parser.add_argument('-s', '--sparseness', type=float, default=.0,
                         help='What percentage of internal nodes will not be saved. '
                              'Ranges from 0.0 (save all nodes) to 1.0 (no nodes saved)')
@@ -643,7 +645,8 @@ def index(args):
         tree = create_sbt_index(args.bf_size, n_children=args.n_children)
 
     if args.traverse_directory:
-        inp_files = list(sourmash_args.traverse_find_sigs(args.signatures))
+        inp_files = list(sourmash_args.traverse_find_sigs(args.signatures,
+                                                          args.force))
     else:
         inp_files = list(args.signatures)
 

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -665,6 +665,7 @@ def index(args):
                                       select_moltype=moltype)
 
         # load all matching signatures in this file
+        ss = None
         for ss in siglist:
             ksizes.add(ss.minhash.ksize)
             moltypes.add(sourmash_args.get_moltype(ss))
@@ -674,6 +675,9 @@ def index(args):
             leaf = SigLeaf(ss.md5sum(), ss)
             tree.add_node(leaf)
             n += 1
+
+        if not ss:
+            continue
 
         # check to make sure we aren't loading incompatible signatures
         if len(ksizes) > 1 or len(moltypes) > 1:

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -151,7 +151,7 @@ class LoadSingleSignatures(object):
 
 def traverse_find_sigs(dirnames, yield_all_files=False):
     for dirname in dirnames:
-        if dirname.endswith('.sig') and os.path.isfile(dirname):
+        if (dirname.endswith('.sig') or yield_all_files) and os.path.isfile(dirname):
             yield dirname
             continue
 


### PR DESCRIPTION
This lets us do

```
sourmash index genbank-k31 ../.sbt.genbank-k31 --traverse-directory -f
```

to reindex SBTs, etc. etc.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
