### PR TITLE
[MRG] replace khmer.Nodegraph with rust nodegraph

### DIFF
--- a/.github/workflows/khmer.yml
+++ b/.github/workflows/khmer.yml
@@ -1,4 +1,4 @@
-name: Hypothesis tests
+name: khmer compatibility tests
 
 on:
   push:
@@ -21,10 +21,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[test]
+          python -m pip install khmer
 
-      - name: Run Hypothesis tests
+      - name: Run khmer tests
         run: |
-          python -m pytest --cov=. --cov-report=xml --run-hypothesis --hypothesis-show-statistics --hypothesis-profile ci
+          python -m pytest -k test_nodegraph --cov=. --cov-report=xml
 
       - name: Upload coverage to Codecov  
         uses: codecov/codecov-action@v1

--- a/.github/workflows/khmer.yml
+++ b/.github/workflows/khmer.yml
@@ -21,10 +21,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[test]
-          python -m pip install khmer
 
-      - name: Run khmer tests
+      - name: Run tests with latest released khmer
         run: |
+          python -m pip install khmer
+          python -m pytest -k test_nodegraph --cov=. --cov-report=xml
+
+      - name: Run tests with khmer master tests
+        run: |
+          python -m pip install -U git+https://github.com/dib-lab/khmer.git#egg=khmer
           python -m pytest -k test_nodegraph --cov=. --cov-report=xml
 
       - name: Upload coverage to Codecov  

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,15 +39,19 @@ jobs:
           - build: macos
             os: macos-latest
             rust: stable
+            continue: false
           - build: windows
             os: windows-latest
             rust: stable
+            continue: true
           - build: beta
             os: ubuntu-latest
             rust: beta
+            continue: false
           - build: stable
             os: ubuntu-latest
             rust: stable
+            continue: false
     steps:
       - uses: actions/checkout@v1
 
@@ -57,13 +61,12 @@ jobs:
           override: true
 
       - name: Set up Python 3.8
-        if: matrix.os != 'windows-latest'
         uses: actions/setup-python@v1
         with:
           python-version: "3.8"
 
       - name: Install dependencies
-        if: matrix.os != 'windows-latest'
+        continue-on-error: ${{ matrix.continue }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       services:
         - docker
       env:
-        - CIBW_BUILD: "'pp36* cp37-*'"    # build wheels for PyPy too
+        - CIBW_BUILD: "'cp37-*'"
         - CIBW_SKIP: "'*-win32 *-manylinux_i686'"
         - CIBW_BEFORE_BUILD='source .travis/install_cargo.sh'
         - CIBW_ENVIRONMENT='PATH="$HOME/.cargo/bin:$PATH"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,12 @@ jobs:
         - "/snap/bin/ipfs --version"
         - "/snap/bin/ipfs daemon --init --offline &>/dev/null &"
       services:
-        - redis-server
+        - redis
         - docker
     - <<: *test
-      python: 2.7
-    - <<: *test
       python: 3.5
+    - <<: *test
+      python: 2.7
 
     - &wheel
       stage: build wheel and send to github releases
@@ -60,19 +60,18 @@ jobs:
       services:
         - docker
       env:
-        - CIBW_BUILD='cp37-*'
-        - CIBW_SKIP='*-manylinux_i686'
+        - CIBW_BUILD: "'pp36* cp37-*'"    # build wheels for PyPy too
+        - CIBW_SKIP: "'*-win32 *-manylinux_i686'"
         - CIBW_BEFORE_BUILD='source .travis/install_cargo.sh'
         - CIBW_ENVIRONMENT='PATH="$HOME/.cargo/bin:$PATH"'
         - CIBW_ENVIRONMENT_MACOS='MACOSX_DEPLOYMENT_TARGET=10.11'
-      before_script: skip
+      before_script:
+        - python3 -m pip install cibuildwheel==1.3.0
       script:
-        - python -m pip install -U pip setuptools
-        - python -m pip install cibuildwheel==1.3.0
-        - python -m cibuildwheel --output-dir wheelhouse
+        - python3 -m cibuildwheel --output-dir wheelhouse
       deploy:
         provider: releases
-        api_key:
+        token:
           secure: "FZmx00gL0m0uNVN8fpvqbUZSI20EEk4sgrEv4wpGFr8SFNwPb/VuizQRTapeF2AW9qzbfbUv4bR/+oSKu5jxvd+7+p9HlOZT285a5yfxay9OA8YUbpQz4a9J0CETOpxrA2wRRWBDqzjEWzLTGUquOhyBZn4cwujvA9syOdB7OSNKsB6ARc+zhqPeoMKc9JcjzwiEIh7tcCHoZ1epN5zyfsjqFEY8XlylHTU/WSI3SS9KIGuBqWf6/haoYD7BH+f2g56GMHvBEmGjk5cf/lrCpqiho7Z3fGgJcYf3fRWM3qSVUM9JyHUIqPS6oPZIp7zP40TztiK4Oeen4EpcS/KdoSdu5CjfgMYgF/qdlL28ntgnVYhcA/6IDSRg6V4H3b20qjsn3NlaNVdsSNCu3GzkvM/dtvp5I/41XcFCNqMOljMr3tRw2ZVo44/1vYW0FB0b0FjhjNcnMyTOQjSRR78zetdoorewTJdEmxthMieHIw1Mqzwg4e6JvsC30sh1uSaFq4FHrj2Fe6lAlgwPs1e9vx4w0Zs0kxxusNAdbBB8FH8paFuUEGjgT0Jo9KHOLtvRy+OU2OacQePuhG1kGBRvJz7O4/prAFLGWIW8tyZDnMCuv1vmk6YZd6ih3omkL178X94pjzavtlUip/ugF0NIwS5o+zucRow9txAX2jXgDCM="
         file_glob: true
         file: wheelhouse/sourmash*.whl
@@ -84,18 +83,16 @@ jobs:
       osx_image: xcode10.1
       language: shell
     - <<: *wheel
-      os: windows
-      language: shell
-      before_install:
-        - choco install python --version 3.8.0
-        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
-        - ln -s /c/Python38/python.exe /c/Python38/python3.exe
-    - <<: *wheel
-      arch: aarch64
+      arch: arm64
     - <<: *wheel
       arch: ppc64le
-    - <<: *wheel
-      arch: s390x
+    #- <<: *wheel
+    #  os: windows
+    #  language: shell
+    #  before_install:
+    #    - choco install python --version 3.8.0
+    #    - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+    #    - ln -s /c/Python38/python.exe /c/Python38/python3.exe
 
 stages:
   - check

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
       before_script: skip
       script:
         - python -m pip install -U pip setuptools
-        - python -m pip install cibuildwheel==1.1.0
+        - python -m pip install cibuildwheel==1.3.0
         - python -m cibuildwheel --output-dir wheelhouse
       deploy:
         provider: releases
@@ -83,6 +83,19 @@ jobs:
       os: osx
       osx_image: xcode10.1
       language: shell
+    - <<: *wheel
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.8.0
+        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        - ln -s /c/Python38/python.exe /c/Python38/python3.exe
+    - <<: *wheel
+      arch: aarch64
+    - <<: *wheel
+      arch: ppc64le
+    - <<: *wheel
+      arch: s390x
 
 stages:
   - check

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,22 +25,20 @@ jobs:
   include:
     - &check
       stage: check # do a pre-screen to make sure this is even worth testing
-      python: 3.7
+      python: 3.8
       env:
         - PYTHONDEVMODE=1
 
     - &test
       stage: test
-      python: 3.6
+      python: 3.7
     - <<: *test
       os: osx
       osx_image: xcode10.1
-      python: 3.7
       language: generic
       env:
         - TOXENV=py37
     - <<: *test
-      python: 3.7
       name: integration (ipfs/redis)
       before_install:
         - sudo snap install ipfs
@@ -49,6 +47,8 @@ jobs:
       services:
         - redis
         - docker
+    - <<: *test
+      python: 3.6
     - <<: *test
       python: 3.5
     - <<: *test

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -182,6 +182,8 @@ bool kmerminhash_track_abundance(KmerMinHash *ptr);
 
 bool nodegraph_count(Nodegraph *ptr, uint64_t h);
 
+bool nodegraph_count_kmer(Nodegraph *ptr, const char *kmer);
+
 double nodegraph_expected_collisions(Nodegraph *ptr);
 
 void nodegraph_free(Nodegraph *ptr);
@@ -191,6 +193,8 @@ Nodegraph *nodegraph_from_buffer(const char *ptr, uintptr_t insize);
 Nodegraph *nodegraph_from_path(const char *filename);
 
 uintptr_t nodegraph_get(Nodegraph *ptr, uint64_t h);
+
+uintptr_t nodegraph_get_kmer(Nodegraph *ptr, const char *kmer);
 
 uintptr_t nodegraph_ksize(Nodegraph *ptr);
 

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -212,6 +212,8 @@ uintptr_t nodegraph_tablesize(Nodegraph *ptr);
 
 void nodegraph_update(Nodegraph *ptr, Nodegraph *optr);
 
+void nodegraph_update_mh(Nodegraph *ptr, KmerMinHash *optr);
+
 Nodegraph *nodegraph_with_tables(uintptr_t ksize, uintptr_t starting_size, uintptr_t n_tables);
 
 void signature_add_sequence(Signature *ptr, const char *sequence, bool force);

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -208,6 +208,8 @@ uintptr_t nodegraph_ntables(Nodegraph *ptr);
 
 void nodegraph_save(Nodegraph *ptr, const char *filename);
 
+uint8_t *nodegraph_to_buffer(Nodegraph *ptr, uintptr_t *size);
+
 uintptr_t nodegraph_tablesize(Nodegraph *ptr);
 
 void nodegraph_update(Nodegraph *ptr, Nodegraph *optr);

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -212,7 +212,7 @@ uint8_t *nodegraph_to_buffer(Nodegraph *ptr, uintptr_t *size);
 
 void nodegraph_buffer_free(uint8_t *ptr, uintptr_t insize);
 
-uintptr_t nodegraph_tablesize(Nodegraph *ptr);
+uint64_t *nodegraph_hashsizes(Nodegraph *ptr, uintptr_t *size);
 
 void nodegraph_update(Nodegraph *ptr, Nodegraph *optr);
 

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -210,6 +210,8 @@ void nodegraph_save(Nodegraph *ptr, const char *filename);
 
 uint8_t *nodegraph_to_buffer(Nodegraph *ptr, uintptr_t *size);
 
+void nodegraph_buffer_free(uint8_t *ptr, uintptr_t insize);
+
 uintptr_t nodegraph_tablesize(Nodegraph *ptr);
 
 void nodegraph_update(Nodegraph *ptr, Nodegraph *optr);

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ SETUP_METADATA = {
         'sourmash = sourmash.__main__:main'
         ]
     },
-    "install_requires": ["screed>=0.9", "khmer>=2.1", "cffi>=1.14.0", 'numpy',
+    "install_requires": ["screed>=0.9", "cffi>=1.14.0", 'numpy',
                          'matplotlib', 'scipy', "deprecation>=2.0.6"],
     "setup_requires": [
         "setuptools>=38.6.0",

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ SETUP_METADATA = {
         'doc' : ['sphinx', 'recommonmark', 'alabaster',
                  "sphinxcontrib-napoleon", "nbsphinx",
                  "ipython"],
-        '10x': ['bam2fasta==1.0.1'],
+        '10x': ['bam2fasta==1.0.4'],
         'storage': ["ipfshttpclient>=0.4.13", "redis"]
     },
     "include_package_data": True,

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ SETUP_METADATA = {
     "zip_safe": False,
     "platforms": "any",
     "extras_require": {
-        'test' : ['pytest', 'pytest-cov', 'recommonmark', 'hypothesis'],
+        'test' : ['pytest', 'pytest-cov', 'recommonmark', 'hypothesis', 'khmer>=2.1'],
         'demo' : ['jupyter', 'jupyter_client', 'ipython'],
         'doc' : ['sphinx', 'recommonmark', 'alabaster',
                  "sphinxcontrib-napoleon", "nbsphinx",

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ SETUP_METADATA = {
     "zip_safe": False,
     "platforms": "any",
     "extras_require": {
-        'test' : ['pytest', 'pytest-cov', 'recommonmark', 'hypothesis', 'khmer>=2.1'],
+        'test' : ['pytest', 'pytest-cov', 'recommonmark', 'hypothesis'],
         'demo' : ['jupyter', 'jupyter_client', 'ipython'],
         'doc' : ['sphinx', 'recommonmark', 'alabaster',
                  "sphinxcontrib-napoleon", "nbsphinx",

--- a/sourmash/cli/info.py
+++ b/sourmash/cli/info.py
@@ -14,14 +14,13 @@ def subparser(subparsers):
 
 
 def info(verbose=False):
+    "Report sourmash version + version of installed dependencies."
     notify('sourmash version {}', sourmash.VERSION)
     notify('- loaded from path: {}', os.path.dirname(__file__))
     notify('')
 
     if verbose:
-        import khmer
-        notify('khmer version {}', khmer.__version__)
-        notify('- loaded from path: {}', os.path.dirname(khmer.__file__))
+        notify('khmer version: None (internal Nodegraph)')
         notify('')
 
         notify('screed version {}', screed.__version__)

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -32,9 +32,7 @@ def info(args):
     notify('')
 
     if args.verbose:
-        import khmer
-        notify('khmer version {}', khmer.__version__)
-        notify('- loaded from path: {}', os.path.dirname(khmer.__file__))
+        notify('khmer version: None (internal Nodegraph)')
         notify('')
 
         notify('screed version {}', screed.__version__)

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -24,21 +24,6 @@ WATERMARK_SIZE = 10000
 from .command_compute import compute
 
 
-def info(args):
-    "Report sourmash version + version of installed dependencies."
-    from . import VERSION
-    notify('sourmash version {}', VERSION)
-    notify('- loaded from path: {}', os.path.dirname(__file__))
-    notify('')
-
-    if args.verbose:
-        notify('khmer version: None (internal Nodegraph)')
-        notify('')
-
-        notify('screed version {}', screed.__version__)
-        notify('- loaded from path: {}', os.path.dirname(screed.__file__))
-
-
 def compare(args):
     "Compare multiple signature files and create a distance matrix."
     import numpy

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-from __future__ import unicode_literals, division
+from __future__ import unicode_literals, division, print_function
 
 from struct import pack, unpack
 import sys

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 from __future__ import unicode_literals, division
 
+import sys
 from tempfile import NamedTemporaryFile
 
 from ._compat import string_types, range_type

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -29,6 +29,12 @@ class Nodegraph(RustObject):
     def save(self, filename):
         self._methodcall(lib.nodegraph_save, to_bytes(filename))
 
+    def to_bytes(self):
+        size = ffi.new("uintptr_t *")
+        rawbuf = self._methodcall(lib.nodegraph_to_buffer, size)
+        size = ffi.unpack(size, 1)[0]
+        return ffi.buffer(rawbuf, size)[:]
+
     def update(self, other):
         if isinstance(other, Nodegraph):
             return self._methodcall(lib.nodegraph_update, other._objptr)

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -1,0 +1,112 @@
+# -*- coding: UTF-8 -*-
+from __future__ import unicode_literals, division
+
+from tempfile import NamedTemporaryFile
+
+from ._compat import string_types, range_type
+from ._lowlevel import ffi, lib
+from ._minhash import to_bytes, MinHash
+from .utils import RustObject, rustcall, decode_str
+from .exceptions import SourmashError
+
+
+class Nodegraph(RustObject):
+    __dealloc_func__ = lib.nodegraph_free
+
+    def __init__(self, ksize, starting_size, n_tables):
+        self._objptr = lib.nodegraph_with_tables(ksize, int(starting_size), n_tables)
+
+    @staticmethod
+    def load(filename):
+        ng_ptr = rustcall(lib.nodegraph_from_path, to_bytes(filename))
+        return Nodegraph._from_objptr(ng_ptr)
+
+    @staticmethod
+    def from_buffer(buf):
+        ng_ptr = rustcall(lib.nodegraph_from_buffer, buf, len(buf))
+        return Nodegraph._from_objptr(ng_ptr)
+
+    def save(self, filename):
+        self._methodcall(lib.nodegraph_save, to_bytes(filename))
+
+    def update(self, other):
+        if not isinstance(other, Nodegraph):
+            raise TypeError("Must be a Nodegraph")
+
+        return self._methodcall(lib.nodegraph_update, other._objptr)
+
+    def count(self, h):
+        if isinstance(h, string_types):
+            return self._methodcall(lib.nodegraph_count_kmer, to_bytes(h))
+        return self._methodcall(lib.nodegraph_count, h)
+
+    def get(self, h):
+        if isinstance(h, string_types):
+            return self._methodcall(lib.nodegraph_get_kmer, to_bytes(h))
+        return self._methodcall(lib.nodegraph_get, h)
+
+    @property
+    def n_occupied(self):
+        return self._methodcall(lib.nodegraph_noccupied)
+
+    @property
+    def ksize(self):
+        return self._methodcall(lib.nodegraph_ksize)
+
+    @property
+    def tablesize(self):
+        return self._methodcall(lib.nodegraph_tablesize)
+
+    @property
+    def n_tables(self):
+        return self._methodcall(lib.nodegraph_ntables)
+
+    @property
+    def expected_collisions(self):
+        return self._methodcall(lib.nodegraph_expected_collisions)
+
+    def matches(self, mh):
+        if not isinstance(mh, MinHash):
+            raise ValueError("mh must be a MinHash")
+
+        return self._methodcall(lib.nodegraph_matches, mh._objptr)
+
+    def to_khmer_nodegraph(self):
+        import khmer
+        try:
+            load_nodegraph = khmer.load_nodegraph
+        except AttributeError:
+            load_nodegraph = khmer.Nodegraph.load
+
+        with NamedTemporaryFile(suffix=".gz") as f:
+            self.save(f.name)
+            f.file.flush()
+            f.file.seek(0)
+            return load_nodegraph(f.name)
+
+
+def extract_nodegraph_info(filename):
+    ng = Nodegraph.load(filename)
+    return ng.ksize, ng.tablesize, ng.n_tables
+
+
+def calc_expected_collisions(graph, force=False, max_false_pos=.2):
+    fp_all = graph.expected_collisions()
+
+    if fp_all > max_false_pos:
+        print("**", file=sys.stderr)
+        print("** ERROR: the graph structure is too small for ",
+              file=sys.stderr)
+        print("** this data set.  Increase data structure size.",
+              file=sys.stderr)
+        print("** Do not use these results!!", file=sys.stderr)
+        print("**", file=sys.stderr)
+        print("** (estimated false positive rate of %.3f;" % fp_all,
+              file=sys.stderr, end=' ')
+        print("max recommended %.3f)" % max_false_pos, file=sys.stderr)
+        print("**", file=sys.stderr)
+
+        if not force:
+            sys.exit(1)
+
+    return fp_all

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -33,9 +33,11 @@ class Nodegraph(RustObject):
     def to_bytes(self):
         size = ffi.new("uintptr_t *")
         rawbuf = self._methodcall(lib.nodegraph_to_buffer, size)
-        size = ffi.unpack(size, 1)[0]
-        buf = ffi.buffer(rawbuf, size)[:]
-        lib.nodegraph_buffer_free(rawbuf, size)
+        size = size[0]
+
+        rawbuf = ffi.gc(rawbuf, lambda o: lib.nodegraph_buffer_free(o, size), size)
+        buf = ffi.buffer(rawbuf, size)
+
         return buf
 
     def update(self, other):

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -80,7 +80,7 @@ class Nodegraph(RustObject):
         except AttributeError:
             load_nodegraph = khmer.Nodegraph.load
 
-        with NamedTemporaryFile(suffix=".gz") as f:
+        with NamedTemporaryFile() as f:
             self.save(f.name)
             f.file.flush()
             f.file.seek(0)

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -34,7 +34,9 @@ class Nodegraph(RustObject):
         size = ffi.new("uintptr_t *")
         rawbuf = self._methodcall(lib.nodegraph_to_buffer, size)
         size = ffi.unpack(size, 1)[0]
-        return ffi.buffer(rawbuf, size)[:]
+        buf = ffi.buffer(rawbuf, size)[:]
+        lib.nodegraph_buffer_free(rawbuf, size)
+        return buf
 
     def update(self, other):
         if isinstance(other, Nodegraph):

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -47,6 +47,8 @@ class Nodegraph(RustObject):
         elif isinstance(other, MinHash):
             return self._methodcall(lib.nodegraph_update_mh, other._objptr)
         else:
+            # FIXME: we could take sets here too (or anything that can be
+            # converted to a list of ints...)
             raise TypeError("Must be a Nodegraph or MinHash")
 
     def count(self, h):
@@ -59,15 +61,12 @@ class Nodegraph(RustObject):
             return self._methodcall(lib.nodegraph_get_kmer, to_bytes(h))
         return self._methodcall(lib.nodegraph_get, h)
 
-    @property
     def n_occupied(self):
         return self._methodcall(lib.nodegraph_noccupied)
 
-    @property
     def ksize(self):
         return self._methodcall(lib.nodegraph_ksize)
 
-    @property
     def hashsizes(self):
         size = ffi.new("uintptr_t *")
         ptr = self._methodcall(lib.nodegraph_hashsizes, size)
@@ -83,6 +82,8 @@ class Nodegraph(RustObject):
 
     def matches(self, mh):
         if not isinstance(mh, MinHash):
+            # FIXME: we could take sets here too (or anything that can be
+            # converted to a list of ints...)
             raise ValueError("mh must be a MinHash")
 
         return self._methodcall(lib.nodegraph_matches, mh._objptr)
@@ -141,7 +142,7 @@ def extract_nodegraph_info(filename):
 
 
 def calc_expected_collisions(graph, force=False, max_false_pos=.2):
-    fp_all = graph.expected_collisions()
+    fp_all = graph.expected_collisions
 
     if fp_all > max_false_pos:
         print("**", file=sys.stderr)
@@ -157,6 +158,6 @@ def calc_expected_collisions(graph, force=False, max_false_pos=.2):
         print("**", file=sys.stderr)
 
         if not force:
-            sys.exit(1)
+            raise SystemExit(1)
 
     return fp_all

--- a/sourmash/nodegraph.py
+++ b/sourmash/nodegraph.py
@@ -30,10 +30,12 @@ class Nodegraph(RustObject):
         self._methodcall(lib.nodegraph_save, to_bytes(filename))
 
     def update(self, other):
-        if not isinstance(other, Nodegraph):
-            raise TypeError("Must be a Nodegraph")
-
-        return self._methodcall(lib.nodegraph_update, other._objptr)
+        if isinstance(other, Nodegraph):
+            return self._methodcall(lib.nodegraph_update, other._objptr)
+        elif isinstance(other, MinHash):
+            return self._methodcall(lib.nodegraph_update_mh, other._objptr)
+        else:
+            raise TypeError("Must be a Nodegraph or MinHash")
 
     def count(self, h):
         if isinstance(h, string_types):

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -57,16 +57,12 @@ from random import randint, random
 import sys
 from tempfile import NamedTemporaryFile
 
-import khmer
-
-try:
-    load_nodegraph = khmer.load_nodegraph
-except AttributeError:
-    load_nodegraph = khmer.Nodegraph.load
+from deprecation import deprecated
 
 from .sbt_storage import FSStorage, TarStorage, IPFSStorage, RedisStorage
 from .logging import error, notify, debug
 from .index import Index
+from .nodegraph import Nodegraph, extract_nodegraph_info, calc_expected_collisions
 
 STORAGES = {
     'TarStorage': TarStorage,
@@ -96,7 +92,7 @@ class GraphFactory(object):
         self.n_tables = n_tables
 
     def __call__(self):
-        return khmer.Nodegraph(self.ksize, self.starting_size, self.n_tables)
+        return Nodegraph(self.ksize, self.starting_size, self.n_tables)
 
     def init_args(self):
         return (self.ksize, self.starting_size, self.n_tables)
@@ -667,14 +663,6 @@ class SBT(Index):
             5: cls._load_v5,
         }
 
-        # @CTB hack: check to make sure khmer Nodegraph supports the
-        # correct methods.
-        x = khmer.Nodegraph(1, 1, 1)
-        try:
-            x.count(10)
-        except TypeError:
-            raise Exception("khmer version is too old; need >= 2.1,<3")
-
         if leaf_loader is None:
             leaf_loader = Leaf.load
 
@@ -703,7 +691,7 @@ class SBT(Index):
         sbt_nodes = {}
 
         sample_bf = os.path.join(dirname, jnodes[0]['filename'])
-        ksize, tablesize, ntables = khmer.extract_nodegraph_info(sample_bf)[:3]
+        ksize, tablesize, ntables = extract_nodegraph_info(sample_bf)[:3]
         factory = GraphFactory(ksize, tablesize, ntables)
 
         for i, jnode in enumerate(jnodes):
@@ -736,7 +724,7 @@ class SBT(Index):
         sbt_leaves = {}
 
         sample_bf = os.path.join(dirname, nodes[0]['filename'])
-        k, size, ntables = khmer.extract_nodegraph_info(sample_bf)[:3]
+        k, size, ntables = extract_nodegraph_info(sample_bf)[:3]
         factory = GraphFactory(k, size, ntables)
 
         for k, node in nodes.items():
@@ -1073,11 +1061,12 @@ class Node(object):
     def __str__(self):
         return '*Node:{name} [occupied: {nb}, fpr: {fpr:.2}]'.format(
                 name=self.name, nb=self.data.n_occupied(),
-                fpr=khmer.calc_expected_collisions(self.data, True, 1.1))
+                fpr=calc_expected_collisions(self.data, True, 1.1))
 
     def save(self, path):
         # We need to do this tempfile dance because khmer only load
         # data from files.
+        # FIXME: with the internal Nodegraph we can skip the temp file
         with NamedTemporaryFile(suffix=".gz") as f:
             self.data.save(f.name)
             f.file.flush()
@@ -1091,12 +1080,7 @@ class Node(object):
                 self._data = self._factory()
             else:
                 data = self.storage.load(self._path)
-                # We need to do this tempfile dance because khmer only load
-                # data from files.
-                with NamedTemporaryFile(suffix=".gz") as f:
-                    f.write(data)
-                    f.file.flush()
-                    self._data = load_nodegraph(f.name)
+                self._data = Nodegraph.from_buffer(data)
         return self._data
 
     @data.setter
@@ -1142,7 +1126,7 @@ class Leaf(object):
         return '**Leaf:{name} [occupied: {nb}, fpr: {fpr:.2}] -> {metadata}'.format(
                 name=self.name, metadata=self.metadata,
                 nb=self.data.n_occupied(),
-                fpr=khmer.calc_expected_collisions(self.data, True, 1.1))
+                fpr=calc_expected_collisions(self.data, True, 1.1))
 
     @property
     def data(self):
@@ -1150,10 +1134,7 @@ class Leaf(object):
             data = self.storage.load(self._path)
             # We need to do this tempfile dance because khmer only load
             # data from files.
-            with NamedTemporaryFile(suffix=".gz") as f:
-                f.write(data)
-                f.file.flush()
-                self._data = load_nodegraph(f.name)
+            self._data = Nodegraph.from_buffer(data)
         return self._data
 
     @data.setter
@@ -1166,6 +1147,7 @@ class Leaf(object):
     def save(self, path):
         # We need to do this tempfile dance because khmer only load
         # data from files.
+        # FIXME: with the internal Nodegraph we can skip the temp file
         with NamedTemporaryFile(suffix=".gz") as f:
             self.data.save(f.name)
             f.file.flush()

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -55,7 +55,6 @@ import math
 import os
 from random import randint, random
 import sys
-from tempfile import NamedTemporaryFile
 
 from deprecation import deprecated
 
@@ -1064,14 +1063,8 @@ class Node(object):
                 fpr=calc_expected_collisions(self.data, True, 1.1))
 
     def save(self, path):
-        # We need to do this tempfile dance because khmer only load
-        # data from files.
-        # FIXME: with the internal Nodegraph we can skip the temp file
-        with NamedTemporaryFile(suffix=".gz") as f:
-            self.data.save(f.name)
-            f.file.flush()
-            f.file.seek(0)
-            return self.storage.save(path, f.read())
+        buf = self.data.to_bytes()
+        return self.storage.save(path, buf)
 
     @property
     def data(self):
@@ -1132,8 +1125,6 @@ class Leaf(object):
     def data(self):
         if self._data is None:
             data = self.storage.load(self._path)
-            # We need to do this tempfile dance because khmer only load
-            # data from files.
             self._data = Nodegraph.from_buffer(data)
         return self._data
 
@@ -1145,14 +1136,8 @@ class Leaf(object):
         self._data = None
 
     def save(self, path):
-        # We need to do this tempfile dance because khmer only load
-        # data from files.
-        # FIXME: with the internal Nodegraph we can skip the temp file
-        with NamedTemporaryFile(suffix=".gz") as f:
-            self.data.save(f.name)
-            f.file.flush()
-            f.file.seek(0)
-            return self.storage.save(path, f.read())
+        buf = self.data.to_bytes()
+        return self.storage.save(path, buf)
 
     def update(self, parent):
         parent.data.update(self.data)

--- a/sourmash/sbt_storage.py
+++ b/sourmash/sbt_storage.py
@@ -142,6 +142,8 @@ class RedisStorage(Storage):
         self.conn = redis.Redis(**self.redis_args)
 
     def save(self, path, content):
+        if not isinstance(content, bytes):
+            content = bytes(content)
         self.conn.set(path, content)
         return path
 

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -55,8 +55,7 @@ class SigLeaf(Leaf):
 
     def update(self, parent):
         mh = self.data.minhash
-        for v in mh.get_mins():
-            parent.data.count(v)
+        parent.data.update(mh)
         min_n_below = parent.metadata.get('min_n_below', sys.maxsize)
         min_n_below = min(len(mh), min_n_below)
 

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -109,13 +109,13 @@ def search_minhashes(node, sig, threshold, results=None):
     """\
     Default tree search function, searching for best Jaccard similarity.
     """
-    mins = sig.minhash.get_mins()
+    sig_mh = sig.minhash
     score = 0
 
     if isinstance(node, SigLeaf):
-        score = node.data.minhash.similarity(sig.minhash)
+        score = node.data.minhash.similarity(sig_mh)
     else:  # Node minhash comparison
-        score = _max_jaccard_underneath_internal_node(node, sig.minhash)
+        score = _max_jaccard_underneath_internal_node(node, sig_mh)
 
     if results is not None:
         results[node.name] = score
@@ -131,13 +131,13 @@ class SearchMinHashesFindBest(object):
         self.best_match = 0.
 
     def search(self, node, sig, threshold, results=None):
-        mins = sig.minhash.get_mins()
+        sig_mh = sig.minhash
         score = 0
 
         if isinstance(node, SigLeaf):
-            score = node.data.minhash.similarity(sig.minhash)
+            score = node.data.minhash.similarity(sig_mh)
         else:  # internal object, not leaf.
-            score = _max_jaccard_underneath_internal_node(node, sig.minhash)
+            score = _max_jaccard_underneath_internal_node(node, sig_mh)
 
         if results is not None:
             results[node.name] = score
@@ -162,7 +162,7 @@ def search_minhashes_containment(node, sig, threshold, results=None, downsample=
         matches = node.data.matches(mh)
 
     if results is not None:
-        results[node.name] = float(matches) / len(sig)
+        results[node.name] = float(matches) / len(mh)
 
     if len(mh) and float(matches) / len(mh) >= threshold:
         return 1
@@ -174,18 +174,19 @@ class GatherMinHashes(object):
         self.best_match = 0
 
     def search(self, node, query, threshold, results=None):
-        if not len(query.minhash):
+        mh = query.minhash
+        if not len(mh):
             return 0
 
         if isinstance(node, SigLeaf):
-            matches = query.minhash.count_common(node.data.minhash, True)
+            matches = mh.count_common(node.data.minhash, True)
         else:  # Nodegraph by minhash comparison
-            matches = node.data.matches(query.minhash)
+            matches = node.data.matches(mh)
 
         if not matches:
             return 0
 
-        score = float(matches) / len(query.minhash)
+        score = float(matches) / len(mh)
 
         # store results if we have passed in an appropriate dictionary
         if results is not None:

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -50,16 +50,15 @@ features = ["serde-serialize"]
 version = "1.0"
 default-features = false
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-proptest = "0.9.4"
 
 [dev-dependencies]
+assert_cmd = "0.12.0"
+assert_matches = "1.3.0"
 criterion = "0.3.0"
+predicates = "1.0.2"
+proptest = { version = "0.9.4", default-features = false, features = ["std"]}
 rand = "0.7.2"
 tempfile = "3.1.0"
-assert_matches = "1.3.0"
-assert_cmd = "0.12.0"
-predicates = "1.0.2"
 
 [dev-dependencies.needletail]
 version = "0.3.2"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -25,7 +25,8 @@ parallel = ["rayon"]
 #cbindgen = "~0.6.7"
 
 [dependencies]
-byteorder = "1.3.2"
+#byteorder = "1.3.2"
+byteorder = { git = "https://github.com/luizirber/byteorder", branch="write_u32_from" }
 cfg-if = "0.1.10"
 failure = "0.1.6"
 failure_derive = "0.1.6"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -34,6 +34,7 @@ fixedbitset = "0.3.0"
 log = "0.4.8"
 md5 = "0.7.0"
 murmurhash3 = "0.0.5"
+niffler = { version = "2.0", default-features = false }
 once_cell = "1.2.0"
 rayon = { version = "1.0", optional = true }
 serde = "1.0.103"
@@ -45,11 +46,6 @@ typed-builder = "0.4.0"  # Upgrade to 0.5.1 needs rust 1.37
 [target.'cfg(all(target_arch = "wasm32", target_vendor="unknown"))'.dependencies.wasm-bindgen]
 version = "0.2.55"
 features = ["serde-serialize"]
-
-[target.'cfg(not(all(target_arch = "wasm32", target_vendor="unknown")))'.dependencies.niffler]
-version = "1.0"
-default-features = false
-
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -30,7 +30,8 @@ cfg-if = "0.1.10"
 failure = "0.1.6"
 failure_derive = "0.1.6"
 finch = { version = "0.3.0", optional = true }
-fixedbitset = "0.2.0"
+#fixedbitset = "0.2.0"
+fixedbitset = { git = "https://github.com/luizirber/fixedbitset", branch="with_capacity_and_blocks" }
 log = "0.4.8"
 md5 = "0.7.0"
 murmurhash3 = "0.0.5"
@@ -71,4 +72,8 @@ harness = false
 
 [[bench]]
 name = "compute"
+harness = false
+
+[[bench]]
+name = "nodegraph"
 harness = false

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -25,8 +25,7 @@ parallel = ["rayon"]
 #cbindgen = "~0.6.7"
 
 [dependencies]
-#byteorder = "1.3.2"
-byteorder = { git = "https://github.com/luizirber/byteorder", branch="write_u32_from" }
+byteorder = "1.3.2"
 cfg-if = "0.1.10"
 failure = "0.1.6"
 failure_derive = "0.1.6"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -40,7 +40,7 @@ serde = "1.0.103"
 serde_derive = "1.0.103"
 serde_json = "1.0.44"
 primal-check = "0.2.3"
-typed-builder = "0.4.0"
+typed-builder = "0.4.0"  # Upgrade to 0.5.1 needs rust 1.37
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor="unknown"))'.dependencies.wasm-bindgen]
 version = "0.2.55"
@@ -52,7 +52,7 @@ default-features = false
 
 
 [dev-dependencies]
-assert_cmd = "0.12.0"
+assert_cmd = "1.0"
 assert_matches = "1.3.0"
 criterion = "0.3.0"
 predicates = "1.0.2"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 description = "MinHash sketches for genomic data"
 repository = "https://github.com/dib-lab/sourmash"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -30,8 +30,7 @@ cfg-if = "0.1.10"
 failure = "0.1.6"
 failure_derive = "0.1.6"
 finch = { version = "0.3.0", optional = true }
-#fixedbitset = "0.2.0"
-fixedbitset = { git = "https://github.com/luizirber/fixedbitset", branch="with_capacity_and_blocks" }
+fixedbitset = "0.3.0"
 log = "0.4.8"
 md5 = "0.7.0"
 murmurhash3 = "0.0.5"

--- a/src/core/benches/nodegraph.rs
+++ b/src/core/benches/nodegraph.rs
@@ -1,0 +1,38 @@
+#[macro_use]
+extern crate criterion;
+
+use std::fs::File;
+use std::io::{BufWriter, Cursor, Read};
+
+use sourmash::sketch::nodegraph::Nodegraph;
+
+use criterion::Criterion;
+
+fn save_load(c: &mut Criterion) {
+    let mut data: Vec<u8> = vec![];
+    let mut f = File::open("../../tests/test-data/.sbt.v3/internal.0").unwrap();
+    let _ = f.read_to_end(&mut data);
+
+    let mut group = c.benchmark_group("save_load");
+
+    let mut reader = Cursor::new(data.clone());
+    let ng = Nodegraph::from_reader(&mut reader).unwrap();
+
+    group.bench_function("load nodegraph", |b| {
+        b.iter(|| {
+            let mut reader = Cursor::new(data.clone());
+            let _ng = Nodegraph::from_reader(&mut reader).unwrap();
+        });
+    });
+
+    group.bench_function("save nodegraph", |b| {
+        b.iter(|| {
+            let mut buf = Vec::new();
+            let mut writer = BufWriter::new(&mut buf);
+            ng.save_to_writer(&mut writer).unwrap();
+        });
+    });
+}
+
+criterion_group!(nodegraph, save_load);
+criterion_main!(nodegraph);

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -21,6 +21,14 @@ pub unsafe extern "C" fn nodegraph_free(ptr: *mut Nodegraph) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn nodegraph_buffer_free(ptr: *mut u8, insize: usize) {
+    if ptr.is_null() {
+        return;
+    }
+    Vec::from_raw_parts(ptr as *mut u8, insize, insize);
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn nodegraph_with_tables(
     ksize: usize,
     starting_size: usize,

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -2,8 +2,6 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::slice;
 
-use niffler::get_input;
-
 use crate::index::sbt::Update;
 use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::nodegraph::Nodegraph;
@@ -202,7 +200,7 @@ unsafe fn nodegraph_from_path(filename: *const c_char) -> Result<*mut Nodegraph>
         CStr::from_ptr(filename)
     };
 
-    let (mut input, _) = get_input(c_str.to_str()?)?;
+    let (mut input, _) = niffler::from_path(c_str.to_str()?)?;
     let ng = Nodegraph::from_reader(&mut input)?;
 
     Ok(Box::into_raw(Box::new(ng)))

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -226,3 +226,20 @@ unsafe fn nodegraph_save(ptr: *mut Nodegraph, filename: *const c_char) -> Result
     Ok(())
 }
 }
+
+ffi_fn! {
+unsafe fn nodegraph_to_buffer(ptr: *mut Nodegraph, size: *mut usize) -> Result<*const u8> {
+    let ng = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+
+    let mut st: Vec<u8> = Vec::new();
+    ng.save_to_writer(&mut st)?;
+
+    let b = st.into_boxed_slice();
+    *size = b.len();
+
+    Ok(Box::into_raw(b) as *const u8)
+}
+}

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -4,6 +4,7 @@ use std::slice;
 
 use niffler::get_input;
 
+use crate::index::sbt::Update;
 use crate::sketch::minhash::KmerMinHash;
 use crate::sketch::nodegraph::Nodegraph;
 
@@ -170,7 +171,7 @@ pub unsafe extern "C" fn nodegraph_update(ptr: *mut Nodegraph, optr: *mut Nodegr
         &mut *optr
     };
 
-    ng.update(ong);
+    ong.update(ng).unwrap();
 }
 
 #[no_mangle]
@@ -180,12 +181,12 @@ pub unsafe extern "C" fn nodegraph_update_mh(ptr: *mut Nodegraph, optr: *mut Kme
         &mut *ptr
     };
 
-    let ong = {
+    let mh = {
         assert!(!optr.is_null());
-        &mut *optr
+        &*optr
     };
 
-    ng.update_mh(ong);
+    mh.update(ng).unwrap();
 }
 
 ffi_fn! {

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -165,6 +165,21 @@ pub unsafe extern "C" fn nodegraph_update(ptr: *mut Nodegraph, optr: *mut Nodegr
     ng.update(ong);
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn nodegraph_update_mh(ptr: *mut Nodegraph, optr: *mut KmerMinHash) {
+    let ng = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+
+    let ong = {
+        assert!(!optr.is_null());
+        &mut *optr
+    };
+
+    ng.update_mh(ong);
+}
+
 ffi_fn! {
 unsafe fn nodegraph_from_path(filename: *const c_char) -> Result<*mut Nodegraph> {
     let c_str = {

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -115,13 +115,18 @@ pub unsafe extern "C" fn nodegraph_ksize(ptr: *mut Nodegraph) -> usize {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn nodegraph_tablesize(ptr: *mut Nodegraph) -> usize {
+pub unsafe extern "C" fn nodegraph_hashsizes(ptr: *mut Nodegraph, size: *mut usize) -> *const u64 {
     let ng = {
         assert!(!ptr.is_null());
         &mut *ptr
     };
 
-    ng.tablesize()
+    let st = ng.tablesizes();
+
+    let b = st.into_boxed_slice();
+    *size = b.len();
+
+    Box::into_raw(b) as *const u64
 }
 
 #[no_mangle]

--- a/src/core/src/ffi/nodegraph.rs
+++ b/src/core/src/ffi/nodegraph.rs
@@ -44,6 +44,22 @@ pub unsafe extern "C" fn nodegraph_count(ptr: *mut Nodegraph, h: u64) -> bool {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn nodegraph_count_kmer(ptr: *mut Nodegraph, kmer: *const c_char) -> bool {
+    let ng = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+
+    let c_str = {
+        assert!(!kmer.is_null());
+
+        CStr::from_ptr(kmer)
+    };
+
+    ng.count_kmer(c_str.to_bytes())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn nodegraph_get(ptr: *mut Nodegraph, h: u64) -> usize {
     let ng = {
         assert!(!ptr.is_null());
@@ -51,6 +67,22 @@ pub unsafe extern "C" fn nodegraph_get(ptr: *mut Nodegraph, h: u64) -> usize {
     };
 
     ng.get(h)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nodegraph_get_kmer(ptr: *mut Nodegraph, kmer: *const c_char) -> usize {
+    let ng = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+
+    let c_str = {
+        assert!(!kmer.is_null());
+
+        CStr::from_ptr(kmer)
+    };
+
+    ng.get_kmer(c_str.to_bytes())
 }
 
 #[no_mangle]

--- a/src/core/src/ffi/signature.rs
+++ b/src/core/src/ffi/signature.rs
@@ -4,7 +4,6 @@ use std::io;
 use std::os::raw::c_char;
 use std::slice;
 
-use niffler::get_input;
 use serde_json;
 
 use crate::cmd::ComputeParameters;
@@ -303,7 +302,7 @@ unsafe fn signatures_load_path(ptr: *const c_char,
       x => Some(x)
     };
 
-    let (mut input, _) = get_input(buf.to_str()?)?;
+    let (mut input, _) = niffler::from_path(buf.to_str()?)?;
     let filtered_sigs = Signature::load_signatures(&mut input, k, moltype, None)?;
 
     let ptr_sigs: Vec<*mut Signature> = filtered_sigs.into_iter().map(|x| {

--- a/src/core/src/index/sbt/mod.rs
+++ b/src/core/src/index/sbt/mod.rs
@@ -817,6 +817,8 @@ impl BinaryTree {
         next_round
     }
 
+    // Remove this when MSRV is >= 1.40
+    #[allow(clippy::mem_replace_with_default)]
     fn new_tree(mut left: BinaryTree, mut right: BinaryTree) -> BinaryTree {
         let in_common = if let BinaryTree::Internal(ref mut el1) = left {
             match right {

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -180,8 +180,8 @@ impl Nodegraph {
             if rem != 0 {
                 let mut cursor = [0u8; 4];
                 LittleEndian::write_u32(&mut cursor, count.as_slice()[div]);
-                for i in 0..rem {
-                    wtr.write_u8(cursor[i])?;
+                for item in cursor.iter().take(rem) {
+                    wtr.write_u8(*item)?;
                 }
             }
         }
@@ -222,9 +222,9 @@ impl Nodegraph {
                 rdr.read_u32_into::<LittleEndian>(&mut blocks)?;
 
                 let mut values = [0u8; 4];
-                for i in 0..rem {
+                for item in values.iter_mut().take(rem) {
                     let byte = rdr.read_u8().expect("error reading bins");
-                    values[i] = byte;
+                    *item = byte;
                 }
                 let mut block = vec![0u32; 1];
                 LittleEndian::read_u32_into(&values, &mut block);
@@ -255,7 +255,6 @@ impl Nodegraph {
     }
 
     pub fn n_occupied_bins(&self) -> usize {
-        //self.bs.iter().map(|x| x.count_ones(..)).sum::<usize>() / 8
         self.occupied_bins
     }
 
@@ -320,28 +319,28 @@ fn uniqify_rc(f: HashIntoType, r: HashIntoType) -> HashIntoType {
 }
 
 fn _hash(kmer: &[u8]) -> HashIntoType {
-    let k = kmer.len();
-    let mut h = 0;
-    let mut r = 0;
+    let ksize = kmer.len();
+    let mut hash = 0;
+    let mut rev = 0;
 
-    h |= twobit_repr(kmer[0]);
-    r |= twobit_comp(kmer[k - 1]);
+    hash |= twobit_repr(kmer[0]);
+    rev |= twobit_comp(kmer[ksize - 1]);
 
     let mut i = 1;
-    let mut j: isize = (k - 2) as isize;
+    let mut j: isize = (ksize - 2) as isize;
 
-    while i < k {
-        h = h << 2;
-        r = r << 2;
+    while i < ksize {
+        hash <<= 2;
+        rev <<= 2;
 
-        h |= twobit_repr(kmer[i]);
-        r |= twobit_comp(kmer[j as usize]);
+        hash |= twobit_repr(kmer[i]);
+        rev |= twobit_comp(kmer[j as usize]);
 
         i += 1;
         j -= 1;
     }
 
-    uniqify_rc(h, r)
+    uniqify_rc(hash, rev)
 }
 
 #[cfg(test)]

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -272,8 +272,8 @@ impl Nodegraph {
         Ok(Nodegraph::from_reader(&mut reader)?)
     }
 
-    pub fn tablesizes(&self) -> Vec<usize> {
-        self.bs.iter().map(|x| x.len()).collect()
+    pub fn tablesizes(&self) -> Vec<u64> {
+        self.bs.iter().map(|x| x.len() as u64).collect()
     }
 
     pub fn n_occupied_bins(&self) -> usize {

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -166,30 +166,16 @@ impl Nodegraph {
             let tablesize = count.len();
             wtr.write_u64::<LittleEndian>(tablesize as u64)?;
 
-            /*
             let byte_size = tablesize / 8 + 1;
             let (div, rem) = (byte_size / 4, byte_size % 4);
 
             // https://github.com/BurntSushi/byteorder/issues/155
-            //wtr.write_u32_from(&count.as_slice()[..div]);
-            */
-
-            for (i, chunk) in count.as_slice().iter().enumerate() {
-                let next = (i + 1) * 32;
-                if next <= tablesize {
-                    wtr.write_u32::<LittleEndian>(*chunk).unwrap()
-                } else {
-                    let rem = tablesize - (i * 32);
-                    let remainder = if rem % 8 != 0 { rem / 8 + 1 } else { rem / 8 };
-
-                    if remainder == 0 {
-                        wtr.write_u8(0).unwrap()
-                    } else {
-                        for pos in 0..remainder {
-                            let byte: u8 = (chunk.wrapping_shr(pos as u32 * 8) & 0xff) as u8;
-                            wtr.write_u8(byte).unwrap()
-                        }
-                    }
+            wtr.write_u32_from::<LittleEndian>(&count.as_slice()[..div])?;
+            if rem != 0 {
+                let mut cursor = [0u8; 4];
+                LittleEndian::write_u32(&mut cursor, count.as_slice()[div]);
+                for i in 0..rem {
+                    wtr.write_u8(cursor[i])?;
                 }
             }
         }

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -139,7 +139,7 @@ impl Nodegraph {
         let n_ht = self.bs.len();
         let occupancy = self.occupied_bins;
 
-        let fp_one = occupancy / min_size;
+        let fp_one = occupancy as f64 / min_size as f64;
         f64::powf(fp_one as f64, n_ht as f64)
     }
 

--- a/src/core/src/sketch/nodegraph.rs
+++ b/src/core/src/sketch/nodegraph.rs
@@ -115,6 +115,12 @@ impl Nodegraph {
             .sum();
     }
 
+    pub fn update_mh(&mut self, other: &KmerMinHash) {
+        for h in other.mins() {
+            self.count(h);
+        }
+    }
+
     pub fn expected_collisions(&self) -> f64 {
         let min_size = self.bs.iter().map(|x| x.len()).min().unwrap();
         let n_ht = self.bs.len();

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -2,7 +2,7 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
-from sourmash.nodegraph import Nodegraph
+from sourmash.nodegraph import Nodegraph, extract_nodegraph_info
 
 from . import sourmash_tst_utils as utils
 
@@ -32,8 +32,7 @@ def test_nodegraph_khmer_compare():
     sm_ng.count("CGA")
 
     assert sm_ng.ksize == khmer_ng.ksize()
-    assert sm_ng.n_tables == len(khmer_ng.hashsizes())
-    assert sm_ng.tablesize == sum(khmer_ng.hashsizes())
+    assert sm_ng.hashsizes == khmer_ng.hashsizes()
     assert sm_ng.get("ACG")
     assert sm_ng.get("TTA")
     assert sm_ng.get("CGA")
@@ -68,6 +67,10 @@ def test_nodegraph_same_file():
 
         f3.seek(0)
         kh_data = f3.read()
+
+        assert extract_nodegraph_info(f1.name) == extract_nodegraph_info(f2.name)
+        assert extract_nodegraph_info(f3.name) == extract_nodegraph_info(f2.name)
+        assert extract_nodegraph_info(f1.name) == extract_nodegraph_info(f3.name)
 
         assert sm_data == kh_data
         assert sm_data == kh_sm_data

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -1,4 +1,7 @@
+from tempfile import NamedTemporaryFile
+
 import pytest
+
 from sourmash.nodegraph import Nodegraph
 
 from . import sourmash_tst_utils as utils
@@ -15,15 +18,28 @@ def test_nodegraph_to_khmer_basic():
     assert sourmash_ng.ksize == khmer_sm_ng.ksize()
 
 
-def test_nodegraph_to_khmer_raw_tables():
+def test_nodegraph_same_file():
     khmer = pytest.importorskip('khmer')
 
     ng_file = utils.get_test_data('.sbt.v3/internal.0')
+    with open(ng_file, 'rb') as f:
+        ng_data = f.read()
 
     sourmash_ng = Nodegraph.load(ng_file)
     khmer_sm_ng = sourmash_ng.to_khmer_nodegraph()
 
     khmer_ng = khmer.load_nodegraph(ng_file)
 
-    for t1, t2 in zip(khmer_ng.get_raw_tables(), khmer_sm_ng.get_raw_tables()):
-        assert list(t1) == list(t2)
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        sourmash_ng.save(f1.name)
+        khmer_ng.save(f2.name)
+
+        f1.seek(0)
+        sm_data = f1.read()
+
+        f2.seek(0)
+        kh_data = f2.read()
+
+        assert sm_data == kh_data
+        assert ng_data == sm_data
+        assert ng_data == kh_data

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -44,6 +44,10 @@ def test_nodegraph_khmer_compare():
 
 def test_nodegraph_same_file():
     khmer = pytest.importorskip('khmer')
+    try:
+        load_nodegraph = khmer.load_nodegraph
+    except AttributeError:
+        load_nodegraph = khmer.Nodegraph.load
 
     ng_file = utils.get_test_data('.sbt.v3/internal.0')
     with open(ng_file, 'rb') as f:
@@ -52,7 +56,7 @@ def test_nodegraph_same_file():
     sourmash_ng = Nodegraph.load(ng_file)
     khmer_sm_ng = sourmash_ng.to_khmer_nodegraph()
 
-    khmer_ng = khmer.load_nodegraph(ng_file)
+    khmer_ng = load_nodegraph(ng_file)
 
     with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2, NamedTemporaryFile() as f3:
         sourmash_ng.save(f1.name)

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -1,0 +1,29 @@
+import pytest
+from sourmash.nodegraph import Nodegraph
+
+from . import sourmash_tst_utils as utils
+
+
+def test_nodegraph_to_khmer_basic():
+    khmer = pytest.importorskip('khmer')
+
+    ng_file = utils.get_test_data('.sbt.v3/internal.0')
+
+    sourmash_ng = Nodegraph.load(ng_file)
+    khmer_sm_ng = sourmash_ng.to_khmer_nodegraph()
+
+    assert sourmash_ng.ksize == khmer_sm_ng.ksize()
+
+
+def test_nodegraph_to_khmer_raw_tables():
+    khmer = pytest.importorskip('khmer')
+
+    ng_file = utils.get_test_data('.sbt.v3/internal.0')
+
+    sourmash_ng = Nodegraph.load(ng_file)
+    khmer_sm_ng = sourmash_ng.to_khmer_nodegraph()
+
+    khmer_ng = khmer.load_nodegraph(ng_file)
+
+    for t1, t2 in zip(khmer_ng.get_raw_tables(), khmer_sm_ng.get_raw_tables()):
+        assert list(t1) == list(t2)

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -18,6 +18,31 @@ def test_nodegraph_to_khmer_basic():
     assert sourmash_ng.ksize == khmer_sm_ng.ksize()
 
 
+def test_nodegraph_khmer_compare():
+    khmer = pytest.importorskip('khmer')
+
+    khmer_ng = khmer.Nodegraph(3, 23, 6)
+    khmer_ng.count("ACG")
+    khmer_ng.count("TTA")
+    khmer_ng.count("CGA")
+
+    sm_ng = Nodegraph(3, 23, 6)
+    sm_ng.count("ACG")
+    sm_ng.count("TTA")
+    sm_ng.count("CGA")
+
+    assert sm_ng.ksize == khmer_ng.ksize()
+    assert sm_ng.n_tables == len(khmer_ng.hashsizes())
+    assert sm_ng.tablesize == sum(khmer_ng.hashsizes())
+    assert sm_ng.get("ACG")
+    assert sm_ng.get("TTA")
+    assert sm_ng.get("CGA")
+
+    assert khmer_ng.get("ACG")
+    assert khmer_ng.get("TTA")
+    assert khmer_ng.get("CGA")
+
+
 def test_nodegraph_same_file():
     khmer = pytest.importorskip('khmer')
 

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -8,7 +8,7 @@ from . import sourmash_tst_utils as utils
 
 
 def test_nodegraph_to_khmer_basic():
-    khmer = pytest.importorskip('khmer')
+    pytest.importorskip('khmer')
 
     ng_file = utils.get_test_data('.sbt.v3/internal.0')
 
@@ -30,16 +30,23 @@ def test_nodegraph_same_file():
 
     khmer_ng = khmer.load_nodegraph(ng_file)
 
-    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2, NamedTemporaryFile() as f3:
         sourmash_ng.save(f1.name)
-        khmer_ng.save(f2.name)
+        khmer_sm_ng.save(f2.name)
+        khmer_ng.save(f3.name)
 
         f1.seek(0)
         sm_data = f1.read()
 
         f2.seek(0)
-        kh_data = f2.read()
+        kh_sm_data = f2.read()
+
+        f3.seek(0)
+        kh_data = f3.read()
 
         assert sm_data == kh_data
+        assert sm_data == kh_sm_data
+
         assert ng_data == sm_data
         assert ng_data == kh_data
+        assert ng_data == kh_sm_data

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -2,7 +2,7 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
-from sourmash.nodegraph import Nodegraph, extract_nodegraph_info
+from sourmash.nodegraph import Nodegraph, extract_nodegraph_info, calc_expected_collisions
 
 from . import sourmash_tst_utils as utils
 
@@ -15,7 +15,7 @@ def test_nodegraph_to_khmer_basic():
     sourmash_ng = Nodegraph.load(ng_file)
     khmer_sm_ng = sourmash_ng.to_khmer_nodegraph()
 
-    assert sourmash_ng.ksize == khmer_sm_ng.ksize()
+    assert sourmash_ng.ksize() == khmer_sm_ng.ksize()
 
 
 def test_nodegraph_khmer_compare():
@@ -31,8 +31,8 @@ def test_nodegraph_khmer_compare():
     sm_ng.count("TTA")
     sm_ng.count("CGA")
 
-    assert sm_ng.ksize == khmer_ng.ksize()
-    assert sm_ng.hashsizes == khmer_ng.hashsizes()
+    assert sm_ng.ksize() == khmer_ng.ksize()
+    assert sm_ng.hashsizes() == khmer_ng.hashsizes()
     assert sm_ng.get("ACG")
     assert sm_ng.get("TTA")
     assert sm_ng.get("CGA")
@@ -82,3 +82,20 @@ def test_nodegraph_same_file():
         assert ng_data == sm_data
         assert ng_data == kh_data
         assert ng_data == kh_sm_data
+
+
+def test_nodegraph_expected_collisions():
+    ng_file = utils.get_test_data('.sbt.v3/internal.0')
+
+    sourmash_ng = Nodegraph.load(ng_file)
+
+    assert calc_expected_collisions(sourmash_ng) == 3.412442571740036e-07
+
+
+def test_nodegraph_expected_collisions_error():
+    ng_file = utils.get_test_data('.sbt.v3/internal.0')
+
+    sourmash_ng = Nodegraph.load(ng_file)
+
+    with pytest.raises(SystemExit):
+        calc_expected_collisions(sourmash_ng, max_false_pos=1e-8)

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -73,6 +73,16 @@ def test_simple(n_children):
     print([ x.metadata for x in root.find(search_kmer, "CAAAA") ])
     print([ x.metadata for x in root.find(search_kmer, "GAAAA") ])
 
+    with utils.TempDirectory() as location:
+        root.save(os.path.join(location, 'demo'))
+        root = SBT.load(os.path.join(location, 'demo'))
+
+        for kmer in kmers:
+            new_result = {str(r) for r in root.find(search_kmer, kmer)}
+            print(*new_result, sep='\n')
+
+            assert new_result == {str(r) for r in search_kmer_in_list(kmer)}
+
 
 def test_longer_search(n_children):
     ksize = 5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py35,py36,py37
+envlist=py27,py35,py36,py37,py38
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* PYTHONDEVMODE
@@ -16,3 +16,9 @@ deps=
 commands=
   make coverage
   codecov --gcov-glob third-party
+
+[testenv::py38]
+extras =
+  test
+  doc
+  storage

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands=
   make coverage
   codecov --gcov-glob third-party
 
-[testenv::py38]
+[testenv:py38]
 extras =
   test
   doc


### PR DESCRIPTION
Main benefits:
- Read/write Nodegraph to/from buffers (no intermediate temporary files)
- Remove dep on khmer (but can still convert this Nodegraph into a khmer.Nodegraph)

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
