### PR TITLE
Fix memory leak in `MinHash.intersection`.

### DIFF
--- a/sourmash/_minhash.pyx
+++ b/sourmash/_minhash.pyx
@@ -324,7 +324,10 @@ cdef class MinHash(object):
         common.intersection_update(other.get_mins())
         common.intersection_update(combined_mh.mins)
 
-        return common, max(combined_mh.size(), 1)
+        size = max(combined_mh.size(), 1)
+        del combined_mh
+
+        return common, size
 
     def compare(self, MinHash other):
         common, size = self.intersection(other)


### PR DESCRIPTION
The intersection function uses the `new` operator to construct
a `KmerMinHash` or `KmerMinAbundance`. Although this is Cython,
`new` still heap-allocates the object, and it is *not* marked
for garbage collection, because it isn't a PyObject. This commit
calls delete (`del`) on the allocated object to prevent it from
being leaked.

Addresses #685.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
