### PR TITLE
[MRG] add optional abundance preservation to sourmash signature intersect

### DIFF
--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -312,6 +312,8 @@ def intersect(args):
     p.add_argument('-o', '--output', type=argparse.FileType('wt'),
                    default=sys.stdout,
                    help='output signature to this file')
+    p.add_argument('-A', '--abundances-from',
+                   help='intersect with & take abundances from this signature')
     sourmash_args.add_ksize_arg(p, DEFAULT_LOAD_K)
     sourmash_args.add_moltype_args(p)
     args = p.parse_args(args)
@@ -338,11 +340,30 @@ def intersect(args):
         error("no signatures to merge!?")
         sys.exit(-1)
 
-    # forcibly turn off track_abundance
-    intersect_mh = first_sig.minhash.copy_and_clear()
-    _flatten(intersect_mh)
-    intersect_mh.add_many(mins)
-    intersect_sigobj = sourmash.SourmashSignature(intersect_mh)
+    # forcibly turn off track_abundance, unless --abundances-from set.
+    if not args.abundances_from:
+        intersect_mh = first_sig.minhash.copy_and_clear()
+        _flatten(intersect_mh)
+        intersect_mh.add_many(mins)
+        intersect_sigobj = sourmash.SourmashSignature(intersect_mh)
+    else:
+        notify('loading signature from {}, keeping abundances',
+               args.abundances_from)
+        abund_sig = sourmash.load_one_signature(args.abundances_from,
+                                                ksize=args.ksize,
+                                                select_moltype=moltype)
+        if not abund_sig.minhash.track_abundance:
+            error("--track-abundance not set on loaded signature?! exiting.")
+            sys.exit(-1)
+        intersect_mh = abund_sig.minhash.copy_and_clear()
+        abund_mins = abund_sig.minhash.get_mins(with_abundance=True)
+
+        # do one last intersection
+        mins.intersection_update(abund_mins)
+        abund_mins = { k: abund_mins[k] for k in mins }
+
+        intersect_mh.set_abundances(abund_mins)
+        intersect_sigobj = sourmash.SourmashSignature(intersect_mh)
 
     sourmash.save_signatures([intersect_sigobj], fp=args.output)
 

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -228,6 +228,81 @@ def test_sig_intersect_2(c):
 
 
 @utils.in_tempdir
+def test_sig_intersect_3(c):
+    # use --abundances-from to preserve abundances from sig #47
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('track_abund/63.fa.sig')
+    c.run_sourmash('sig', 'intersect', '--abundances-from', sig47, sig63)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    actual_intersect_sig = sourmash.load_one_signature(out)
+
+    # actually do an intersection ourselves for the test
+    mh47 = sourmash.load_one_signature(sig47).minhash
+    mh63 = sourmash.load_one_signature(sig63).minhash
+    mh47_abunds = mh47.get_mins(with_abundance=True)
+    mh63_mins = set(mh63.get_mins())
+
+    # get the set of mins that are in common
+    mh63_mins.intersection_update(mh47_abunds)
+
+    # take abundances from mh47 & create new sig
+    mh47_abunds = { k: mh47_abunds[k] for k in mh63_mins }
+    test_mh = mh47.copy_and_clear()
+    test_mh.set_abundances(mh47_abunds)
+
+    print(actual_intersect_sig.minhash)
+    print(out)
+
+    assert actual_intersect_sig.minhash == test_mh
+
+
+@utils.in_tempdir
+def test_sig_intersect_4(c):
+    # use --abundances-from to preserve abundances from sig #47
+    sig47 = utils.get_test_data('track_abund/47.fa.sig')
+    sig63 = utils.get_test_data('track_abund/63.fa.sig')
+    c.run_sourmash('sig', 'intersect', '--abundances-from', sig47, sig63)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    actual_intersect_sig = sourmash.load_one_signature(out)
+
+    # actually do an intersection ourselves for the test
+    mh47 = sourmash.load_one_signature(sig47).minhash
+    mh63 = sourmash.load_one_signature(sig63).minhash
+    mh47_abunds = mh47.get_mins(with_abundance=True)
+    mh63_mins = set(mh63.get_mins())
+
+    # get the set of mins that are in common
+    mh63_mins.intersection_update(mh47_abunds)
+
+    # take abundances from mh47 & create new sig
+    mh47_abunds = { k: mh47_abunds[k] for k in mh63_mins }
+    test_mh = mh47.copy_and_clear()
+    test_mh.set_abundances(mh47_abunds)
+
+    print(actual_intersect_sig.minhash)
+    print(out)
+
+    assert actual_intersect_sig.minhash == test_mh
+
+
+@utils.in_tempdir
+def test_sig_intersect_5(c):
+    # use --abundances-from to preserve abundances from sig #47
+    # make sure that you can't specify a flat sig for --abundances-from
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('track_abund/63.fa.sig')
+
+    with pytest.raises(ValueError):
+        c.run_sourmash('sig', 'intersect', '--abundances-from', sig47, sig63)
+
+
+@utils.in_tempdir
 def test_sig_subtract_1(c):
     # subtract of 63 from 47
     sig47 = utils.get_test_data('47.fa.sig')


### PR DESCRIPTION
This PR adds an option `--abundances-from/-A` to `sourmash signature intersect` that allows the user to specify a specific signature from which to preserve abundances in the output signature.

Ref #743.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
