### PR TITLE
[WIP] bring back draff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,13 +46,21 @@ murmurhash3 = "0.0.5"
 serde = "1.0.103"
 serde_derive = "1.0.103"
 serde_json = "1.0.44"
-#ukhs = { git = "https://github.com/luizirber/ukhs", branch = "feature/alternative_backends", features = ["boomphf_mphf"], default-features = false}
 primal = "0.2.3"
-#pdatastructs = { git = "https://github.com/luizirber/pdatastructs.rs", branch = "succinct_wasm" }
 itertools = "0.8.2"
 typed-builder = "0.4.0"
 csv = "1.1.1"
 tempfile = "3.1.0"
+
+[dependencies.ukhs]
+git = "https://github.com/luizirber/ukhs"
+branch = "feature/alternative_backends"
+features = ["boomphf_mphf"]
+default-features = false
+
+[dependencies.pdatastructs]
+git = "https://github.com/luizirber/pdatastructs.rs"
+branch = "succinct_wasm"
 
 [dependencies.needletail]
 version = "0.3.2"

--- a/src/bin/smrs.rs
+++ b/src/bin/smrs.rs
@@ -12,10 +12,7 @@ use niffler::{get_output, CompressionFormat};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 
-/* FIXME bring back after succint-rs changes
 use sourmash::cmd::{count_unique, draff_compare, draff_search, draff_signature, prepare};
-*/
-use sourmash::cmd::prepare;
 
 use sourmash::index::linear::LinearIndex;
 use sourmash::index::sbt::scaffold;
@@ -334,7 +331,6 @@ fn main() -> Result<(), ExitFailure> {
     let m = App::from_yaml(yml).get_matches();
 
     match m.subcommand_name() {
-        /* FIXME bring back after succint-rs changes
         Some("draff") => {
             let cmd = m.subcommand_matches("draff").unwrap();
             let inputs = cmd
@@ -371,7 +367,6 @@ fn main() -> Result<(), ExitFailure> {
 
             count_unique(index)?;
         }
-        */
         Some("prepare") => {
             let cmd = m.subcommand_matches("prepare").unwrap();
             let index: &str = cmd.value_of("index").unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,21 +1,18 @@
 use failure::Error;
 
-use crate::index::MHBT;
-
-/* FIXME: bring back after boomphf changes
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use log::info;
 use needletail::parse_sequence_path;
 
-use crate::index::{Comparable, Index, MHBT};
 use crate::index::linear::LinearIndex;
 use crate::index::storage::{FSStorage, Storage};
+use crate::index::UKHSTree;
+use crate::index::{Comparable, Index, MHBT};
 use crate::signature::{Signature, SigsTrait};
-use crate::sketch::Sketch;
-use crate::index::{UKHSTree};
 use crate::sketch::ukhs::{FlatUKHS, UKHSTrait, UniqueUKHS};
+use crate::sketch::Sketch;
 
 pub fn draff_index(sig_files: Vec<&str>, outfile: &str) -> Result<(), Error> {
     let storage: Rc<dyn Storage> = Rc::new(
@@ -140,9 +137,7 @@ pub fn draff_signature(files: Vec<&str>, k: usize, w: usize) -> Result<(), Error
 
     Ok(())
 }
-*/
 
-/* FIXME bring back after succint-rs changes
 pub fn count_unique(index_path: &str) -> Result<(), Error> {
     let index = MHBT::from_path(index_path)?;
 
@@ -171,7 +166,6 @@ pub fn count_unique(index_path: &str) -> Result<(), Error> {
 
     Ok(())
 }
-*/
 
 pub fn prepare(index_path: &str) -> Result<(), Error> {
     let mut index = MHBT::from_path(index_path)?;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -27,11 +27,9 @@ use crate::signature::Signature;
 use crate::sketch::nodegraph::Nodegraph;
 use crate::sketch::Sketch;
 
-/* FIXME: bring back after boomphf changes
 use crate::sketch::ukhs::{FlatUKHS, UKHSTrait};
-pub type UKHSTree = SBT<Node<FlatUKHS>, Signature>;
-*/
 
+pub type UKHSTree = SBT<Node<FlatUKHS>, Signature>;
 pub type MHBT = SBT<Node<Nodegraph>, Signature>;
 
 /* FIXME: bring back after MQF works on macOS and Windows
@@ -267,13 +265,11 @@ impl Comparable<SigStore<Signature>> for SigStore<Signature> {
             }
         }
 
-        /* FIXME: bring back after boomphf changes
         if let Sketch::UKHS(mh) = &ng.signatures[0] {
             if let Sketch::UKHS(omh) = &ong.signatures[0] {
                 return 1. - mh.distance(&omh);
             }
         }
-        */
 
         unimplemented!()
     }
@@ -305,13 +301,11 @@ impl Comparable<Signature> for Signature {
             }
         }
 
-        /* FIXME: bring back after boomphf changes
         if let Sketch::UKHS(mh) = &self.signatures[0] {
             if let Sketch::UKHS(omh) = &other.signatures[0] {
                 return 1. - mh.distance(&omh);
             }
         }
-        */
 
         unimplemented!()
     }

--- a/src/index/sbt/mod.rs
+++ b/src/index/sbt/mod.rs
@@ -1,8 +1,6 @@
 pub mod mhbt;
 
-/* FIXME: bring back after boomphf changes
 pub mod ukhs;
-*/
 
 /* FIXME: bring back after MQF works on macOS and Windows
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -12,5 +12,5 @@ use crate::sketch::ukhs::FlatUKHS;
 #[serde(untagged)]
 pub enum Sketch {
     MinHash(KmerMinHash),
-    UKHS(FlatUKHS), // FIXME
+    UKHS(FlatUKHS),
 }

--- a/src/sketch/ukhs.rs
+++ b/src/sketch/ukhs.rs
@@ -1,41 +1,3 @@
-use failure::Error;
-use serde_derive::{Deserialize, Serialize};
-
-use crate::signature::SigsTrait;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FlatUKHS {}
-
-impl FlatUKHS {
-    pub fn md5sum(&self) -> String {
-        unimplemented!()
-    }
-}
-
-impl SigsTrait for FlatUKHS {
-    fn size(&self) -> usize {
-        unimplemented!()
-    }
-
-    fn to_vec(&self) -> Vec<u64> {
-        unimplemented!()
-    }
-
-    fn ksize(&self) -> usize {
-        unimplemented!()
-    }
-
-    fn check_compatible(&self, _other: &Self) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn add_sequence(&mut self, _seq: &[u8], _force: bool) -> Result<(), Error> {
-        unimplemented!()
-    }
-}
-
-/* FIXME bring back after succint-rs changes
-
 use std::f64::consts::PI;
 use std::fs::File;
 use std::hash::BuildHasherDefault;
@@ -43,13 +5,18 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::mem;
 use std::path::Path;
 
+use failure::Error;
 use itertools::Itertools;
 use pdatastructs::hyperloglog::HyperLogLog;
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+use serde_derive::Deserialize;
 use ukhs;
 
 use crate::errors::SourmashError;
 use crate::index::sbt::NoHashHasher;
 use crate::index::storage::ToWriter;
+use crate::signature::SigsTrait;
 use crate::sketch::nodegraph::Nodegraph;
 
 #[derive(Clone)]
@@ -629,4 +596,3 @@ mod test {
         }
     }
 }
-*/


### PR DESCRIPTION
same as #800, but problem here is `1)`: if the rust crate is publishable (long story short: a crate can only be published if all dependencies are also in crates.io)

Depends on:
- [ ] Merging https://github.com/tov/succinct-rs/pull/9
- [ ] bumping `pdatastructs` to one with :point_up: updated
- [ ] make rust-boomphf compatible with bbhash (info: https://github.com/luizirber/ukhs/issues/1)

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
