### PR TITLE
Fix exception assertions

### DIFF
--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -206,7 +206,7 @@ def test_no_downsample_scaled_if_n(track_abundance):
     with pytest.raises(ValueError) as excinfo:
         mh.downsample_scaled(100000000)
 
-    assert 'cannot downsample a standard MinHash' in str(excinfo)
+    assert 'cannot downsample a standard MinHash' in str(excinfo.value)
 
 
 def test_scaled(track_abundance):
@@ -223,7 +223,7 @@ def test_basic_dna_bad(track_abundance):
         mh.add_sequence('ATGR')
     print(e)
 
-    assert 'invalid DNA character in input k-mer: ATGR' in str(e)
+    assert 'invalid DNA character in input k-mer: ATGR' in str(e.value)
 
 
 def test_basic_dna_bad_2(track_abundance):

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -49,7 +49,7 @@ def test_zip_lineage_4():
     with pytest.raises(ValueError) as e:
         zip_lineage(x)
 
-    assert 'incomplete lineage at phylum - is class instead' in str(e)
+    assert 'incomplete lineage at phylum - is class instead' in str(e.value)
 
 
 def test_build_tree():


### PR DESCRIPTION
Master branch is broken because pytest 5 changed how to check for exception messages. This PR fixes the checks.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
