### PR TITLE
[WIP] add signatures() method to both LCA and SBT indices

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -450,8 +450,7 @@ def index(args):
                 ss.minhash = ss.minhash.downsample_scaled(args.scaled)
             scaleds.add(ss.minhash.scaled)
 
-            leaf = SigLeaf(ss.md5sum(), ss)
-            tree.insert(leaf)
+            tree.insert(ss)
             n += 1
 
         if not ss:

--- a/sourmash/index.py
+++ b/sourmash/index.py
@@ -13,7 +13,7 @@ class Index(ABC):
         "Return an iterator over all signatures in the Index object."
 
     @abstractmethod
-    def insert(self, node):
+    def insert(self, signature):
         """ """
 
     @abstractmethod
@@ -26,6 +26,14 @@ class Index(ABC):
         """ """
 
     def find(self, search_fn, *args, **kwargs):
+        """Use search_fn to find matching signatures in the index.
+
+        search_fn(other_sig, *args) should return a boolean that indicates
+        whether other_sig is a match.
+
+        Returns a list.
+        """
+
         matches = []
 
         for node in self.signatures():

--- a/sourmash/lca/lca_utils.py
+++ b/sourmash/lca/lca_utils.py
@@ -279,7 +279,7 @@ class LCA_Database(Index):
             raise TypeError("'search' on LCA databases does not use abundance")
 
         results = []
-        for x in self.find(query.minhash, threshold, do_containment):
+        for x in self.find_signatures(query.minhash, threshold, do_containment):
             (score, match, filename) = x
             results.append((score, match, filename))
 
@@ -288,8 +288,8 @@ class LCA_Database(Index):
 
     def gather(self, query, *args, **kwargs):
         results = []
-        for x in self.find(query.minhash, 0.0,
-                           containment=True, ignore_scaled=True):
+        for x in self.find_signatures(query.minhash, 0.0,
+                                      containment=True, ignore_scaled=True):
             (score, match, filename) = x
             if score:
                 results.append((score, match, filename))
@@ -297,7 +297,10 @@ class LCA_Database(Index):
         return results
 
     def insert(self, node):
-        pass
+        raise NotImplementedError
+
+    def find(self, search_fn, *args, **kwargs):
+        raise NotImplementedError
 
     def downsample_scaled(self, scaled):
         """
@@ -350,7 +353,8 @@ class LCA_Database(Index):
 
         debug('=> {} signatures!', len(self._signatures))
 
-    def find(self, minhash, threshold, containment=False, ignore_scaled=False):
+    def find_signatures(self, minhash, threshold, containment=False,
+                       ignore_scaled=False):
         """
         Do a Jaccard similarity or containment search.
         """
@@ -400,7 +404,6 @@ class LCA_Database(Index):
             debug('score: {} (containment? {})', score, containment)
 
             if score >= threshold:
-                # reconstruct signature... ugh.
                 from .. import SourmashSignature
                 match_sig = SourmashSignature(match_mh, name=name)
 

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -165,7 +165,14 @@ class SBT(Index):
 
         return self.next_node
 
-    def insert(self, node):
+    def insert(self, signature):
+        "Add a new SourmashSignature in to the SBT."
+        from .sbtmh import SigLeaf
+        
+        leaf = SigLeaf(signature.name(), signature)
+        self.add_node(leaf)
+
+    def add_node(self, node):
         pos = self.new_node_pos(node)
 
         if pos == 0:  # empty tree; initialize w/node.
@@ -212,10 +219,6 @@ class SBT(Index):
             self._rebuild_node(p.pos)
             node.update(self._nodes[p.pos])
             p = self.parent(p.pos)
-
-    @deprecated(details="Use the insert method instead")
-    def add_node(self, node):
-        self.insert(node)
 
     def find(self, search_fn, *args, **kwargs):
         "Search the tree using `search_fn`."

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -135,7 +135,8 @@ class SBT(Index):
         self.storage = storage
 
     def signatures(self):
-        return leaves()
+        for k in self.leaves():
+            yield k.data
 
     def new_node_pos(self, node):
         if not self._nodes:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -36,11 +36,11 @@ def test_simple_index(n_children):
     leaf5.data.count("AAAAT")
     leaf5.data.count("GAAAA")
 
-    root.insert(leaf1)
-    root.insert(leaf2)
-    root.insert(leaf3)
-    root.insert(leaf4)
-    root.insert(leaf5)
+    root.add_node(leaf1)
+    root.add_node(leaf2)
+    root.add_node(leaf3)
+    root.add_node(leaf4)
+    root.add_node(leaf5)
 
     def search_kmer(obj, seq):
         return obj.data.get(seq)

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -133,6 +133,14 @@ def test_db_repr():
     assert repr(db) == "LCA_Database('{}')".format(filename)
 
 
+def test_lca_index_signatures_method():
+    filename = utils.get_test_data('lca/47+63.lca.json')
+    db, ksize, scaled = lca_utils.load_single_database(filename)
+
+    siglist = list(db.signatures())
+    assert len(siglist) == 2
+
+
 ## command line tests
 
 

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -134,12 +134,32 @@ def test_db_repr():
 
 
 def test_lca_index_signatures_method():
+    # test 'signatures' method from base class Index
     filename = utils.get_test_data('lca/47+63.lca.json')
     db, ksize, scaled = lca_utils.load_single_database(filename)
 
     siglist = list(db.signatures())
     assert len(siglist) == 2
 
+def test_lca_index_insert_method():
+    # test 'signatures' method from base class Index
+    filename = utils.get_test_data('lca/47+63.lca.json')
+    db, ksize, scaled = lca_utils.load_single_database(filename)
+
+    sig = next(iter(db.signatures()))
+
+    with pytest.raises(NotImplementedError) as e:
+        db.insert(sig)
+
+def test_lca_index_find_method():
+    # test 'signatures' method from base class Index
+    filename = utils.get_test_data('lca/47+63.lca.json')
+    db, ksize, scaled = lca_utils.load_single_database(filename)
+
+    sig = next(iter(db.signatures()))
+
+    with pytest.raises(NotImplementedError) as e:
+        db.find(None)
 
 ## command line tests
 

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -591,7 +591,8 @@ def test_save_sparseness(n_children):
                 assert all(c.node is None for c in tree_loaded.children(pos))
 
 
-def test_sbt_signatures():
+def test_sbt_as_index_signatures():
+    # test 'signatures' method from Index base class.
     factory = GraphFactory(31, 1e5, 4)
     tree = SBT(factory, d=2)
 

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from sourmash import load_signatures, load_one_signature
+from sourmash import load_one_signature
 from sourmash.sbt import SBT, GraphFactory, Leaf, Node
 from sourmash.sbtmh import (SigLeaf, search_minhashes,
                             search_minhashes_containment)
@@ -157,7 +157,7 @@ def test_tree_v2_load():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(load_signatures(testdata1))
+    to_search = load_one_signature(testdata1)
 
     results_v2 = {str(s) for s in tree_v2.find(search_minhashes_containment,
                                                to_search, 0.1)}
@@ -176,7 +176,7 @@ def test_tree_v3_load():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(load_signatures(testdata1))
+    to_search = load_one_signature(testdata1)
 
     results_v2 = {str(s) for s in tree_v2.find(search_minhashes_containment,
                                                to_search, 0.1)}
@@ -195,7 +195,7 @@ def test_tree_v5_load():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(load_signatures(testdata1))
+    to_search = load_one_signature(testdata1)
 
     results_v2 = {str(s) for s in tree_v2.find(search_minhashes_containment,
                                                to_search, 0.1)}
@@ -211,8 +211,8 @@ def test_tree_save_load(n_children):
     tree = SBT(factory, d=n_children)
 
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
-        leaf = SigLeaf(f, sig)
+        sig = load_one_signature(utils.get_test_data(f))
+        leaf = SigLeaf(os.path.basename(f), sig)
         tree.add_node(leaf)
         to_search = leaf
 
@@ -241,7 +241,7 @@ def test_tree_save_load_v5(n_children):
     tree = SBT(factory, d=n_children)
 
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
+        sig = load_one_signature(utils.get_test_data(f))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.add_node(leaf)
         to_search = leaf
@@ -272,8 +272,9 @@ def test_search_minhashes():
 
     n_leaves = 0
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
-        tree.insert(sig)
+        sig = load_one_signature(utils.get_test_data(f))
+        leaf = SigLeaf(os.path.basename(f), sig)
+        tree.add_node(leaf)
 
     to_search = next(iter(tree.leaves()))
 
@@ -294,7 +295,7 @@ def test_binary_nary_tree():
 
     n_leaves = 0
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
+        sig = load_one_signature(utils.get_test_data(f))
         leaf = SigLeaf(os.path.basename(f), sig)
         for tree in trees.values():
             tree.add_node(leaf)
@@ -322,12 +323,13 @@ def test_sbt_combine(n_children):
 
     n_leaves = 0
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
-        tree.insert(sig)
+        sig = load_one_signature(utils.get_test_data(f))
+        leaf = SigLeaf(os.path.basename(f), sig)
+        tree.add_node(leaf)
         if n_leaves < 4:
-            tree_1.insert(sig)
+            tree_1.add_node(leaf)
         else:
-            tree_2.insert(sig)
+            tree_2.add_node(leaf)
         n_leaves += 1
 
     tree_1.combine(tree_2)
@@ -339,8 +341,7 @@ def test_sbt_combine(n_children):
     assert len(t_leaves) == len(t1_leaves)
     assert t1_leaves == t_leaves
 
-    to_search = next(load_signatures(
-                        utils.get_test_data(utils.SIG_FILES[0])))
+    to_search = load_one_signature(utils.get_test_data(utils.SIG_FILES[0]))
     t1_result = {str(s) for s in tree_1.find(search_minhashes,
                                              to_search, 0.1)}
     tree_result = {str(s) for s in tree.find(search_minhashes,
@@ -368,7 +369,8 @@ def test_sbt_fsstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(load_signatures(utils.get_test_data(f)))
+            sig = load_one_signature(utils.get_test_data(f))
+
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.add_node(leaf)
             to_search = leaf
@@ -401,7 +403,8 @@ def test_sbt_tarstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(load_signatures(utils.get_test_data(f)))
+            sig = load_one_signature(utils.get_test_data(f))
+
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.add_node(leaf)
             to_search = leaf
@@ -437,7 +440,8 @@ def test_sbt_ipfsstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(load_signatures(utils.get_test_data(f)))
+            sig = load_one_signature(utils.get_test_data(f))
+
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.add_node(leaf)
             to_search = leaf
@@ -475,7 +479,8 @@ def test_sbt_redisstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(load_signatures(utils.get_test_data(f)))
+            sig = load_one_signature(utils.get_test_data(f))
+
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.add_node(leaf)
             to_search = leaf
@@ -514,7 +519,7 @@ def test_tree_repair():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(load_signatures(testdata1))
+    to_search = load_one_signature(testdata1)
 
     results_repair = {str(s) for s in tree_repair.find(search_minhashes,
                                                        to_search, 0.1)}
@@ -530,8 +535,9 @@ def test_tree_repair_insert():
                            leaf_loader=SigLeaf.load)
 
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
-        tree_repair.insert(sig)
+        sig = load_one_signature(utils.get_test_data(f))
+        leaf = SigLeaf(os.path.basename(f), sig)
+        tree_repair.add_node(leaf)
 
     for pos, node in tree_repair:
         # Every parent of a node must be an internal node (and not a leaf),
@@ -549,7 +555,7 @@ def test_save_sparseness(n_children):
     tree = SBT(factory, d=n_children)
 
     for f in utils.SIG_FILES:
-        sig = next(load_signatures(utils.get_test_data(f)))
+        sig = load_one_signature(utils.get_test_data(f))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.add_node(leaf)
         to_search = leaf

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -4,12 +4,12 @@ import os
 
 import pytest
 
-from sourmash import signature
+from sourmash import load_signatures, load_one_signature
 from sourmash.sbt import SBT, GraphFactory, Leaf, Node
 from sourmash.sbtmh import (SigLeaf, search_minhashes,
-                                search_minhashes_containment)
+                            search_minhashes_containment)
 from sourmash.sbt_storage import (FSStorage, TarStorage,
-                                      RedisStorage, IPFSStorage)
+                                  RedisStorage, IPFSStorage)
 
 from . import sourmash_tst_utils as utils
 
@@ -138,7 +138,7 @@ def test_tree_v1_load():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(signature.load_signatures(testdata1))
+    to_search = next(load_signatures(testdata1))
 
     results_v1 = {str(s) for s in tree_v1.find(search_minhashes_containment,
                                                to_search, 0.1)}
@@ -157,7 +157,7 @@ def test_tree_v2_load():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(signature.load_signatures(testdata1))
+    to_search = next(load_signatures(testdata1))
 
     results_v2 = {str(s) for s in tree_v2.find(search_minhashes_containment,
                                                to_search, 0.1)}
@@ -176,7 +176,7 @@ def test_tree_v3_load():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(signature.load_signatures(testdata1))
+    to_search = next(load_signatures(testdata1))
 
     results_v2 = {str(s) for s in tree_v2.find(search_minhashes_containment,
                                                to_search, 0.1)}
@@ -195,7 +195,7 @@ def test_tree_v5_load():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(signature.load_signatures(testdata1))
+    to_search = next(load_signatures(testdata1))
 
     results_v2 = {str(s) for s in tree_v2.find(search_minhashes_containment,
                                                to_search, 0.1)}
@@ -211,7 +211,7 @@ def test_tree_save_load(n_children):
     tree = SBT(factory, d=n_children)
 
     for f in utils.SIG_FILES:
-        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.insert(leaf)
         to_search = leaf
@@ -241,7 +241,7 @@ def test_tree_save_load_v5(n_children):
     tree = SBT(factory, d=n_children)
 
     for f in utils.SIG_FILES:
-        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.add_node(leaf)
         to_search = leaf
@@ -272,7 +272,7 @@ def test_search_minhashes():
 
     n_leaves = 0
     for f in utils.SIG_FILES:
-        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.insert(leaf)
 
@@ -295,7 +295,7 @@ def test_binary_nary_tree():
 
     n_leaves = 0
     for f in utils.SIG_FILES:
-        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         for tree in trees.values():
             tree.insert(leaf)
@@ -323,7 +323,7 @@ def test_sbt_combine(n_children):
 
     n_leaves = 0
     for f in utils.SIG_FILES:
-        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.insert(leaf)
         if n_leaves < 4:
@@ -341,7 +341,7 @@ def test_sbt_combine(n_children):
     assert len(t_leaves) == len(t1_leaves)
     assert t1_leaves == t_leaves
 
-    to_search = next(signature.load_signatures(
+    to_search = next(load_signatures(
                         utils.get_test_data(utils.SIG_FILES[0])))
     t1_result = {str(s) for s in tree_1.find(search_minhashes,
                                              to_search, 0.1)}
@@ -370,7 +370,7 @@ def test_sbt_fsstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(signature.load_signatures(utils.get_test_data(f)))
+            sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.insert(leaf)
             to_search = leaf
@@ -403,7 +403,7 @@ def test_sbt_tarstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(signature.load_signatures(utils.get_test_data(f)))
+            sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.insert(leaf)
             to_search = leaf
@@ -439,7 +439,7 @@ def test_sbt_ipfsstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(signature.load_signatures(utils.get_test_data(f)))
+            sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.insert(leaf)
             to_search = leaf
@@ -477,7 +477,7 @@ def test_sbt_redisstorage():
         tree = SBT(factory)
 
         for f in utils.SIG_FILES:
-            sig = next(signature.load_signatures(utils.get_test_data(f)))
+            sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
             tree.insert(leaf)
             to_search = leaf
@@ -516,7 +516,7 @@ def test_tree_repair():
                         leaf_loader=SigLeaf.load)
 
     testdata1 = utils.get_test_data(utils.SIG_FILES[0])
-    to_search = next(signature.load_signatures(testdata1))
+    to_search = next(load_signatures(testdata1))
 
     results_repair = {str(s) for s in tree_repair.find(search_minhashes,
                                                        to_search, 0.1)}
@@ -532,7 +532,7 @@ def test_tree_repair_insert():
                            leaf_loader=SigLeaf.load)
 
     for f in utils.SIG_FILES:
-        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree_repair.insert(leaf)
 
@@ -552,7 +552,7 @@ def test_save_sparseness(n_children):
     tree = SBT(factory, d=n_children)
 
     for f in utils.SIG_FILES:
-        sig = next(signature.load_signatures(utils.get_test_data(f)))
+        sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         tree.insert(leaf)
         to_search = leaf
@@ -586,3 +586,20 @@ def test_save_sparseness(n_children):
             # Leaf nodes can't have children
             if isinstance(node, Leaf):
                 assert all(c.node is None for c in tree_loaded.children(pos))
+
+
+def test_sbt_signatures():
+    factory = GraphFactory(31, 1e5, 4)
+    tree = SBT(factory, d=2)
+
+    sig47 = load_one_signature(utils.get_test_data('47.fa.sig'))
+    sig63 = load_one_signature(utils.get_test_data('63.fa.sig'))
+
+    tree.insert(SigLeaf('47', sig47))
+    tree.insert(SigLeaf('63', sig63))
+
+    xx = list(tree.signatures())
+    assert len(xx) == 2
+
+    assert sig47 in xx
+    assert sig63 in xx

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -43,11 +43,11 @@ def test_simple(n_children):
     leaf5.data.count('AAAAT')
     leaf5.data.count('GAAAA')
 
-    root.insert(leaf1)
-    root.insert(leaf2)
-    root.insert(leaf3)
-    root.insert(leaf4)
-    root.insert(leaf5)
+    root.add_node(leaf1)
+    root.add_node(leaf2)
+    root.add_node(leaf3)
+    root.add_node(leaf4)
+    root.add_node(leaf5)
 
     def search_kmer(obj, seq):
         return obj.data.get(seq)
@@ -104,11 +104,11 @@ def test_longer_search(n_children):
     leaf5.data.count('AAAAT')
     leaf5.data.count('GAAAA')
 
-    root.insert(leaf1)
-    root.insert(leaf2)
-    root.insert(leaf3)
-    root.insert(leaf4)
-    root.insert(leaf5)
+    root.add_node(leaf1)
+    root.add_node(leaf2)
+    root.add_node(leaf3)
+    root.add_node(leaf4)
+    root.add_node(leaf5)
 
     def kmers(k, seq):
         for start in range(len(seq) - k + 1):
@@ -212,8 +212,8 @@ def test_tree_save_load(n_children):
 
     for f in utils.SIG_FILES:
         sig = next(load_signatures(utils.get_test_data(f)))
-        leaf = SigLeaf(os.path.basename(f), sig)
-        tree.insert(leaf)
+        leaf = SigLeaf(f, sig)
+        tree.add_node(leaf)
         to_search = leaf
 
     print('*' * 60)
@@ -273,8 +273,7 @@ def test_search_minhashes():
     n_leaves = 0
     for f in utils.SIG_FILES:
         sig = next(load_signatures(utils.get_test_data(f)))
-        leaf = SigLeaf(os.path.basename(f), sig)
-        tree.insert(leaf)
+        tree.insert(sig)
 
     to_search = next(iter(tree.leaves()))
 
@@ -298,7 +297,7 @@ def test_binary_nary_tree():
         sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
         for tree in trees.values():
-            tree.insert(leaf)
+            tree.add_node(leaf)
         to_search = leaf
         n_leaves += 1
 
@@ -324,12 +323,11 @@ def test_sbt_combine(n_children):
     n_leaves = 0
     for f in utils.SIG_FILES:
         sig = next(load_signatures(utils.get_test_data(f)))
-        leaf = SigLeaf(os.path.basename(f), sig)
-        tree.insert(leaf)
+        tree.insert(sig)
         if n_leaves < 4:
-            tree_1.insert(leaf)
+            tree_1.insert(sig)
         else:
-            tree_2.insert(leaf)
+            tree_2.insert(sig)
         n_leaves += 1
 
     tree_1.combine(tree_2)
@@ -360,7 +358,7 @@ def test_sbt_combine(n_children):
     if not next_empty:
         next_empty = n + 1
 
-    tree_1.insert(leaf)
+    tree_1.add_node(SigLeaf(to_search.name(), to_search))
     assert tree_1.next_node == next_empty
 
 
@@ -372,7 +370,7 @@ def test_sbt_fsstorage():
         for f in utils.SIG_FILES:
             sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
-            tree.insert(leaf)
+            tree.add_node(leaf)
             to_search = leaf
 
         print('*' * 60)
@@ -405,7 +403,7 @@ def test_sbt_tarstorage():
         for f in utils.SIG_FILES:
             sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
-            tree.insert(leaf)
+            tree.add_node(leaf)
             to_search = leaf
 
         print('*' * 60)
@@ -441,7 +439,7 @@ def test_sbt_ipfsstorage():
         for f in utils.SIG_FILES:
             sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
-            tree.insert(leaf)
+            tree.add_node(leaf)
             to_search = leaf
 
         print('*' * 60)
@@ -479,7 +477,7 @@ def test_sbt_redisstorage():
         for f in utils.SIG_FILES:
             sig = next(load_signatures(utils.get_test_data(f)))
             leaf = SigLeaf(os.path.basename(f), sig)
-            tree.insert(leaf)
+            tree.add_node(leaf)
             to_search = leaf
 
         print('*' * 60)
@@ -533,8 +531,7 @@ def test_tree_repair_insert():
 
     for f in utils.SIG_FILES:
         sig = next(load_signatures(utils.get_test_data(f)))
-        leaf = SigLeaf(os.path.basename(f), sig)
-        tree_repair.insert(leaf)
+        tree_repair.insert(sig)
 
     for pos, node in tree_repair:
         # Every parent of a node must be an internal node (and not a leaf),
@@ -554,7 +551,7 @@ def test_save_sparseness(n_children):
     for f in utils.SIG_FILES:
         sig = next(load_signatures(utils.get_test_data(f)))
         leaf = SigLeaf(os.path.basename(f), sig)
-        tree.insert(leaf)
+        tree.add_node(leaf)
         to_search = leaf
 
     print('*' * 60)
@@ -595,8 +592,8 @@ def test_sbt_signatures():
     sig47 = load_one_signature(utils.get_test_data('47.fa.sig'))
     sig63 = load_one_signature(utils.get_test_data('63.fa.sig'))
 
-    tree.insert(SigLeaf('47', sig47))
-    tree.insert(SigLeaf('63', sig63))
+    tree.insert(sig47)
+    tree.insert(sig63)
 
     xx = list(tree.signatures())
     assert len(xx) == 2


### PR DESCRIPTION
NOTE: this is a PR into #556.

Some quick notes for @luizirber -

* the SBT class has `insert` already defined but it takes different arguments than `Index.insert`.
* at least at the moment LCA indices don't support inserting.
