### PR TITLE
[MRG] Avoid calling node.data

### DIFF
--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -93,7 +93,8 @@ def _max_jaccard_underneath_internal_node(node, hashes):
         return 0.0
 
     # count the maximum number of hash matches beneath this node
-    matches = sum(1 for value in hashes if node.data.get(value))
+    get = node.data.get
+    matches = sum(1 for value in hashes if get(value))
 
     # get the size of the smallest collection of hashes below this point
     min_n_below = node.metadata.get('min_n_below', -1)
@@ -192,7 +193,8 @@ def search_minhashes_containment(node, sig, threshold,
                 raise
 
     else:  # Node or Leaf, Nodegraph by minhash comparison
-        matches = sum(1 for value in mins if node.data.get(value))
+        get = node.data.get
+        matches = sum(1 for value in mins if get(value))
 
     if results is not None:
         results[node.name] = float(matches) / len(mins)
@@ -216,7 +218,8 @@ class SearchMinHashesFindBestIgnoreMaxHash(object):
             mh2 = sig.minhash.downsample_scaled(max_scaled)
             matches = mh1.count_common(mh2)
         else:  # Node or Leaf, Nodegraph by minhash comparison
-            matches = sum(1 for value in mins if node.data.get(value))
+            get = node.data.get
+            matches = sum(1 for value in mins if get(value))
 
         score = 0
         if not len(mins):


### PR DESCRIPTION
While doing profiling on `sourmash gather` I found out this line is where we spend almost all the runtime:
`matches = sum(1 for value in hashes if node.data.get(value))`
This makes sense, since it's the part where we check if the hashes are in the internal node Bloom Filter.

Turns out doing `node.data` takes some time, so replacing the line with
```
get = node.data.get
matches = sum(1 for value in hashes if get(value))
```
gives us ~40% reduced runtime. Yay!

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?

Ready for review and merge @ctb