### PR TITLE
fix mem leak in get_mins

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -79,6 +79,8 @@ void kmerminhash_enable_abundance(KmerMinHash *ptr);
 
 void kmerminhash_free(KmerMinHash *ptr);
 
+void kmerminhash_slice_free(uint64_t *ptr, uintptr_t insize);
+
 uint64_t kmerminhash_get_abund_idx(KmerMinHash *ptr, uint64_t idx);
 
 const uint64_t *kmerminhash_get_abunds(KmerMinHash *ptr);

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -234,9 +234,13 @@ class MinHash(RustObject):
 
         if with_abundance and self.track_abundance:
             abunds_ptr = self._methodcall(lib.kmerminhash_get_abunds)
-            return dict(zip(ffi.unpack(mins_ptr, size), ffi.unpack(abunds_ptr, size)))
+            result = dict(zip(ffi.unpack(mins_ptr, size), ffi.unpack(abunds_ptr, size)))
+            lib.kmerminhash_slice_free(abunds_ptr, size)
         else:
-            return ffi.unpack(mins_ptr, size)
+            result = ffi.unpack(mins_ptr, size)
+
+        lib.kmerminhash_slice_free(mins_ptr, size)
+        return result
 
     def get_hashes(self):
         return self.get_mins()

--- a/src/ffi/minhash.rs
+++ b/src/ffi/minhash.rs
@@ -50,6 +50,14 @@ pub unsafe extern "C" fn kmerminhash_free(ptr: *mut KmerMinHash) {
     Box::from_raw(ptr);
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn kmerminhash_slice_free(ptr: *mut u64, insize: usize) {
+    if ptr.is_null() {
+        return;
+    }
+    Vec::from_raw_parts(ptr as *mut u64, insize, insize);
+}
+
 ffi_fn! {
 unsafe fn kmerminhash_add_sequence(ptr: *mut KmerMinHash, sequence: *const c_char, force: bool) ->
     Result<()> {
@@ -165,7 +173,8 @@ unsafe fn kmerminhash_get_abunds(ptr: *mut KmerMinHash) -> Result<*const u64> {
         let output = abunds.clone();
         Ok(Box::into_raw(output.into_boxed_slice()) as *const u64)
     } else {
-        Ok(ptr::null())
+        //throw error, can't get abund
+        unimplemented!()
     }
 }
 }

--- a/src/ffi/minhash.rs
+++ b/src/ffi/minhash.rs
@@ -1,6 +1,5 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use std::ptr;
 use std::slice;
 
 use crate::errors::SourmashError;


### PR DESCRIPTION
Oops. It was particularly bad with `gather`...

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
