### PR TITLE
Fixes for WASI compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,16 @@ jobs:
         - rustup target add wasm32-unknown-unknown
         - cargo install --force wasm-pack
         - wasm-pack build
+    - <<: *test
+      name: wasi target
+      language: rust
+      rust: stable
+      before_script: skip
+      install: skip
+      script:
+        - rustup target add wasm32-wasi
+        - cargo install --force cargo-wasi
+        - cargo wasi build
 
     - &wheel
       stage: build wheel and send to github releases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,15 +53,14 @@ itertools = "0.8.0"
 typed-builder = "0.3.0"
 csv = "1.0.7"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
+[target.'cfg(all(target_arch = "wasm32", target_vendor="unknown"))'.dependencies.wasm-bindgen]
 version = "^0.2"
 features = ["serde-serialize"]
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.ocf]
+[target.'cfg(not(all(target_arch = "wasm32", target_vendor="unknown")))'.dependencies.ocf]
 version = "0.1"
 path = "ocf"
 default-features = false
-features = ["bz2"]
 
 [dev-dependencies]
 proptest = "^0.8"

--- a/src/index/sbt/mod.rs
+++ b/src/index/sbt/mod.rs
@@ -232,7 +232,8 @@ where
         // add a function to build a Storage from a StorageInfo
         let mut basepath = PathBuf::new();
         basepath.push(path);
-        basepath.canonicalize()?;
+        // TODO: canonicalize doesn't work on wasm32-wasi
+        //basepath.canonicalize()?;
 
         let sbt =
             SBT::<Node<U>, Dataset<T>>::from_reader(&mut reader, &basepath.parent().unwrap())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use cfg_if::cfg_if;
 use murmurhash3::murmurhash3_x64_128;
 
 cfg_if! {
-    if #[cfg(target_arch = "wasm32")] {
+    if #[cfg(all(target_arch = "wasm32", target_vendor = "unknown"))] {
         pub mod wasm;
     } else {
         pub mod ffi;

--- a/src/sketch/minhash.rs
+++ b/src/sketch/minhash.rs
@@ -14,10 +14,10 @@ use crate::_hash_murmur;
 use crate::errors::SourmashError;
 use crate::signature::SigsTrait;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_vendor = "unknown"))]
 use wasm_bindgen::prelude::*;
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown"), wasm_bindgen)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct KmerMinHash {
     num: u32,


### PR DESCRIPTION
`wasm32-unknown-unknown` (the webassembly target for browsers) and `wasm32-wasi` both have the same target arch, so change the conditional compilation to account for that.

(also avoid a call to `.canonicalize()` because that's not implemented in WASI std yet...)

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
