### PR TITLE
[MRG] make sourmash compatible with khmer 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ SETUP_METADATA = \
                                language="c++",
                                extra_compile_args=EXTRA_COMPILE_ARGS,
                                extra_link_args=EXTRA_LINK_ARGS)],
-    "install_requires": ["screed>=0.9", "ijson", "khmer>=2.1<3.0"],
+    "install_requires": ["screed>=0.9", "ijson", "khmer>=2.1"],
     "setup_requires": ['Cython>=0.25.2', "setuptools>=38.6.0"],
     "extras_require": {
         'test' : ['pytest', 'pytest-cov', 'numpy', 'matplotlib', 'scipy','recommonmark'],

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -54,6 +54,11 @@ from tempfile import NamedTemporaryFile
 
 import khmer
 
+try:
+    load_nodegraph = khmer.load_nodegraph
+except AttributeError:
+    load_nodegraph = khmer.Nodegraph.load
+
 from .sbt_storage import FSStorage, TarStorage, IPFSStorage, RedisStorage
 from .logging import error, notify, debug
 
@@ -785,7 +790,7 @@ class Node(object):
                 with NamedTemporaryFile(suffix=".gz") as f:
                     f.write(data)
                     f.file.flush()
-                    self._data = khmer.load_nodegraph(f.name)
+                    self._data = load_nodegraph(f.name)
         return self._data
 
     @data.setter
@@ -838,7 +843,7 @@ class Leaf(object):
             with NamedTemporaryFile(suffix=".gz") as f:
                 f.write(data)
                 f.file.flush()
-                self._data = khmer.load_nodegraph(f.name)
+                self._data = load_nodegraph(f.name)
         return self._data
 
     @data.setter


### PR DESCRIPTION
Fixes `load_nodegraph` being removed from `khmer 3`.

(Travis is testing only on khmer 2.1.1, should we put a matrix config to check on both khmer 2 and 3? My vote is no.)

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
