### PR TITLE
[MRG] Update docstring for `--traverse-directory` on `sourmash index`

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -713,7 +713,7 @@ def index(args):
     parser.add_argument('-d', '--n_children', type=int, default=2,
                         help='Number of children for internal nodes')
     parser.add_argument('--traverse-directory', action='store_true',
-                        help='load all signatures underneath this directory.')
+                        help='load all signatures underneath any directories.')
     parser.add_argument('--append', action='store_true', default=False,
                         help='add signatures to an existing SBT.')
     parser.add_argument('-x', '--bf-size', type=float, default=1e5,


### PR DESCRIPTION
Addresses #649.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
