### PR TITLE
Bug: save_signatures with a file opened in binary mode fails

### DIFF
--- a/sourmash/signature_json.py
+++ b/sourmash/signature_json.py
@@ -277,8 +277,11 @@ def write_records_to_json(records, fp=None, indent=None, sort_keys=True):
     if fp:
         try:
             fp.write(s)
-        except TypeError:
-            fp.write(unicode(s))
+        except TypeError:  # fp is opened in binary mode
+            try:
+                fp.write(s.encode('utf-8'))
+            except TypeError:  # Python 2
+                fp.write(unicode(s))
         return None
     return s
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -294,3 +294,13 @@ def test_load_minified(track_abundance):
         orig_file = f.read()
     assert len(minified) < len(orig_file)
     assert '\n' not in minified
+
+
+def test_binary_fp(tmpdir, track_abundance):
+    e = sourmash.MinHash(n=1, ksize=20, track_abundance=track_abundance)
+    e.add("AT" * 10)
+
+    path = tmpdir.join("1.sig")
+    with open(str(path), 'wb') as fp:
+        sig = SourmashSignature(e)
+        s = save_signatures([sig], fp)


### PR DESCRIPTION
(Yes, it's one of those days)

This will fail in Python 3:
```python
with open(output, "wb") as fp:
    sourmash.save_signatures([query], fp)
```

because there is a call to `unicode(s)` and `unicode()` doesn't exist in Python 3 anymore:

```python-traceback
Traceback (most recent call last):
  File "src/sourmash/sourmash/signature_json.py", line 279, in write_records_to_json
    fp.write(s)
TypeError: a bytes-like object is required, not 'str'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "unassigned.py", line 54, in <module>
    sourmash.save_signatures([query], fp)
  File "/home/chick/Envs/2019-10-17-unassigned_hashes-gY7Uf7Ke/src/sourmash/sourmash/signature.py", line 262, in save_signatures
    return signature_json.save_signatures_json(siglist, fp)  File "/home/chick/Envs/2019-10-17-unassigned_hashes-gY7Uf7Ke/src/sourmash/sourmash/signature_json.py", line 298, in save_signatures_json    s = write_records_to_json(records, fp, indent, sort_keys)
  File "/home/chick/Envs/2019-10-17-unassigned_hashes-gY7Uf7Ke/src/sourmash/sourmash/signature_json.py", line 281, in write_records_to_json
    fp.write(unicode(s))
NameError: name 'unicode' is not defined
```

This PR adds a test to trigger the bug, and a fix that works in Py 3/2.

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
