### PR TITLE
[WIP] Moving functionality to C++

### DIFF
--- a/sourmash/_minhash.pxd
+++ b/sourmash/_minhash.pxd
@@ -10,11 +10,13 @@ from libcpp.set cimport set as cppset
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t, uint64_t
 from libcpp.vector cimport vector
+from libcpp.pair cimport pair
 
 
 cdef extern from "kmer_min_hash.hh":
     ctypedef uint64_t HashIntoType;
     ctypedef vector[HashIntoType] CMinHashType;
+    ctypedef pair[CMinHashType, uint64_t] IntersectionResult;
 
 
     cdef uint64_t _hash_murmur(const string, uint32_t seed)
@@ -34,6 +36,8 @@ cdef extern from "kmer_min_hash.hh":
         void add_sequence(const char *, bool) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         unsigned int count_common(const KmerMinHash&) except +ValueError
+        double compare(const KmerMinHash&) except +ValueError
+        IntersectionResult intersection(const KmerMinHash&) except +ValueError
         unsigned long size()
 
 
@@ -47,6 +51,7 @@ cdef extern from "kmer_min_hash.hh":
         void merge(const KmerMinAbundance&) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         unsigned int count_common(const KmerMinAbundance&) except +ValueError
+        double compare(const KmerMinHash&) except +ValueError
         unsigned long size()
 
 

--- a/sourmash/_minhash.pyx
+++ b/sourmash/_minhash.pyx
@@ -287,41 +287,18 @@ cdef class MinHash(object):
 
         return a
 
-    def intersection(self, MinHash other):
-        if self.num != other.num:
-            err = 'must have same num: {} != {}'.format(self.num,
-                                                            other.num)
-            raise TypeError(err)
-        else:
-            num = self.num
+    def intersection(self, MinHash other, in_common=False):
+        cdef IntersectionResult result;
+        result = deref(self._this).intersection(deref(other._this));
 
-        if self.track_abundance and other.track_abundance:
-            combined_mh = new KmerMinAbundance(num,
-                                          deref(self._this).ksize,
-                                          deref(self._this).is_protein,
-                                          deref(self._this).seed,
-                                          deref(self._this).max_hash)
+        common = set()
+        if in_common:
+            common = set(result.first)
 
-        else:
-            combined_mh = new KmerMinHash(num,
-                                          deref(self._this).ksize,
-                                          deref(self._this).is_protein,
-                                          deref(self._this).seed,
-                                          deref(self._this).max_hash)
-
-        combined_mh.merge(deref(self._this))
-        combined_mh.merge(deref(other._this))
-
-        common = set(self.get_mins())
-        common.intersection_update(other.get_mins())
-        common.intersection_update(combined_mh.mins)
-
-        return common, max(combined_mh.size(), 1)
+        return common, result.second
 
     def compare(self, MinHash other):
-        common, size = self.intersection(other)
-        n = len(common)
-        return n / size
+        return deref(self._this).compare(deref(other._this));
 
     def jaccard(self, MinHash other):
         return self.compare(other)

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -954,7 +954,7 @@ def gather(args):
         query.minhash = query.minhash.downsample_scaled(args.scaled)
 
     # empty?
-    if not query.minhash.get_mins():
+    if not len(query.minhash):
         error('no query hashes!? exiting.')
         sys.exit(-1)
 
@@ -1033,7 +1033,7 @@ def gather(args):
     if args.output_unassigned:
         if not found:
             notify('nothing found - entire query signature unassigned.')
-        elif not query.minhash.get_mins():
+        elif not len(query.minhash):
             notify('no unassigned hashes! not saving.')
         else:
             outname = args.output_unassigned.name

--- a/sourmash/lca/command_gather.py
+++ b/sourmash/lca/command_gather.py
@@ -247,7 +247,7 @@ def gather_main(args):
             print_results('')
     # nothing found.
     else:
-        est_bp = len(query_sig.minhash.get_mins()) * query_sig.minhash.scaled
+        est_bp = len(query_sig.minhash) * query_sig.minhash.scaled
         print_results('')
         print_results('No assignment for est {} of sequence.',
                       format_bp(est_bp))

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -286,38 +286,38 @@ def test_intersection_1(track_abundance):
     common = set(a.get_mins())
     combined_size = 3
 
-    intersection, size = a.intersection(b)
+    intersection, size = a.intersection(b, in_common=True)
     assert intersection == common
     assert combined_size == size
 
-    intersection, size = b.intersection(b)
+    intersection, size = b.intersection(b, in_common=True)
     assert intersection == common
     assert combined_size == size
 
-    intersection, size = b.intersection(a)
+    intersection, size = b.intersection(a, in_common=True)
     assert intersection == common
     assert combined_size == size
 
-    intersection, size = a.intersection(a)
+    intersection, size = a.intersection(a, in_common=True)
     assert intersection == common
     assert combined_size == size
 
     # add same sequence again
     b.add_sequence('TGCCGCCCAGCA')
 
-    intersection, size = a.intersection(b)
+    intersection, size = a.intersection(b, in_common=True)
     assert intersection == common
     assert combined_size == size
 
-    intersection, size = b.intersection(b)
+    intersection, size = b.intersection(b, in_common=True)
     assert intersection == common
     assert combined_size == size
 
-    intersection, size = b.intersection(a)
+    intersection, size = b.intersection(a, in_common=True)
     assert intersection == common
     assert combined_size == size
 
-    intersection, size = a.intersection(a)
+    intersection, size = a.intersection(a, in_common=True)
     assert intersection == common
     assert combined_size == size
 
@@ -327,18 +327,18 @@ def test_intersection_1(track_abundance):
     new_in_common = set(a.get_mins()).intersection(set(b.get_mins()))
     new_combined_size = 8
 
-    intersection, size = a.intersection(b)
+    intersection, size = a.intersection(b, in_common=True)
     assert intersection == new_in_common
     assert size == new_combined_size
 
-    intersection, size = b.intersection(a)
+    intersection, size = b.intersection(a, in_common=True)
     assert intersection == new_in_common
     assert size == new_combined_size
 
-    intersection, size = a.intersection(a)
+    intersection, size = a.intersection(a, in_common=True)
     assert intersection == set(a.get_mins())
 
-    intersection, size = b.intersection(b)
+    intersection, size = b.intersection(b, in_common=True)
     assert intersection == set(b.get_mins())
 
 
@@ -430,7 +430,7 @@ def test_mh_asymmetric(track_abundance):
     assert a.count_common(b) == 10
     assert b.count_common(a) == 10
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         a.compare(b)
 
     a = a.downsample_n(10)
@@ -506,7 +506,7 @@ def test_mh_asymmetric_merge(track_abundance):
     assert len(d) == len(b)
 
     # can't compare different sizes without downsampling
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         d.compare(a)
 
     a = a.downsample_n(d.num)
@@ -542,7 +542,7 @@ def test_mh_inplace_concat_asymmetric(track_abundance):
 
     try:
         d.compare(a)
-    except TypeError as exc:
+    except ValueError as exc:
         assert 'must have same num' in str(exc)
 
     a = a.downsample_n(d.num)


### PR DESCRIPTION
Some perf improvements inspired by #424 

- Move `intersection` and `compare` to C++
- Only populate the `common` part of `intersection` if `in_common` is set (we only use it for tests...)
- use `len(minhash)` instead of `len(minhash.get_mins())` when possible
- (more to come?)

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
