### PR TITLE
Optimize KmerMinHash add_sequence

### DIFF
--- a/sourmash/_minhash.pxd
+++ b/sourmash/_minhash.pxd
@@ -18,7 +18,7 @@ cdef extern from "kmer_min_hash.hh":
 
 
     cdef uint64_t _hash_murmur(const string, uint32_t seed)
-
+    cdef uint64_t _hash_murmur(const char *, unsigned int, uint32_t)
 
     cdef cppclass KmerMinHash:
         const uint32_t seed;
@@ -32,8 +32,9 @@ cdef extern from "kmer_min_hash.hh":
         KmerMinHash(unsigned int, unsigned int, bool, bool, uint32_t, HashIntoType)
         void add_hash(HashIntoType) except +ValueError
         void remove_hash(HashIntoType) except +ValueError
-        void add_word(string word) except +ValueError
-        void add_sequence(const char *, bool) except +ValueError
+        void add_word(const string& word) except +ValueError
+        void add_word(const char * word) except +ValueError
+        void add_sequence(const string&, bool) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         string aa_to_dayhoff(string aa) except +ValueError
         string translate_codon(string codon) except +ValueError
@@ -48,7 +49,8 @@ cdef extern from "kmer_min_hash.hh":
         void add_hash(HashIntoType) except +ValueError
         void remove_hash(HashIntoType) except +ValueError
         void add_word(string word) except +ValueError
-        void add_sequence(const char *, bool) except +ValueError
+        void add_word(const char * word) except +ValueError
+        void add_sequence(const string&, bool) except +ValueError
         void merge(const KmerMinAbundance&) except +ValueError
         void merge(const KmerMinHash&) except +ValueError
         string aa_to_dayhoff(string aa) except +ValueError


### PR DESCRIPTION
Removes a bunch of unnecessary string copying and adds some "unsafe" methods for hashing and sanity checking which accept C-strings (`const char *`) instead of `std::string`.

Note that this makes `KmerMinHash::add_sequence` volatile: the `sequence` is no longer passed as `const`. However, the user-facing interface always makes a copy of the incoming Python `str` in the Cython layer, so this volatility is discarded.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
