### PR TITLE
Fix min_n_below calculation

### DIFF
--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -49,6 +49,7 @@ import json
 import math
 import os
 from random import randint, random
+import sys
 from tempfile import NamedTemporaryFile
 
 import khmer
@@ -578,7 +579,7 @@ class SBT(object):
             if isinstance(n, Leaf):
                 parent = self.parent(i)
                 if parent.pos not in self.missing_nodes:
-                    min_n_below = parent.node.metadata.get('min_n_below', 1)
+                    min_n_below = parent.node.metadata.get('min_n_below', sys.maxsize)
                     min_n_below = min(len(n.data.minhash.get_mins()),
                                       min_n_below)
                     parent.node.metadata['min_n_below'] = min_n_below
@@ -586,7 +587,7 @@ class SBT(object):
                     current = parent
                     parent = self.parent(parent.pos)
                     while parent and parent.pos not in self.missing_nodes:
-                        min_n_below = parent.node.metadata.get('min_n_below', 1)
+                        min_n_below = parent.node.metadata.get('min_n_below', sys.maxsize)
                         min_n_below = min(current.node.metadata['min_n_below'],
                                           min_n_below)
                         parent.node.metadata['min_n_below'] = min_n_below
@@ -744,7 +745,7 @@ class Node(object):
 
     def update(self, parent):
         parent.data.update(self.data)
-        min_n_below = min(parent.metadata.get('min_n_below', 1),
+        min_n_below = min(parent.metadata.get('min_n_below', sys.maxsize),
                           self.metadata.get('min_n_below'))
         parent.metadata['min_n_below'] = min_n_below
 

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import division
 
 from io import BytesIO, TextIOWrapper
+import sys
 
 from .sbt import Leaf, SBT, GraphFactory
 from . import signature
@@ -54,7 +55,7 @@ class SigLeaf(Leaf):
     def update(self, parent):
         for v in self.data.minhash.get_mins():
             parent.data.count(v)
-        min_n_below = parent.metadata.get('min_n_below', 1)
+        min_n_below = parent.metadata.get('min_n_below', sys.maxsize)
         min_n_below = min(len(self.data.minhash.get_mins()),
                           min_n_below)
 
@@ -100,7 +101,7 @@ def _max_jaccard_underneath_internal_node(node, hashes):
     max_score = float(matches) / min_n_below
 
     return max_score
-    
+
 
 def search_minhashes(node, sig, threshold, results=None, downsample=True):
     """\

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -15,7 +15,7 @@ from . import sourmash_tst_utils as utils
 import sourmash_lib
 from sourmash_lib import MinHash
 from sourmash_lib.sbt import SBT
-from sourmash_lib.sbtmh import SigLeaf
+from sourmash_lib.sbtmh import SigLeaf, load_sbt_index
 try:
     import matplotlib
     matplotlib.use('Agg')
@@ -1270,9 +1270,8 @@ def test_do_sourmash_sbt_search_check_bug():
                                            in_directory=location)
         assert '1 matches:' in out
 
-        with open(os.path.join(location, 'zzz.sbt.json')) as fp:
-            d = json.load(fp)
-            assert d['nodes']['0']['metadata']['min_n_below'] == 431
+        tree = load_sbt_index(os.path.join(location, 'zzz.sbt.json'))
+        assert tree.nodes[0].metadata['min_n_below'] == 431
 
 
 def test_do_sourmash_sbt_move_and_search_output():

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -640,12 +640,12 @@ def test_do_traverse_directory_compare():
     import numpy
     with utils.TempDirectory() as location:
         status, out, err = utils.runscript('sourmash',
-                                           ['compare', '--traverse-directory', 
+                                           ['compare', '--traverse-directory',
                                             '-k 21', '--dna', utils.get_test_data('compare')],
                                            in_directory=location)
         print(out)
-        assert '0-genome-s10.fa.gz' in out
-        assert '1-genome-s11.fa.gz' in out
+        assert 'genome-s10.fa.gz' in out
+        assert 'genome-s11.fa.gz' in out
 
 def test_do_compare_output_csv():
     with utils.TempDirectory() as location:

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -133,7 +133,6 @@ def test_do_sourmash_compute_output_and_name_valid_file():
         assert 'calculated 1 signatures for 4 sequences taken from 3 files' in err
 
         # is it valid json?
-        import json
         with open(sigfile, 'r') as f:
             data = json.load(f)
 
@@ -1253,7 +1252,10 @@ def test_do_sourmash_sbt_search_output():
 # calculation.
 def test_do_sourmash_sbt_search_check_bug():
     with utils.TempDirectory() as location:
+        # mins: 431
         testdata1 = utils.get_test_data('sbt-search-bug/nano.sig')
+
+        # mins: 6264
         testdata2 = utils.get_test_data('sbt-search-bug/bacteroides.sig')
 
         status, out, err = utils.runscript('sourmash',
@@ -1267,6 +1269,10 @@ def test_do_sourmash_sbt_search_check_bug():
                                            ['search', testdata1, 'zzz'],
                                            in_directory=location)
         assert '1 matches:' in out
+
+        with open(os.path.join(location, 'zzz.sbt.json')) as fp:
+            d = json.load(fp)
+            assert d['nodes']['0']['metadata']['min_n_below'] == 431
 
 
 def test_do_sourmash_sbt_move_and_search_output():
@@ -1287,7 +1293,6 @@ def test_do_sourmash_sbt_move_and_search_output():
 
         print(out)
 
-        import json
         with open(os.path.join(location, 'zzz.sbt.json')) as fp:
             d = json.load(fp)
             assert d['storage']['args']['path'] == '.sbt.zzz'


### PR DESCRIPTION
`min_n_below` was always `1` (since we were doing `min(some_number, 1)`. Fix it by doing `min(some_number, sys.maxsize)` instead.

Also fix a formatting detail in the `test_do_traverse_directory_compare` test, if files are read in a different order it won't fail the test.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
