### PR TITLE
Update ipfsapi dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script: tox
 install: pip install tox-travis
 
 jobs:
+  allow_failures:
+    - name: integration (ipfs/redis)
   include:
     - &check
       stage: check # do a pre-screen to make sure this is even worth testing
@@ -34,6 +36,7 @@ jobs:
       name: integration (ipfs/redis)
       before_install:
         - sudo snap install ipfs
+        - "/snap/bin/ipfs --version"
         - "/snap/bin/ipfs daemon --init --offline &>/dev/null &"
       services:
         - redis-server

--- a/sourmash/sbt_storage.py
+++ b/sourmash/sbt_storage.py
@@ -100,16 +100,16 @@ class TarStorage(Storage):
 class IPFSStorage(Storage):
 
     def __init__(self, pin_on_add=True, **kwargs):
-        import ipfsapi
+        import ipfshttpclient
         self.ipfs_args = kwargs
         self.pin_on_add = pin_on_add
-        self.api = ipfsapi.connect(**self.ipfs_args)
+        self.api = ipfshttpclient.connect(**self.ipfs_args)
 
     def save(self, path, content):
         # api.add_bytes(b"Mary had a little lamb")
         new_obj = self.api.add_bytes(content)
         if self.pin_on_add:
-            self.api.pin_add(new_obj)
+            self.api.pin.add(new_obj)
         return new_obj
 
         # TODO: the above solution is quick and dirty.

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -364,7 +364,7 @@ def test_sbt_tarstorage():
 
 
 def test_sbt_ipfsstorage():
-    ipfsapi = pytest.importorskip('ipfsapi')
+    ipfshttpclient = pytest.importorskip('ipfshttpclient')
 
     factory = GraphFactory(31, 1e5, 4)
     with utils.TempDirectory() as location:
@@ -385,7 +385,7 @@ def test_sbt_ipfsstorage():
         try:
             with IPFSStorage() as storage:
                 tree.save(os.path.join(location, 'tree'), storage=storage)
-        except ipfsapi.exceptions.ConnectionError:
+        except ipfshttpclient.exceptions.ConnectionError:
             pytest.xfail("ipfs not installed/functioning probably")
 
         with IPFSStorage() as storage:

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals=
     make
 deps=
     codecov
-    ipfsapi
+    ipfshttpclient
     redis
     bamnostic
     pathos


### PR DESCRIPTION
The Python IPFS client recently changed its name and a bit of the API.

## TODO

- [ ] `0.4.20` (the most recent go-ipfs version) is blacklisted. Need to set up 0.4.19 in travis for now

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
