### PR TITLE
[MRG] gather optimizations

### DIFF
--- a/sourmash/_minhash.pxd
+++ b/sourmash/_minhash.pxd
@@ -30,6 +30,7 @@ cdef extern from "kmer_min_hash.hh":
 
         KmerMinHash(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
         void add_hash(HashIntoType) except +ValueError
+        void remove_hash(HashIntoType) except +ValueError
         void add_word(string word) except +ValueError
         void add_sequence(const char *, bool) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
@@ -42,6 +43,7 @@ cdef extern from "kmer_min_hash.hh":
 
         KmerMinAbundance(unsigned int, unsigned int, bool, uint32_t, HashIntoType)
         void add_hash(HashIntoType) except +ValueError
+        void remove_hash(HashIntoType) except +ValueError
         void add_word(string word) except +ValueError
         void add_sequence(const char *, bool) except +ValueError
         void merge(const KmerMinAbundance&) except +ValueError

--- a/sourmash/_minhash.pyx
+++ b/sourmash/_minhash.pyx
@@ -189,6 +189,11 @@ cdef class MinHash(object):
         for hash in hashes:
             self.add_hash(hash)
 
+    def remove_many(self, hashes):
+        "Remove many hashes at once."
+        for hash in hashes:
+            deref(self._this).remove_hash(hash)
+
     def update(self, other):
         "Update this estimator from all the hashes from the other."
         self.add_many(other.get_mins())

--- a/sourmash/kmer_min_hash.hh
+++ b/sourmash/kmer_min_hash.hh
@@ -114,6 +114,14 @@ public:
         }
       }
     }
+
+    virtual void remove_hash(const HashIntoType h) {
+        auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
+        if (pos != mins.cend() and *pos == h) {
+          mins.erase(pos);
+        }
+    }
+
     void add_word(const std::string& word) {
         const HashIntoType hash = _hash_murmur(word, seed);
         add_hash(hash);
@@ -341,6 +349,15 @@ class KmerMinAbundance: public KmerMinHash {
           }
         }
       }
+    }
+
+    virtual void remove_hash(const HashIntoType h) {
+        auto pos = std::lower_bound(std::begin(mins), std::end(mins), h);
+        if (pos != mins.cend() and *pos == h) {
+          mins.erase(pos);
+          size_t dist = std::distance(begin(mins), pos);
+          abunds.erase(begin(abunds) + dist);
+        }
     }
 
     virtual void merge(const KmerMinAbundance& other) {

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -207,24 +207,29 @@ class GatherMinHashesFindBestIgnoreMaxHash(object):
     def __init__(self, initial_best_match=0.0):
         self.best_match = initial_best_match
 
-    def search(self, node, sig, threshold, results=None):
-        mins = sig.minhash.get_mins()
-
+    def search(self, node, query, threshold, results=None):
         score = 0
-        if not len(mins):
+        if not len(query.minhash):
             return 0
 
         if isinstance(node, SigLeaf):
-            max_scaled = max(node.data.minhash.scaled, sig.minhash.scaled)
+            max_scaled = max(node.data.minhash.scaled, query.minhash.scaled)
 
-            mh1 = node.data.minhash.downsample_scaled(max_scaled)
-            mh2 = sig.minhash.downsample_scaled(max_scaled)
+            mh1 = node.data.minhash
+            if mh1.scaled != max_scaled:
+                mh1 = node.data.minhash.downsample_scaled(max_scaled)
+
+            mh2 = query.minhash
+            if mh2.scaled != max_scaled:
+                mh2 = query.minhash.downsample_scaled(max_scaled)
+
             matches = mh1.count_common(mh2)
         else:  # Nodegraph by minhash comparison
+            mins = query.minhash.get_mins()
             get = node.data.get
             matches = sum(1 for value in mins if get(value))
 
-        score = float(matches) / len(mins)
+        score = float(matches) / len(query.minhash)
 
         # store results if we have passed in an appropriate dictionary
         if results is not None:

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1030,3 +1030,41 @@ def test_distance_matrix(track_abundance):
             D1[i][j] = E.similarity(E2, track_abundance)
 
     assert numpy.array_equal(D1, D2)
+
+
+def test_remove_many(track_abundance):
+    a = MinHash(0, 10, track_abundance=track_abundance, max_hash=5000)
+
+    a.add_many(list(range(0, 100, 2)))
+
+    orig_sig = signature.SourmashSignature(a)
+    orig_md5 = orig_sig.md5sum()
+
+    a.remove_many(list(range(0, 100, 3)))
+    new_sig = signature.SourmashSignature(a)
+    new_md5 = new_sig.md5sum()
+
+    assert orig_md5 == "f1cc295157374f5c07cfca5f867188a1"
+    assert new_md5 == "dd93fa319ef57f4a019c59ee1a8c73e2"
+    assert orig_md5 != new_md5
+
+    assert len(a) == 33
+    assert all(c % 6 != 0 for c in a.get_mins())
+
+
+def test_add_many(track_abundance):
+    a = MinHash(0, 10, track_abundance=track_abundance, max_hash=5000)
+    b = MinHash(0, 10, track_abundance=track_abundance, max_hash=5000)
+
+    a.add_many(list(range(0, 100, 2)))
+    a.add_many(list(range(0, 100, 2)))
+
+    assert len(a) == 50
+    assert all(c % 2 == 0 for c in a.get_mins())
+
+    for h in range(0, 100, 2):
+        b.add_hash(h)
+        b.add_hash(h)
+
+    assert len(b) == 50
+    assert a == b


### PR DESCRIPTION
A couple of fixes for gather perf problems

- don't recalculate scaled query minhash everytime we reach a leaf in the SBT
- add a `remove_many` method to remove hashes from a minhash
- use the `remove_many` method to remove matches from the query (instead of building a new one). This makes a huge difference for large queries.

I ran `master` with a large metagenome query, got 4 matches in 17h. This PR takes 17 minutes to find the same matches.

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
