### PR TITLE
[MRG] Fix JSON loading

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ include=
     sourmash/*.py
     sourmash_lib/*.py
 omit =
+    doc/conf.py
     setup.py
     tests/*
     third-party/smhasher/MurmurHash3.cc

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,10 @@
 [run]
-include=sourmash,sourmash_lib/*.py
-omit=setup.py,tests/test__minhash.py,tests/test_sourmash.py,tests/sourmash_tst_utils.py,third-party/smhasher/MurmurHash3.cc
+include=
+    sourmash/*.py
+    sourmash_lib/*.py
+omit =
+    setup.py
+    tests/*
+    third-party/smhasher/MurmurHash3.cc
+    .tox/*
+    benchmarks/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ branches:
   only:
   - master
   - "/^v.*$/"
+addons:
+  apt:
+    packages:
+    - libyajl2
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - pip install tox
 - sudo snap install ipfs
 script:
-- "/snap/bin/ipfs daemon --init --offline &"
+- "/snap/bin/ipfs daemon --init --offline &>/dev/null &"
 - tox -e $TOX_ENV
 before_deploy:
 - git clean -xfd

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ matrix:
     dist: xenial
     env:
     - TOX_ENV=py36
+  - os: linux
+    python: '3.7'
+    sudo: required
+    dist: xenial
+    env:
+    - TOX_ENV=py37
 install:
 - pip install tox
 - sudo snap install ipfs

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dist: FORCE
 	$(PYTHON) setup.py sdist
 
 test: all
-	pip install '.[test]'
+	pip install -e '.[test]'
 	$(PYTHON) -m pytest
 
 doc: .PHONY

--- a/doc/api-example.md
+++ b/doc/api-example.md
@@ -121,7 +121,7 @@ Here, `/tmp/genome1.sig` is a JSON file that can now be loaded and
 compared -- first, load:
 
 ```
->>> sigfp = open('/tmp/genome1.sig', 'rt')
+>>> sigfp = open('/tmp/genome1.sig', 'rb')
 >>> siglist = list(signature.load_signatures(sigfp))
 >>> loaded_sig = siglist[0]
 

--- a/sourmash/lca/command_index.py
+++ b/sourmash/lca/command_index.py
@@ -16,8 +16,12 @@ from .lca_utils import debug, set_debug, LineagePair
 
 def load_taxonomy_assignments(filename, delimiter=',', start_column=2,
                               use_headers=True, force=False):
+    mode = 'rt'
+    if sys.version_info < (3, ):
+        mode = 'rtU'
+
     # parse spreadsheet!
-    fp = open(filename, 'rtU')
+    fp = open(filename, mode)
     r = csv.reader(fp, delimiter=delimiter)
     row_headers = ['identifiers']
     row_headers += ['_skip_']*(start_column - 2)

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -44,7 +44,11 @@ then define a search function, ::
 from __future__ import print_function, unicode_literals, division
 
 from collections import namedtuple, defaultdict
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python 2...
+    from collections import Mapping
+
 from copy import copy
 import json
 import math

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -43,7 +43,8 @@ then define a search function, ::
 
 from __future__ import print_function, unicode_literals, division
 
-from collections import namedtuple, Mapping, defaultdict
+from collections import namedtuple, defaultdict
+from collections.abc import Mapping
 from copy import copy
 import json
 import math

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -69,8 +69,7 @@ class SigLeaf(Leaf):
     def data(self):
         if self._data is None:
             buf = BytesIO(self.storage.load(self._path))
-            with TextIOWrapper(buf) as data:
-                self._data = signature.load_one_signature(data)
+            self._data = signature.load_one_signature(buf)
         return self._data
 
     @data.setter

--- a/sourmash/signature.py
+++ b/sourmash/signature.py
@@ -4,12 +4,15 @@ Save and load MinHash sketches in a JSON format, along with some metadata.
 """
 from __future__ import print_function
 import hashlib
+
+import gzip
+import bz2file
+import io
+import sys
+
 from . import signature_json
 from .logging import error
 
-import io
-import gzip
-import bz2file
 
 SIGNATURE_VERSION=0.4
 
@@ -206,6 +209,11 @@ def load_signatures(data, ksize=None, select_moltype=None,
                 if do_raise:
                     raise
                 return
+    else:  # file-like
+        if hasattr(data, 'mode'):  # file handler
+            if 't' in data.mode:  # need to reopen handler as binary
+                if sys.version_info >= (3, ):
+                    data = data.buffer
 
     try:
         # JSON format

--- a/sourmash/signature_json.py
+++ b/sourmash/signature_json.py
@@ -10,7 +10,10 @@ import sys
 
 import io
 import json
-import ijson.backends.yajl2 as ijson
+try:
+    import ijson.backends.yajl2 as ijson
+except ImportError:
+    import ijson
 
 
 from . import DEFAULT_SEED, MinHash

--- a/sourmash/signature_json.py
+++ b/sourmash/signature_json.py
@@ -10,7 +10,8 @@ import sys
 
 import io
 import json
-import ijson
+import ijson.backends.yajl2 as ijson
+
 
 from . import DEFAULT_SEED, MinHash
 from .logging import notify
@@ -205,10 +206,7 @@ def load_signatures_json(data, ksize=None, ignore_md5sum=True, ijson=ijson):
     n = 0
 
     if isinstance(data, str):
-        # Required for compatibility with Python 2
-        if sys.version_info[0] < 3:
-            data = unicode(data)
-        data = io.StringIO(data)
+        data = io.BytesIO(data.encode('utf-8'))
 
     it = load_signatureset_json_iter(data, ksize=ksize,
                                      ignore_md5sum=ignore_md5sum,

--- a/sourmash/signature_json.py
+++ b/sourmash/signature_json.py
@@ -194,9 +194,13 @@ def load_signatureset_json_iter(data, ksize=None, ignore_md5sum=False, ijson=ijs
                 yield sig
         except ValueError:
             # possible end of the array of signatures
-            prefix, event, value = next(parser)
-            assert event == 'end_array'
-            break
+            try:
+                prefix, event, value = next(parser)
+                assert event == 'end_array'
+            except StopIteration:
+                pass
+            finally:
+                break
         n += 1
 
 def load_signatures_json(data, ksize=None, ignore_md5sum=True, ijson=ijson):

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,0 +1,13 @@
+from sourmash import signature
+from . import sourmash_tst_utils as utils
+
+def test_load_textmode(track_abundance):
+    # ijson requires a file in binary mode or bytes,
+    # but we had an API example in the docs using 'rt'.
+    # I fixed the docs, but I'm keeping this test here
+    # to make sure we still support it =/
+    sigfile = utils.get_test_data('genome-s10+s11.sig')
+    with open(sigfile, 'rt') as sigfp:
+        siglist = list(signature.load_signatures(sigfp))
+    loaded_sig = siglist[0]
+    assert loaded_sig.name() == 's10+s11'


### PR DESCRIPTION
This fixes #544 and add some testing improvements:

- testing with python 3.7
- clean up coverage reports
- `make test` now uses `-e` for pip (avoids reinstallation issues)

## Funny things

- `ijson` has different backends, and we always used the slower one (even with the faster ones available)
- the default one (pure Python) was throwing `DeprecationWarning` (because a generator was raising `StopIteration`, which is a [warning on 3.6 and an error in 3.7](https://www.python.org/dev/peps/pep-0479/#transition-plan)
- any of the optimized ones was throwing errors because we were passing 'text mode' files, when they were expecting 'byte mode' files
- I found a way to fix this without changing the API, but still figuring out how to avoid changing an API doctest.

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
