### PR TITLE
Fix wasm compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ needletail = { version = "~0.2.1", optional = true }
 serde = "1.0"
 serde_derive = "~1.0.58"
 serde_json = "1.0.2"
-ukhs = "0.3.4"
+ukhs = { git = "https://github.com/luizirber/ukhs", branch = "feature/alternative_backends", features = ["boomphf_mphf"], default-features = false}
 bio = { git = "https://github.com/luizirber/rust-bio", branch = "feature/fastx_reader" }
 primal = "0.2.3"
-pdatastructs = "0.5.0"
+pdatastructs = { git = "https://github.com/luizirber/pdatastructs.rs", branch = "succinct_wasm" }
 itertools = "0.8.0"
 typed-builder = "0.3.0"
 csv = "1.0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,6 @@ pub mod sketch;
 #[cfg(feature = "from-finch")]
 pub mod from;
 
-pub mod cmd;
-
 use cfg_if::cfg_if;
 use murmurhash3::murmurhash3_x64_128;
 
@@ -39,6 +37,8 @@ cfg_if! {
         pub mod wasm;
     } else {
         pub mod ffi;
+
+        pub mod cmd;
     }
 }
 

--- a/src/sketch/minhash.rs
+++ b/src/sketch/minhash.rs
@@ -497,7 +497,7 @@ impl SigsTrait for KmerMinHash {
                 for kmer in sequence.windows(self.ksize as usize) {
                     if _checkdna(kmer) {
                         let rc = revcomp(kmer);
-                        if kmer < &rc {
+                        if kmer < rc.as_slice() {
                             self.add_word(kmer);
                         } else {
                             self.add_word(&rc);

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -2,7 +2,8 @@ use wasm_bindgen::prelude::*;
 
 use serde_json;
 
-use crate::KmerMinHash;
+use crate::signature::SigsTrait;
+use crate::sketch::minhash::KmerMinHash;
 
 #[wasm_bindgen]
 impl KmerMinHash {


### PR DESCRIPTION
Main changes:
- Using forks from [pdatastructs.rs](https://github.com/luizirber/pdatastructs.rs/tree/succinct_wasm) and [succinct-rs](https://github.com/luizirber/succinct-rs/tree/wasm_fix) to fix wasm compilation (which is used in parts that are not really exposed in wasm...)
- change the UKHS code to use rust-boomhpf instead of bbhash, because bbhash-sys is C++ and therefore not compilable with the `wasm32-unknown-unknown` toolchain. Main issue here is that `rust-boomphf` is not compatible with `bbhash` (different hashes being used), so it breaks compatibility... Thinking about fixing it (eventually).

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
