### PR TITLE
[MRG] Fix --output-unassigned to output abundances if available.

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -1,3 +1,6 @@
+"""
+Functions implementing the main command-line subcommands.
+"""
 from __future__ import print_function, division, absolute_import
 
 import argparse
@@ -1130,8 +1133,15 @@ def gather(args):
             outname = args.output_unassigned.name
             notify('saving unassigned hashes to "{}"', outname)
 
-            e = MinHash(ksize=query.minhash.ksize, n=0, max_hash=new_max_hash)
-            e.add_many(next_query.minhash.get_mins())
+            with_abundance = next_query.minhash.track_abundance
+            e = MinHash(ksize=query.minhash.ksize, n=0, max_hash=new_max_hash,
+                        track_abundance=with_abundance)
+            if with_abundance:
+                abunds = next_query.minhash.get_mins(with_abundance=True)
+                e.set_abundances(abunds)
+            else:
+                e.add_many(next_query.minhash.get_mins())
+
             sig.save_signatures([ sig.SourmashSignature(e) ],
                                 args.output_unassigned)
 

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3438,6 +3438,20 @@ def test_gather_abund_10_1_ignore_abundance():
         assert 'genome-s12.fa.gz' not in out
 
 
+@utils.in_tempdir
+def test_gather_output_unassigned_with_abundance(c):
+    query = utils.get_test_data('gather-abund/reads-s10x10-s11.sig')
+    against = utils.get_test_data('gather-abund/genome-s10.fa.gz.sig')
+
+    c.run_sourmash('gather', query, against, '--output-unassigned',
+                   c.output('unassigned.sig'))
+
+    assert os.path.exists(c.output('unassigned.sig'))
+
+    ss = sourmash.load_one_signature(c.output('unassigned.sig'))
+    assert ss.minhash.track_abundance
+
+
 def test_sbt_categorize():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')


### PR DESCRIPTION
Fixes #705.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
