### PR TITLE
[WIP] Sort 10x bam file on barcodes before making signatures

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -10,6 +10,7 @@ import sys
 import random
 
 import screed
+from .sourmash_args import SourmashArgumentParser
 from . import DEFAULT_SEED, MinHash, load_sbt_index, create_sbt_index
 from . import signature as sig
 from . import sourmash_args
@@ -23,11 +24,9 @@ DEFAULT_N = 500
 WATERMARK_SIZE = 10000
 
 
-
-
 def info(args):
     "Report sourmash version + version of installed dependencies."
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser(no_citation=True)
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='report versions of khmer and screed')
     args = parser.parse_args(args)
@@ -60,7 +59,7 @@ def compute(args):
             => creates one output file file.sig, with all sequences from
                file1.fa and file2.fa combined into one signature.
     """
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('filenames', nargs='+',
                         help='file(s) of sequences')
 
@@ -112,7 +111,7 @@ def compute(args):
         sys.exit(-1)
 
     if args.input_is_protein and args.dna:
-        notify('WARNING: input is protein, turning off DNA hashing')
+        notify('WARNING: input is protein, turning off nucleotide hashing')
         args.dna = False
         args.protein = True
 
@@ -148,16 +147,16 @@ def compute(args):
 
     num_sigs = 0
     if args.dna and args.protein:
-        notify('Computing both DNA and protein signatures.')
+        notify('Computing both nucleotide and protein signatures.')
         num_sigs = 2*len(ksizes)
     elif args.dna:
-        notify('Computing only DNA (and not protein) signatures.')
+        notify('Computing only nucleotide (and not protein) signatures.')
         num_sigs = len(ksizes)
     elif args.protein:
-        notify('Computing only protein (and not DNA) signatures.')
+        notify('Computing only protein (and not nucleotide) signatures.')
         num_sigs = len(ksizes)
 
-    if args.protein:
+    if args.protein and not args.input_is_protein:
         bad_ksizes = [ str(k) for k in ksizes if k % 3 != 0 ]
         if bad_ksizes:
             error('protein ksizes must be divisible by 3, sorry!')
@@ -222,6 +221,19 @@ def compute(args):
         if barcode not in cell_seqs:
             cell_seqs[barcode] = make_minhashes()
 
+    def add_barcode_seqs(barcode, sequences, filename):
+        """Add all a barcodes' sequences to a signature
+
+        :param barcode: str
+        :param sequences: [str]
+        :return: [sig.SourmashSignature]
+        """
+        Elist = make_minhashes()
+        for sequence in sequences:
+            add_seq(Elist, sequence, args.input_is_protein,
+                    args.check_sequence)
+        return build_siglist(Elist, filename, name=barcode)
+
     def maybe_add_alignment(alignment, cell_seqs, args, barcodes):
         high_quality_mapping = alignment.mapq == 255
         good_barcode = 'CB' in alignment.tags and \
@@ -266,26 +278,18 @@ def compute(args):
                        len(siglist), n + 1, filename)
             elif args.input_is_10x:
                 import pathos.multiprocessing as mp
-                from .tenx import read_10x_folder
+                from .tenx import read_10x_folder, barcode_iterator
 
                 barcodes, bam_file = read_10x_folder(filename)
-                manager = multiprocessing.Manager()
-
-                cell_seqs = manager.dict()
 
                 notify('... reading sequences from {}', filename)
 
-                pool = mp.Pool(processes=args.processes)
-                pool.map(lambda x: maybe_add_alignment(x, cell_seqs, args, barcodes), bam_file)
-                # for n, alignment in enumerate(bam_file):
-                #     if n % 10000 == 0:
-                #         if n:
-                #             notify('\r...{} {}', filename, n, end='')
-                #     maybe_add_alignment(alignment, cell_seqs)
+                barcode_sequences = barcode_iterator(bam_file, barcodes)
 
-                cell_signatures = [
-                    build_siglist(seqs, filename=filename, name=barcode)
-                    for barcode, seqs in cell_seqs.items()]
+                pool = mp.Pool(processes=args.processes)
+                cell_signatures = pool.map(add_barcode_seqs, barcode_sequences,
+                         filename=filename)
+
                 sigs = list(itertools.chain(*cell_signatures))
                 if args.output:
                     siglist += sigs
@@ -356,7 +360,7 @@ def compare(args):
     "Compare multiple signature files and create a distance matrix."
     import numpy
 
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('signatures', nargs='+', help='list of signatures')
     parser.add_argument('-o', '--output')
     parser.add_argument('--ignore-abundance', action='store_true',
@@ -499,7 +503,7 @@ def plot(args):
     from . import fig as sourmash_fig
 
     # set up cmd line arguments
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('distances', help="output from 'sourmash compare'")
     parser.add_argument('--pdf', action='store_true',
                         help='output PDF, not PNG.')
@@ -601,7 +605,7 @@ def plot(args):
 
 def import_csv(args):
     "Import a CSV file full of signatures/hashes."
-    p = argparse.ArgumentParser()
+    p = SourmashArgumentParser()
     p.add_argument('mash_csvfile')
     p.add_argument('-o', '--output', type=argparse.FileType('wt'),
                    default=sys.stdout, help='(default: stdout)')
@@ -635,7 +639,7 @@ def import_csv(args):
 
 
 def dump(args):
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('filenames', nargs='+')
     parser.add_argument('-k', '--ksize', type=int, default=DEFAULT_LOAD_K, help='k-mer size (default: %(default)i)')
     args = parser.parse_args(args)
@@ -654,7 +658,7 @@ def dump(args):
 
 
 def sbt_combine(args):
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('sbt_name', help='name to save SBT into')
     parser.add_argument('sbts', nargs='+',
                         help='SBTs to combine to a new SBT')
@@ -683,7 +687,7 @@ def index(args):
     """
     Build an Sequence Bloom Tree index of the given signatures.
     """
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('sbt_name', help='name to save SBT into')
     parser.add_argument('signatures', nargs='+',
                         help='signatures to load into SBT')
@@ -704,7 +708,8 @@ def index(args):
     parser.add_argument('-s', '--sparseness', type=float, default=.0,
                         help='What percentage of internal nodes will not be saved. '
                              'Ranges from 0.0 (save all nodes) to 1.0 (no nodes saved)')
-
+    parser.add_argument('--scaled', type=float, default=0,
+                        help='downsample signatures to this scaled factor')
     sourmash_args.add_moltype_args(parser)
 
     args = parser.parse_args(args)
@@ -725,6 +730,10 @@ def index(args):
     if args.sparseness < 0 or args.sparseness > 1.0:
         error('sparseness must be in range [0.0, 1.0].')
 
+    if args.scaled:
+        args.scaled = int(args.scaled)
+        notify('downsampling signatures to scaled={}', args.scaled)
+
     notify('loading {} files into SBT', len(inp_files))
 
     n = 0
@@ -733,6 +742,7 @@ def index(args):
     nums = set()
     scaleds = set()
     for f in inp_files:
+        notify('\r...reading from {} ({} signatures so far)', f, n, end='')
         siglist = sig.load_signatures(f, ksize=args.ksize,
                                       select_moltype=moltype)
 
@@ -742,6 +752,9 @@ def index(args):
             ksizes.add(ss.minhash.ksize)
             moltypes.add(sourmash_args.get_moltype(ss))
             nums.add(ss.minhash.num)
+
+            if args.scaled:
+                ss.minhash = ss.minhash.downsample_scaled(args.scaled)
             scaleds.add(ss.minhash.scaled)
 
             leaf = SigLeaf(ss.md5sum(), ss)
@@ -768,6 +781,7 @@ def index(args):
             error('nums = {}; scaleds = {}', repr(nums), repr(scaleds))
             sys.exit(-1)
 
+    notify('')
 
     # did we load any!?
     if n == 0:
@@ -781,7 +795,7 @@ def index(args):
 def search(args):
     from .search import search_databases
 
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('query', help='query signature')
     parser.add_argument('databases', help='signatures/SBTs to search',
                         nargs='+')
@@ -828,14 +842,15 @@ def search(args):
             error('cannot downsample a signature not created with --scaled')
             sys.exit(-1)
 
-        notify('downsampling query from scaled={} to {}',
-               query.minhash.scaled, int(args.scaled))
+        if args.scaled != query.minhash.scaled:
+            notify('downsampling query from scaled={} to {}',
+                   query.minhash.scaled, int(args.scaled))
         query.minhash = query.minhash.downsample_scaled(args.scaled)
 
     # set up the search databases
-    databases = sourmash_args.load_sbts_and_sigs(args.databases, query,
-                                                 not args.containment,
-                                                 args.traverse_directory)
+    databases = sourmash_args.load_dbs_and_sigs(args.databases, query,
+                                                not args.containment,
+                                                args.traverse_directory)
 
     if not len(databases):
         error('Nothing found to search!')
@@ -887,7 +902,7 @@ def search(args):
 
 
 def categorize(args):
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('sbt_name', help='name of SBT to load')
     parser.add_argument('queries', nargs='+',
                         help='list of signatures to categorize')
@@ -969,7 +984,7 @@ def categorize(args):
 def gather(args):
     from .search import gather_databases, format_bp
 
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('query', help='query signature')
     parser.add_argument('databases', help='signatures/SBTs to search',
                         nargs='+')
@@ -995,7 +1010,7 @@ def gather(args):
     sourmash_args.add_moltype_args(parser)
 
     args = parser.parse_args(args)
-    set_quiet(args.quiet)
+    set_quiet(args.quiet, args.debug)
     moltype = sourmash_args.calculate_moltype(args)
 
     # load the query signature & figure out all the things
@@ -1007,7 +1022,7 @@ def gather(args):
                                              sourmash_args.get_moltype(query))
 
     # verify signature was computed right.
-    if query.minhash.max_hash == 0:
+    if query.minhash.scaled == 0:
         error('query signature needs to be created with --scaled')
         sys.exit(-1)
 
@@ -1018,12 +1033,12 @@ def gather(args):
         query.minhash = query.minhash.downsample_scaled(args.scaled)
 
     # empty?
-    if not query.minhash.get_mins():
+    if not len(query.minhash):
         error('no query hashes!? exiting.')
         sys.exit(-1)
 
     # set up the search databases
-    databases = sourmash_args.load_sbts_and_sigs(args.databases, query, False,
+    databases = sourmash_args.load_dbs_and_sigs(args.databases, query, False,
                                                  args.traverse_directory)
 
     if not len(databases):
@@ -1032,6 +1047,8 @@ def gather(args):
 
     found = []
     weighted_missed = 1
+    new_max_hash = query.minhash.max_hash
+    next_query = query
     for result, weighted_missed, new_max_hash, next_query in gather_databases(query, databases, args.threshold_bp, args.ignore_abundance):
         # print interim result & save in a list for later use
         pct_query = '{:.1f}%'.format(result.f_orig_query*100)
@@ -1075,10 +1092,7 @@ def gather(args):
            (1 - weighted_missed) * 100)
     print_results('')
 
-    if not found:
-        sys.exit(0)
-
-    if args.output:
+    if found and args.output:
         fieldnames = ['intersect_bp', 'f_orig_query', 'f_match',
                       'f_unique_to_query', 'f_unique_weighted',
                       'average_abund', 'median_abund', 'std_abund', 'name', 'filename', 'md5']
@@ -1089,15 +1103,13 @@ def gather(args):
             del d['leaf']                 # actual signature not in CSV.
             w.writerow(d)
 
-    if args.save_matches:
+    if found and args.save_matches:
         outname = args.save_matches.name
         notify('saving all matches to "{}"', outname)
         sig.save_signatures([ r.leaf for r in found ], args.save_matches)
 
     if args.output_unassigned:
-        if not found:
-            notify('nothing found - entire query signature unassigned.')
-        elif not query.minhash.get_mins():
+        if not len(query.minhash):
             notify('no unassigned hashes! not saving.')
         else:
             outname = args.output_unassigned.name
@@ -1109,10 +1121,169 @@ def gather(args):
                                 args.output_unassigned)
 
 
+def multigather(args):
+    from .search import gather_databases, format_bp
+
+    parser = SourmashArgumentParser()
+    parser.add_argument('--db', nargs='+', action='append')
+    parser.add_argument('--query', nargs='+', action='append')
+    parser.add_argument('--traverse-directory', action='store_true',
+                        help='search all signatures underneath directories.')
+    parser.add_argument('--threshold-bp', type=float, default=5e4,
+                        help='threshold (in bp) for reporting results')
+    parser.add_argument('--scaled', type=float, default=0,
+                        help='downsample query to this scaled factor')
+    parser.add_argument('-q', '--quiet', action='store_true',
+                        help='suppress non-error output')
+    parser.add_argument('--ignore-abundance',  action='store_true',
+                        help='do NOT use k-mer abundances if present')
+    parser.add_argument('-d', '--debug', action='store_true')
+
+    sourmash_args.add_ksize_arg(parser, DEFAULT_LOAD_K)
+    sourmash_args.add_moltype_args(parser)
+
+    args = parser.parse_args(args)
+    set_quiet(args.quiet)
+    moltype = sourmash_args.calculate_moltype(args)
+
+    if not args.db:
+        error('Error! must specify at least one database with --db')
+        sys.exit(-1)
+
+    if not args.query:
+        error('Error! must specify at least one query signature with --query')
+        sys.exit(-1)
+
+    # flatten --db and --query
+    args.db = [item for sublist in args.db for item in sublist]
+    args.query = [item for sublist in args.query for item in sublist]
+
+    query = sourmash_args.load_query_signature(args.query[0],
+                                               ksize=args.ksize,
+                                               select_moltype=moltype)
+    # set up the search databases
+    databases = sourmash_args.load_dbs_and_sigs(args.db, query, False,
+                                                args.traverse_directory)
+
+    if not len(databases):
+        error('Nothing found to search!')
+        sys.exit(-1)
+
+    # run gather on all the queries.
+    for queryfile in args.query:
+        # load the query signature & figure out all the things
+        query = sourmash_args.load_query_signature(queryfile,
+                                                   ksize=args.ksize,
+                                                   select_moltype=moltype)
+        notify('loaded query: {}... (k={}, {})', query.name()[:30],
+                                                 query.minhash.ksize,
+                                                 sourmash_args.get_moltype(query))
+
+        # verify signature was computed right.
+        if query.minhash.max_hash == 0:
+            error('query signature needs to be created with --scaled; skipping')
+            continue
+
+        # downsample if requested
+        if args.scaled:
+            notify('downsampling query from scaled={} to {}',
+                   query.minhash.scaled, int(args.scaled))
+            query.minhash = query.minhash.downsample_scaled(args.scaled)
+
+        # empty?
+        if not len(query.minhash):
+            error('no query hashes!? skipping to next..')
+            continue
+
+        found = []
+        weighted_missed = 1
+        for result, weighted_missed, new_max_hash, next_query in gather_databases(query, databases, args.threshold_bp, args.ignore_abundance):
+            # print interim result & save in a list for later use
+            pct_query = '{:.1f}%'.format(result.f_orig_query*100)
+            pct_genome = '{:.1f}%'.format(result.f_match*100)
+
+            name = result.leaf._display_name(40)
+
+
+            if not len(found):                # first result? print header.
+                if query.minhash.track_abundance and not args.ignore_abundance:
+                    print_results("")
+                    print_results("overlap     p_query p_match avg_abund")
+                    print_results("---------   ------- ------- ---------")
+                else:
+                    print_results("")
+                    print_results("overlap     p_query p_match")
+                    print_results("---------   ------- -------")
+
+
+            # print interim result & save in a list for later use
+            pct_query = '{:.1f}%'.format(result.f_unique_weighted*100)
+            pct_genome = '{:.1f}%'.format(result.f_match*100)
+            average_abund ='{:.1f}'.format(result.average_abund)
+            name = result.leaf._display_name(40)
+
+            if query.minhash.track_abundance and not args.ignore_abundance:
+                print_results('{:9}   {:>7} {:>7} {:>9}    {}',
+                          format_bp(result.intersect_bp), pct_query, pct_genome,
+                          average_abund, name)
+            else:
+                print_results('{:9}   {:>7} {:>7}    {}',
+                          format_bp(result.intersect_bp), pct_query, pct_genome,
+                          name)
+            found.append(result)
+
+
+        # basic reporting
+        print_results('\nfound {} matches total;', len(found))
+
+        print_results('the recovered matches hit {:.1f}% of the query',
+               (1 - weighted_missed) * 100)
+        print_results('')
+
+        if not found:
+            notify('nothing found... skipping.')
+            continue
+
+        output_base = os.path.basename(queryfile)
+        output_csv = output_base + '.csv'
+
+        fieldnames = ['intersect_bp', 'f_orig_query', 'f_match',
+                  'f_unique_to_query', 'f_unique_weighted',
+                  'average_abund', 'median_abund', 'std_abund', 'name', 'filename', 'md5']
+        with open(output_csv, 'wt') as fp:
+            w = csv.DictWriter(fp, fieldnames=fieldnames)
+            w.writeheader()
+            for result in found:
+                d = dict(result._asdict())
+                del d['leaf']                 # actual signature not in CSV.
+                w.writerow(d)
+
+        output_matches = output_base + '.matches.sig'
+        with open(output_matches, 'wt') as fp:
+            outname = output_matches
+            notify('saving all matches to "{}"', outname)
+            sig.save_signatures([ r.leaf for r in found ], fp)
+
+        output_unassigned = output_base + '.unassigned.sig'
+        with open(output_unassigned, 'wt') as fp:
+            if not found:
+                notify('nothing found - entire query signature unassigned.')
+            elif not len(query.minhash):
+                notify('no unassigned hashes! not saving.')
+            else:
+                notify('saving unassigned hashes to "{}"', output_unassigned)
+
+                e = MinHash(ksize=query.minhash.ksize, n=0, max_hash=new_max_hash)
+                e.add_many(next_query.minhash.get_mins())
+                sig.save_signatures([ sig.SourmashSignature(e) ], fp)
+
+        # fini, next query!
+
+
 def watch(args):
     "Build a signature from raw FASTA/FASTQ coming in on stdin, search."
 
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('sbt_name', help='name of SBT to search')
     parser.add_argument('inp_file', nargs='?', default='/dev/stdin')
     parser.add_argument('-q', '--quiet', action='store_true',
@@ -1134,12 +1305,12 @@ def watch(args):
     set_quiet(args.quiet)
 
     if args.input_is_protein and args.dna:
-        notify('WARNING: input is protein, turning off DNA hashing.')
+        notify('WARNING: input is protein, turning off nucleotide hashing.')
         args.dna = False
         args.protein = True
 
     if args.dna and args.protein:
-        notify('ERROR: cannot use "watch" with both DNA and protein.')
+        notify('ERROR: cannot use "watch" with both nucleotide and protein.')
 
     if args.dna:
         moltype = 'DNA'
@@ -1209,7 +1380,7 @@ def watch(args):
 def storage(args):
     from .sbt import convert_cmd
 
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('-q', '--quiet', action='store_true',
                         help='suppress non-error output')
 
@@ -1227,7 +1398,7 @@ def storage(args):
 
 
 def migrate(args):
-    parser = argparse.ArgumentParser()
+    parser = SourmashArgumentParser()
     parser.add_argument('sbt_name', help='name to save SBT into')
 
     args = parser.parse_args(args)

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -221,18 +221,20 @@ def compute(args):
         if barcode not in cell_seqs:
             cell_seqs[barcode] = make_minhashes()
 
-    def add_barcode_seqs(barcode, sequences, filename):
+    def add_barcode_seqs(barcode, sequences):
         """Add all a barcodes' sequences to a signature
 
         :param barcode: str
         :param sequences: [str]
         :return: [sig.SourmashSignature]
         """
+        from .tenx import BAM_FILENAME
+
         Elist = make_minhashes()
         for sequence in sequences:
             add_seq(Elist, sequence, args.input_is_protein,
                     args.check_sequence)
-        return build_siglist(Elist, filename, name=barcode)
+        return build_siglist(Elist, BAM_FILENAME, name=barcode)
 
     def maybe_add_alignment(alignment, cell_seqs, args, barcodes):
         high_quality_mapping = alignment.mapq == 255
@@ -287,8 +289,7 @@ def compute(args):
                 barcode_sequences = barcode_iterator(bam_file, barcodes)
 
                 pool = mp.Pool(processes=args.processes)
-                cell_signatures = pool.map(add_barcode_seqs, barcode_sequences,
-                         filename=filename)
+                cell_signatures = pool.map(add_barcode_seqs, barcode_sequences)
 
                 sigs = list(itertools.chain(*cell_signatures))
                 if args.output:

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -92,7 +92,7 @@ def compute(args):
     parser.add_argument('--rename-10x-barcodes', type=str,
                         help="Tab-separated file mapping 10x barcode name "
                              "to new name, e.g. with channel or cell "
-                             "annotation label")
+                             "annotation label", required=False)
     parser.add_argument('-p', '--processes', default=2, type=int,
                         help='Number of processes to use for reading 10x bam file')
     parser.add_argument('--track-abundance', action='store_true',
@@ -225,13 +225,15 @@ def compute(args):
         if barcode not in cell_seqs:
             cell_seqs[barcode] = make_minhashes()
 
-    def add_barcode_seqs(barcode, sequences):
+    def add_barcode_seqs(barcode_sequences):
         """Add all a barcodes' sequences to a signature
 
         :param barcode: str
         :param sequences: [str]
         :return: [sig.SourmashSignature]
         """
+        barcode, sequences = barcode_sequences
+
         from .tenx import BAM_FILENAME
 
         Elist = make_minhashes()

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -89,6 +89,10 @@ def compute(args):
                         help="name the signature generated from each file after the first record in the file (default: False)")
     parser.add_argument('--input-is-10x', action='store_true',
                         help="Input is 10x single cell output folder (default: False)")
+    parser.add_argument('--10x-barcode-renamer', type=str,
+                        help="Tab-separated file mapping 10x barcode name "
+                             "to new name, e.g. with channel or cell "
+                             "annotation label")
     parser.add_argument('-p', '--processes', default=2, type=int,
                         help='Number of processes to use for reading 10x bam file')
     parser.add_argument('--track-abundance', action='store_true',
@@ -286,7 +290,8 @@ def compute(args):
 
                 notify('... reading sequences from {}', filename)
 
-                barcode_sequences = barcode_iterator(bam_file, barcodes)
+                barcode_sequences = barcode_iterator(bam_file, barcodes,
+                                                     args['10x_barcode_renamer'])
 
                 pool = mp.Pool(processes=args.processes)
                 cell_signatures = pool.map(add_barcode_seqs, barcode_sequences)

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -89,7 +89,7 @@ def compute(args):
                         help="name the signature generated from each file after the first record in the file (default: False)")
     parser.add_argument('--input-is-10x', action='store_true',
                         help="Input is 10x single cell output folder (default: False)")
-    parser.add_argument('--10x-barcode-renamer', type=str,
+    parser.add_argument('--rename-10x-barcodes', type=str,
                         help="Tab-separated file mapping 10x barcode name "
                              "to new name, e.g. with channel or cell "
                              "annotation label")
@@ -291,7 +291,7 @@ def compute(args):
                 notify('... reading sequences from {}', filename)
 
                 barcode_sequences = barcode_iterator(bam_file, barcodes,
-                                                     args['10x_barcode_renamer'])
+                                                     args.rename_10x_barcodes)
 
                 pool = mp.Pool(processes=args.processes)
                 cell_signatures = pool.map(add_barcode_seqs, barcode_sequences)

--- a/sourmash/tenx.py
+++ b/sourmash/tenx.py
@@ -54,7 +54,7 @@ def barcode_iterator(bam, barcodes, barcode_renamer):
     """Yield a (barcode, list of str) pair for each QC-pass barcode"""
     bam_filtered = (x for x in bam if _pass_alignment_qc(x, barcodes))
 
-    renamer = _parse_barcode_renamer(barcode_renamer)
+    renamer = _parse_barcode_renamer(barcodes, barcode_renamer)
 
     # alignments only have a CELL_BARCODE tag if they past QC
     bam_sort_by_barcode = sorted(bam_filtered,

--- a/sourmash/tenx.py
+++ b/sourmash/tenx.py
@@ -42,8 +42,21 @@ def barcode_iterator(bam):
     previous_barcode = None
     barcode_alignments = []
     for alignment in bam_sort_by_barcode:
+        # Get barcode of alignment, looks like "AAATGCCCAAACTGCT-1"
         barcode = alignment.get_tag(CELL_BARCODE)
 
         # If this is a new non-null barcode, return all previous sequences
         if previous_barcode is not None and barcode != previous_barcode:
-            yield barcode_alignments
+            yield previous_barcode, barcode_alignments
+
+            # Reset the barcode alignments
+            barcode_alignments = []
+
+        # Add only the aligned sequence to this list of barcode alignments
+        barcode_alignments.append(alignment.seq)
+
+        # Set this current barcode as the previous one
+        previous_barcode = barcode
+
+    # Yield the final one
+    yield previous_barcode, barcode_alignments

--- a/sourmash/tenx.py
+++ b/sourmash/tenx.py
@@ -1,6 +1,10 @@
 import os
 
 CELL_BARCODE = 'CB'
+UMI = 'UB'
+
+BAM_FILENAME = 'possorted_genome_bam.bam'
+BARCODES_TSV = 'barcodes.tsv'
 
 
 def read_single_column(filename):
@@ -14,19 +18,18 @@ def read_10x_folder(folder):
     """Get QC-pass barcodes, genes, and bam file from a 10x folder"""
     import bamnostic as bs
 
-    barcodes = read_single_column(os.path.join(folder, 'barcodes.tsv'))
+    barcodes = read_single_column(os.path.join(folder, BARCODES_TSV))
 
-    bam_file = bs.AlignmentFile(
-        os.path.join(folder, 'possorted_genome_bam.bam'), mode='rb')
+    bam_file = bs.AlignmentFile(os.path.join(folder, BAM_FILENAME), mode='rb')
 
     return barcodes, bam_file
 
 
 def _pass_alignment_qc(alignment, barcodes):
     high_quality_mapping = alignment.mapq == 255
-    good_barcode = 'CB' in alignment.tags and \
-                   alignment.get_tag('CB') in barcodes
-    good_umi = 'UB' in alignment.tags
+    good_barcode = CELL_BARCODE in alignment.tags and \
+                   alignment.get_tag(CELL_BARCODE) in barcodes
+    good_umi = UMI in alignment.tags
 
     pass_qc = high_quality_mapping and good_barcode and \
               good_umi

--- a/sourmash/tenx.py
+++ b/sourmash/tenx.py
@@ -21,6 +21,7 @@ def read_10x_folder(folder):
 
     return barcodes, bam_file
 
+
 def _pass_alignment_qc(alignment, barcodes):
     high_quality_mapping = alignment.mapq == 255
     good_barcode = 'CB' in alignment.tags and \
@@ -32,8 +33,9 @@ def _pass_alignment_qc(alignment, barcodes):
     return pass_qc
 
 
-def barcode_iterator(bam):
-    bam_filtered = (x for x in bam if _pass_alignment_qc(x))
+def barcode_iterator(bam, barcodes):
+    """Yield a (barcode, list of str) pair for each QC-pass barcode"""
+    bam_filtered = (x for x in bam if _pass_alignment_qc(x, barcodes))
 
     # alignments only have a CELL_BARCODE tag if they past QC
     bam_sort_by_barcode = sorted(bam_filtered,

--- a/sourmash/tenx.py
+++ b/sourmash/tenx.py
@@ -1,5 +1,7 @@
 import os
 
+CELL_BARCODE = 'CB'
+
 
 def read_single_column(filename):
     """Read single-column barcodes.tsv and genes.tsv files from 10x"""
@@ -18,3 +20,30 @@ def read_10x_folder(folder):
         os.path.join(folder, 'possorted_genome_bam.bam'), mode='rb')
 
     return barcodes, bam_file
+
+def _pass_alignment_qc(alignment, barcodes):
+    high_quality_mapping = alignment.mapq == 255
+    good_barcode = 'CB' in alignment.tags and \
+                   alignment.get_tag('CB') in barcodes
+    good_umi = 'UB' in alignment.tags
+
+    pass_qc = high_quality_mapping and good_barcode and \
+              good_umi
+    return pass_qc
+
+
+def barcode_iterator(bam):
+    bam_filtered = (x for x in bam if _pass_alignment_qc(x))
+
+    # alignments only have a CELL_BARCODE tag if they past QC
+    bam_sort_by_barcode = sorted(bam_filtered,
+                                 key=lambda x: x.get_tag(CELL_BARCODE))
+
+    previous_barcode = None
+    barcode_alignments = []
+    for alignment in bam_sort_by_barcode:
+        barcode = alignment.get_tag(CELL_BARCODE)
+
+        # If this is a new non-null barcode, return all previous sequences
+        if previous_barcode is not None and barcode != previous_barcode:
+            yield barcode_alignments

--- a/tests/test_tenx.py
+++ b/tests/test_tenx.py
@@ -7,7 +7,7 @@ from sourmash.tenx import read_10x_folder, read_single_column, \
 def test_read_single_column():
     filename = utils.get_test_data('10x-example/barcodes.tsv')
     barcodes = read_single_column(filename)
-    assert len(barcodes) == 625
+    assert len(barcodes) == 10
 
 
 def test_read_10x_folder():
@@ -17,7 +17,7 @@ def test_read_10x_folder():
 
     barcodes, bam_file = read_10x_folder(tenx_folder)
 
-    assert len(barcodes) == 625
+    assert len(barcodes) == 10
     assert isinstance(bam_file, bs.AlignmentFile)
 
     total_alignments = sum(1 for _ in bam_file)

--- a/tests/test_tenx.py
+++ b/tests/test_tenx.py
@@ -11,4 +11,33 @@ def test_read_single_column():
 
 
 def test_read_10x_folder():
-    utils.get_test_data('10x-example')
+    import bamnostic as bs
+
+    tenx_folder = utils.get_test_data('10x-example')
+
+    barcodes, bam_file = read_10x_folder(tenx_folder)
+
+    assert len(barcodes) == 625
+    assert isinstance(bam_file, bs.AlignmentFile)
+
+    total_alignments = sum(1 for _ in bam_file)
+    assert total_alignments == 72140
+
+
+
+def test__pass_alignment_qc():
+    tenx_folder = utils.get_test_data('10x-example')
+
+    barcodes, bam_file = read_10x_folder(tenx_folder)
+
+    total_pass = sum(1 for alignment in bam_file if
+                     _pass_alignment_qc(alignment, barcodes))
+    assert total_pass == 0
+
+
+def test__parse_barcode_renamer():
+    pass
+
+
+def test_barcode_iterator():
+    pass

--- a/tests/test_tenx.py
+++ b/tests/test_tenx.py
@@ -1,0 +1,14 @@
+from . import sourmash_tst_utils as utils
+
+from sourmash.tenx import read_10x_folder, read_single_column, \
+    _pass_alignment_qc, _parse_barcode_renamer, barcode_iterator
+
+
+def test_read_single_column():
+    filename = utils.get_test_data('10x-example/barcodes.tsv')
+    barcodes = read_single_column(filename)
+    assert len(barcodes) == 625
+
+
+def test_read_10x_folder():
+    utils.get_test_data('10x-example')

--- a/tests/test_tenx.py
+++ b/tests/test_tenx.py
@@ -21,8 +21,7 @@ def test_read_10x_folder():
     assert isinstance(bam_file, bs.AlignmentFile)
 
     total_alignments = sum(1 for _ in bam_file)
-    assert total_alignments == 72140
-
+    assert total_alignments == 1714
 
 
 def test__pass_alignment_qc():
@@ -32,7 +31,7 @@ def test__pass_alignment_qc():
 
     total_pass = sum(1 for alignment in bam_file if
                      _pass_alignment_qc(alignment, barcodes))
-    assert total_pass == 0
+    assert total_pass == 1610
 
 
 def test__parse_barcode_renamer():


### PR DESCRIPTION
Right now, parsing 10x files takes an insane (300GiB+) amount of memory that is just unreasonable... This seems to be happening because all possible sequences for every barcode is stored in a Python list before the signatures are made. This PR flips that around - first, sort the bam alignments by barcode, then do `build_siglist` only on the sequences for each barcode.

This PR also adds the flag `--10x-barcode-renamer` so that one can change the default barcode name of `AAATGCCCAAACTGCT-1` to something more informative for viewing during `sourmash search`, e.g. `lung_endothelial_cell|tissue=Lung|channel=10X_P3_7|barcode=AAATGCCCAAACTGCT-1`

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
