### PR TITLE
Feature: hashes to reads mapping

### DIFF
--- a/sourmash/_minhash.pxd
+++ b/sourmash/_minhash.pxd
@@ -31,7 +31,7 @@ cdef extern from "kmer_min_hash.hh":
         KmerMinHash(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
         bool add_hash(HashIntoType) except +ValueError
         bool add_word(string word) except +ValueError
-        CMinHashType add_sequence(const char *, bool) except +ValueError
+        CMinHashType add_sequence(const char *, bool, bool) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         unsigned int count_common(const KmerMinHash&) except +ValueError
         unsigned long size()
@@ -43,7 +43,7 @@ cdef extern from "kmer_min_hash.hh":
         KmerMinAbundance(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
         bool add_hash(HashIntoType) except +ValueError
         bool add_word(string word) except +ValueError
-        CMinHashType add_sequence(const char *, bool) except +ValueError
+        CMinHashType add_sequence(const char *, bool, bool) except +ValueError
         void merge(const KmerMinAbundance&) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         unsigned int count_common(const KmerMinAbundance&) except +ValueError

--- a/sourmash/_minhash.pxd
+++ b/sourmash/_minhash.pxd
@@ -29,9 +29,9 @@ cdef extern from "kmer_min_hash.hh":
         CMinHashType mins;
 
         KmerMinHash(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
-        void add_hash(HashIntoType) except +ValueError
-        void add_word(string word) except +ValueError
-        void add_sequence(const char *, bool) except +ValueError
+        bool add_hash(HashIntoType) except +ValueError
+        bool add_word(string word) except +ValueError
+        CMinHashType add_sequence(const char *, bool) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         unsigned int count_common(const KmerMinHash&) except +ValueError
         unsigned long size()
@@ -41,9 +41,9 @@ cdef extern from "kmer_min_hash.hh":
         CMinHashType abunds;
 
         KmerMinAbundance(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
-        void add_hash(HashIntoType) except +ValueError
-        void add_word(string word) except +ValueError
-        void add_sequence(const char *, bool) except +ValueError
+        bool add_hash(HashIntoType) except +ValueError
+        bool add_word(string word) except +ValueError
+        CMinHashType add_sequence(const char *, bool) except +ValueError
         void merge(const KmerMinAbundance&) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         unsigned int count_common(const KmerMinAbundance&) except +ValueError

--- a/sourmash/_minhash.pyx
+++ b/sourmash/_minhash.pyx
@@ -176,6 +176,7 @@ cdef class MinHash(object):
 
     def add_sequence(self, sequence, bool force=False):
         deref(self._this).add_sequence(to_bytes(sequence), force)
+        return []
 
     def add(self, kmer):
         "Add kmer into sketch."

--- a/sourmash/_minhash.pyx
+++ b/sourmash/_minhash.pyx
@@ -174,8 +174,10 @@ cdef class MinHash(object):
                     deref(self._this).seed, deref(self._this).max_hash)
         return a
 
-    def add_sequence(self, sequence, bool force=False):
-        return deref(self._this).add_sequence(to_bytes(sequence), force)
+    def add_sequence(self, sequence, bool force=False, bool output_added=False):
+        added = deref(self._this).add_sequence(to_bytes(sequence), force, output_added)
+        if output_added:
+            return added
 
     def add(self, kmer):
         "Add kmer into sketch."

--- a/sourmash/_minhash.pyx
+++ b/sourmash/_minhash.pyx
@@ -175,8 +175,7 @@ cdef class MinHash(object):
         return a
 
     def add_sequence(self, sequence, bool force=False):
-        deref(self._this).add_sequence(to_bytes(sequence), force)
-        return []
+        return deref(self._this).add_sequence(to_bytes(sequence), force)
 
     def add(self, kmer):
         "Add kmer into sketch."

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -199,7 +199,7 @@ def compute(args):
             if input_is_protein:
                 E.add_protein(seq)
             else:
-                added = E.add_sequence(seq, not check_sequence)
+                added = E.add_sequence(seq, not check_sequence, output_added=True)
                 if args.hash_to_reads:
                     for h in added:
                         reads[h].append((record.name, filename))

--- a/sourmash/kmer_min_hash.hh
+++ b/sourmash/kmer_min_hash.hh
@@ -124,7 +124,7 @@ public:
         }
         return 0;
     }
-    std::vector<HashIntoType> add_sequence(const char * sequence, bool force=false) {
+    std::vector<HashIntoType> add_sequence(const char * sequence, bool force=false, bool output_added=false) {
         std::vector<HashIntoType> added;
         if (strlen(sequence) < ksize) {
             return added;
@@ -151,7 +151,7 @@ public:
                 } else {
                     h = add_word(rc);
                 }
-                if (h) {
+                if (h and output_added) {
                     added.push_back(h);
                 }
             }
@@ -166,7 +166,7 @@ public:
                 for (unsigned int j = 0; j < aa.length() - aa_ksize + 1; j++) {
                     kmer = aa.substr(j, aa_ksize);
                     h = add_word(kmer);
-                    if (h) {
+                    if (h and output_added) {
                         added.push_back(h);
                     }
                 }
@@ -177,7 +177,7 @@ public:
                 for (unsigned int j = 0; j < aa.length() - aa_ksize + 1; j++) {
                     kmer = aa.substr(j, aa_ksize);
                     h = add_word(kmer);
-                    if (h) {
+                    if (h and output_added) {
                         added.push_back(h);
                     }
                 }

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3227,8 +3227,8 @@ def test_do_sourmash_compute_hash_to_reads_map():
                                            ['compute', '-k', '31',
                                             '--hash-to-reads', mapfile,
                                             '-o', sigfile,
-                                            testdata1,
-                                            testdata2, testdata3],
+                                            testdata1, testdata2,
+                                            testdata3],
                                            in_directory=location)
 
         assert os.path.exists(sigfile)
@@ -3243,10 +3243,12 @@ def test_do_sourmash_compute_hash_to_reads_map():
         assert all(testdata in filesigs
                    for testdata in (testdata1, testdata2, testdata3))
 
+        hashes = set()
+        for sig in signature.load_signatures(sigfile):
+            hashes.update(sig.minhash.get_mins())
+
         # is it valid json?
         with open(mapfile, 'r') as f:
             data_map = json.load(f)
 
-#        filesigs = [sig['filename'] for sig in data_map]
-#        assert all(testdata in filesigs
-#                   for testdata in (testdata1, testdata2, testdata3))
+        assert len(hashes - set(int(k) for k in data_map.keys())) == 0


### PR DESCRIPTION
During a discussion today with @brooksph and @taylorreiter we figured out it would be useful to have a mapping from hashes back to the reads where they came from. This solution is a pretty dumb one: save an extra file when computing signatures, and then use it to figure out downstream if needed.

Since this might get pretty big, it is not enabled by default.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
