### PR TITLE
[MRG] update readme for bioconda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We have demo notebooks on binder that you can interact with:
 
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/dib-lab/sourmash)
 
-Sourmash is [published on JOSS](https://doi.org/10.21105/joss.00027).
+Sourmash 1.0 is [published on JOSS](https://doi.org/10.21105/joss.00027); please cite that paper if you use sourmash (`doi: 10.21105/joss.00027`):.
 
 ----
 
@@ -26,7 +26,7 @@ combined with @ctb's love of whiskey.
 ([Sour mash](https://en.wikipedia.org/wiki/Sour_mash) is used in
 making whiskey.)
 
-Authors: [C. Titus Brown](mailto:titus@idyll.org) ([@ctb](http://github.com/ctb)) and [Luiz C. Irber, Jr](mailto:sourmash@luizirber.org) ([@luizirber](http://github.com/luizirber)).
+Primary authors: [C. Titus Brown](mailto:titus@idyll.org) ([@ctb](http://github.com/ctb)) and [Luiz C. Irber, Jr](mailto:sourmash@luizirber.org) ([@luizirber](http://github.com/luizirber)).
 
 sourmash is a product of the
 [Lab for Data-Intensive Biology](http://ivory.idyll.org/lab/) at the
@@ -34,10 +34,22 @@ sourmash is a product of the
 
 ## Installation
 
-We currently recommend installing the 2.0 pre-release series.
-You can use pip to do that like so:
+We recommend using bioconda to install sourmash:
 
-    pip install --pre sourmash
+```
+conda install sourmash
+```
+This will install the 2.0 pre-release series.
+
+You can also use pip to install the pre-release like so:
+
+```
+pip install --pre sourmash
+```
+    
+A quickstart tutorial [is available](https://sourmash.readthedocs.io/en/latest/tutorials.html).
+
+### Requirements
 
 sourmash runs under both Python 2.7.x and Python 3.5+.  The base
 requirements are screed and ijson, together with a C++ development
@@ -85,4 +97,4 @@ Please see [the developer notes](doc/developer.md) for more information.
 ----
 
 CTB
-June 2018
+Dec 2018


### PR DESCRIPTION
Update README to prefer bioconda install; see #552. This can be merged now, before the 2.0 release.

See #592 for changes to made for the sourmash 2.0 release. I think the tutorial fix should probably be done post-release.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
