### PR TITLE
[MRG] Fix reporting of bad characters in input by reporting entire k-mer

### DIFF
--- a/sourmash/kmer_min_hash.hh
+++ b/sourmash/kmer_min_hash.hh
@@ -132,8 +132,8 @@ public:
                     if (force) {
                         continue;
                     } else {
-                        std::string msg = "invalid DNA character in input: ";
-                        msg += seq[i + ksize - 1];
+                        std::string msg = "invalid DNA character in input k-mer: ";
+                        msg += kmer;
                         throw minhash_exception(msg);
                     }
                 }

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -197,7 +197,7 @@ def test_basic_dna_bad(track_abundance):
         mh.add_sequence('ATGR')
     print(e)
 
-    assert 'invalid DNA character in input: R' in str(e)
+    assert 'invalid DNA character in input k-mer: ATGR' in str(e)
 
 
 def test_basic_dna_bad_2(track_abundance):


### PR DESCRIPTION
Per https://github.com/dib-lab/sourmash/issues/502#issuecomment-399084320, this fixes a problem where the wrong "bad" character was being reported out from --check-sequence.

The root of the problem was an bad attempt to figure out exactly which character was causing problems. This is a conservative fix that simply reports the whole k-mer that is causing problems, which should be sufficient.

Fixes #502.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
