### PR TITLE
Fix asv benchmarks

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -1,0 +1,23 @@
+name: asv benchmarks
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install asv virtualenv
+    - name: Runs benchmarks against master
+      run: |
+        asv machine --yes
+        asv continuous origin/master

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include index.ipynb
 recursive-include sourmash_lib *
 recursive-include sourmash *
 recursive-include third-party *.cc *.h
+exclude tests/*
 global-exclude *.orig
 global-exclude *.pyc
 global-exclude *.so

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,7 +6,7 @@
     "branches": ["master"], // for git
     "dvcs": "git",
     "environment_type": "virtualenv",
-    "pythons": ["3.6"],
+    "pythons": ["3.7"],
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,8 +6,9 @@
     "branches": ["master"], // for git
     "dvcs": "git",
     "environment_type": "virtualenv",
-    "pythons": ["2.7", "3.5", "3.6"],
+    "pythons": ["3.6"],
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",
+    "build_cache_size": 8
 }

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,22 +1,25 @@
 from __future__ import unicode_literals
-
-from screed.fasta import fasta_iter
-from sourmash._minhash import MinHash
-from tests.sourmash_tst_utils import get_test_data
+import random
 
 
-def load_sequences(filepath):
+try:
+    from sourmash._minhash import MinHash
+except:
+    from sourmash.minhash import MinHash
+
+
+def load_sequences():
     sequences = []
-    with open(filepath, 'rb') as f:
-        for s in fasta_iter(f):
-            sequences.append(s['sequence'])
+    for i in range(10):
+        random_seq = random.sample("A,C,G,T".split(",") * 3000, 300)
+        sequences.append("".join(random_seq))
     return sequences
 
 
 class TimeMinHashSuite:
     def setup(self):
         self.mh = MinHash(500, 21, track_abundance=False)
-        self.sequences = load_sequences(get_test_data('ecoli.genes.fna')) * 10
+        self.sequences = load_sequences()
 
         self.populated_mh = MinHash(500, 21, track_abundance=False)
         for seq in self.sequences:
@@ -73,7 +76,7 @@ class TimeMinHashSuite:
 class PeakmemMinHashSuite:
     def setup(self):
         self.mh = MinHash(500, 21, track_abundance=True)
-        self.sequences = load_sequences(get_test_data('ecoli.genes.fna'))
+        self.sequences = load_sequences()
 
     def peakmem_add_sequence(self):
         mh = self.mh


### PR DESCRIPTION
At some point we configured `asv` to run benchmarks, but it was never integrated into CI (or had many benchmarks implemented). Working on improving the situation =]

This is a start, making `asv` run without dependencies on `tests/`. It would be better to have a fixed set of data in every run (even thought is unlikely that the random data will be extremely biased for one specific comparison in the benchmarks), but maybe do that in #128.

I also added the first github action to the repo. This way we don't extend our running time on Travis. The benchmark check is not required (for now), but it is nice to have some performance tracking that doesn't required running `asv` locally or depending on PR submitter self-reporting.

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
