### PR TITLE
[MRG] fix print_results output of compare to print out symmetric matrix

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -399,14 +399,15 @@ def compare(args):
             D[i][j] = similarity
             D[j][i] = similarity
 
-        if len(siglist) < 30:
+        labeltext.append(E.name())
+
+    if len(siglist) < 30:
+        for i, E in enumerate(siglist):
             # for small matrices, pretty-print some output
             name_num = '{}-{}'.format(i, E.name())
             if len(name_num) > 20:
                 name_num = name_num[:17] + '...'
             print_results('{:20s}\t{}'.format(name_num, D[i, :, ],))
-
-        labeltext.append(E.name())
 
     print_results('min similarity in matrix: {:.3f}', numpy.min(D))
 


### PR DESCRIPTION
fixes #535 by moving the print outside the loop, so the upper right side of the matrix gets calculated
before printout.

- [x] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
