### PR TITLE
[MRG] PyPI fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,12 @@ sourmash is a product of the
 
 ## Installation
 
-We currently recommend installing the 2.0 pre-release series directly
-from GitHub.
-
+We currently recommend installing the 2.0 pre-release series.
 You can use pip to do that like so:
 
-    pip install https://github.com/dib-lab/sourmash/archive/master.zip
+    pip install --pre sourmash
 
-sourmash runs under both Python 2.7.x and Python 3.5.  The base
+sourmash runs under both Python 2.7.x and Python 3.5+.  The base
 requirements are screed and ijson, together with a C++ development
 environment and the CPython development headers and libraries (for the
 C++ extension).
@@ -50,9 +48,11 @@ The comparison code (`sourmash compare`) uses numpy, and the plotting
 code uses matplotlib and scipy, but most of the code is usable without
 these.
 
+For `search` and `gather` you also need `khmer` version 2.1+.
+
 ### Installation with conda
 
-Bioconda is a channel for the [conda](http://conda.pydata.org/docs/intro.html) package manager with a focus on bioinformatics software. After installing conda you will need to add the bioconda channel as well as the [other channels](https://bioconda.github.io/index.html#set-up-channels) bioconda depends on. Once you have setup bioconda, you can install  sourmash by running:
+Bioconda is a channel for the [conda](http://conda.pydata.org/docs/intro.html) package manager with a focus on bioinformatics software. After installing conda you will need to add the bioconda channel as well as the [other channels](https://bioconda.github.io/index.html#set-up-channels) bioconda depends on. Once you have setup bioconda, you can install sourmash by running:
 
 ```bash
 $ conda create -n sourmash_env sourmash python=3.6.4
@@ -85,4 +85,4 @@ Please see [the developer notes](doc/developer.md) for more information.
 ----
 
 CTB
-Feb 2018
+June 2018

--- a/doc/databases.md
+++ b/doc/databases.md
@@ -8,9 +8,9 @@ These database are formatted for use with `sourmash search` and
 Approximately 60,000 microbial genomes (including viral and fungal)
 from NCBI RefSeq.
 
-* [RefSeq k=21, 2018.02.15][0] - 7 GB
-* [RefSeq k=31, 2018.02.15][1] - 7 GB
-* [RefSeq k=51, 2018.02.15][2] - 7.1 GB
+* [RefSeq k=21, 2018.03.29][0] - 7 GB
+* [RefSeq k=31, 2018.03.29][1] - 7 GB
+* [RefSeq k=51, 2018.03.29][2] - 7.1 GB
 
 ## Genbank microbial genomes - SBT
 
@@ -20,9 +20,9 @@ These database are formatted for use with `sourmash search` and
 Approximately 100,000 microbial genomes (including viral and fungal)
 from NCBI Genbank.
 
-* [Genbank k=21, 2018.02.15][3]- 8.4 GB
-* [Genbank k=31, 2018.02.15][4] - 8.4 GB
-* [Genbank k=51, 2018.02.15][5] - 8.4 GB
+* [Genbank k=21, 2018.03.29][3]- 8.4 GB
+* [Genbank k=31, 2018.03.29][4] - 8.4 GB
+* [Genbank k=51, 2018.03.29][5] - 8.4 GB
 
 ### Details
 
@@ -30,29 +30,29 @@ The individual signatures for the above SBTs were calculated as follows:
 
 ```
 sourmash compute -k 4,5 \
-                         -n 2000 \
-                         --track-abundance \
-                         --name-from-first \
-                         -o {output} \
-                         {input}
+                 -n 2000 \
+                 --track-abundance \
+                 --name-from-first \
+                 -o {output} \
+                 {input}
 
 sourmash compute -k 21,31,51 \
-                         --scaled 2000 \
-                         --track-abundance \
-                         --name-from-first \
-                         -o {output} \
-                         {input}
+                 --scaled 2000 \
+                 --track-abundance \
+                 --name-from-first \
+                 -o {output} \
+                 {input}
 ```
 
 See https://github.com/dib-lab/sourmash_databases for a Snakemake workflow
 to build the databases.
 
-[0]: https://s3-us-west-2.amazonaws.com/sourmash-databases/refseq-d2-k21.tar.gz
-[1]: https://s3-us-west-2.amazonaws.com/sourmash-databases/refseq-d2-k31.tar.gz
-[2]: https://s3-us-west-2.amazonaws.com/sourmash-databases/refseq-d2-k51.tar.gz
-[3]: https://s3-us-west-2.amazonaws.com/sourmash-databases/genbank-d2-k21.tar.gz
-[4]: https://s3-us-west-2.amazonaws.com/sourmash-databases/genbank-d2-k31.tar.gz
-[5]: https://s3-us-west-2.amazonaws.com/sourmash-databases/genbank-d2-k51.tar.gz
+[0]: https://s3-us-west-2.amazonaws.com/sourmash-databases/2018-03-29/refseq-d2-k21.tar.gz
+[1]: https://s3-us-west-2.amazonaws.com/sourmash-databases/2018-03-29/refseq-d2-k31.tar.gz
+[2]: https://s3-us-west-2.amazonaws.com/sourmash-databases/2018-03-29/refseq-d2-k51.tar.gz
+[3]: https://s3-us-west-2.amazonaws.com/sourmash-databases/2018-03-29/genbank-d2-k21.tar.gz
+[4]: https://s3-us-west-2.amazonaws.com/sourmash-databases/2018-03-29/genbank-d2-k31.tar.gz
+[5]: https://s3-us-west-2.amazonaws.com/sourmash-databases/2018-03-29/genbank-d2-k51.tar.gz
 
 ## Genbank LCA Database
 

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,16 @@ else:                                     # ...likely Linux
    else:
       EXTRA_COMPILE_ARGS.append('-O3')
 
+with open('README.md', 'r') as readme:
+    LONG_DESCRIPTION = readme.read()
+
 SETUP_METADATA = \
                {
     "name": "sourmash",
     "version": VERSION,
     "description": "tools for comparing DNA sequences with MinHash sketches",
+    "long_description": LONG_DESCRIPTION,
+    "long_description_content_type": "text/markdown",
     "url": "https://github.com/dib-lab/sourmash",
     "author": "C. Titus Brown",
     "author_email": "titus@idyll.org",
@@ -66,7 +71,7 @@ SETUP_METADATA = \
                                extra_compile_args=EXTRA_COMPILE_ARGS,
                                extra_link_args=EXTRA_LINK_ARGS)],
     "install_requires": ["screed>=0.9", "ijson", "khmer>=2.1<3.0"],
-    "setup_requires": ['Cython>=0.25.2', "setuptools>=18.0"],
+    "setup_requires": ['Cython>=0.25.2', "setuptools>=38.6.0"],
     "extras_require": {
         'test' : ['pytest', 'pytest-cov', 'numpy', 'matplotlib', 'scipy','recommonmark'],
         'demo' : ['jupyter', 'jupyter_client', 'ipython'],


### PR DESCRIPTION
It's been some time since we uploaded releases to PyPI, and things changed:

- Warehouse was deployed, so it supports Markdown in the `long_description` field. I decided to put the `README.md` file there (which makes GitHub and PyPI look the same)
- Markdown support requires `setuptools>=38.6.0`, which is a fairly recent version. I bumped the version in `setup.py`, so this would probably also fix https://github.com/dib-lab/sourmash/issues/173
- Update README to point to pre-releases instead of installing from master
- Update DBs in docs (for 2.0.0a8)

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
