### PR TITLE
[WIP] cache top node results for gather

### DIFF
--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -204,6 +204,7 @@ def search_minhashes_containment(node, sig, threshold,
     return 0
 
 
+STORE = {}
 class GatherMinHashesFindBestIgnoreMaxHash(object):
     def __init__(self, initial_best_match=0.0):
         self.best_match = initial_best_match
@@ -222,8 +223,23 @@ class GatherMinHashesFindBestIgnoreMaxHash(object):
             mh2 = sig.minhash.downsample_scaled(max_scaled)
             matches = mh1.count_common(mh2)
         else:  # Nodegraph by minhash comparison
-            get = node.data.get
-            matches = sum(1 for value in mins if get(value))
+            g = node.data.get
+            if node in STORE:
+                d = STORE.get(node)
+                matches = sum(1 for value in mins if d[value])
+            elif len(STORE) < 100:
+                d = STORE.get(node, {})
+                STORE[node] = d
+
+                matches = 0
+                for value in mins:
+                    rez = g(value)
+                    d[value] = rez
+                    if rez:
+                        matches += 1
+                    d[value] = rez
+            else:
+                matches = sum(1 for value in mins if g(value))
 
         score = float(matches) / len(mins)
 

--- a/sourmash/search.py
+++ b/sourmash/search.py
@@ -117,6 +117,7 @@ def gather_databases(query, databases, threshold_bp, ignore_abundance):
                     ctn = query.minhash.containment_ignore_maxhash(leaf_e)
                     if ctn > 0.0:
                         results.append((ctn, leaf.data))
+                        best_ctn_sofar = max(best_ctn_sofar, ctn)
 
             # search a signature
             else:
@@ -124,6 +125,7 @@ def gather_databases(query, databases, threshold_bp, ignore_abundance):
                     ctn = query.minhash.containment_ignore_maxhash(ss.minhash)
                     if ctn > 0.0:
                         results.append((ctn, ss))
+                        best_ctn_sofar = max(best_ctn_sofar, ctn)
 
         if not results:
             return None, None, None


### PR DESCRIPTION
This is a trial branch that seems to result in some speedups for gather (#519).

Here we install a results cache for the first N nodes queries in a gather. Presumably, the performance gains come from caching queries into the top nodes in the tree that have quite full bloom filters. We could maybe cache results from the top M layers in the SBT with better results, but the information about layer is not readily available to the function here.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
