### PR TITLE
[MRG] Move similarity with abundance into Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,9 +115,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
+          python -m pip install -e .[test]
+        env:
+          'CARGO_INCREMENTAL': '0'
+          'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
 
-      - name: Run tests
+      - name: Run Rust tests
         uses: actions-rs/cargo@v1
         with:
           command: test
@@ -126,15 +129,26 @@ jobs:
           'CARGO_INCREMENTAL': '0'
           'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
 
+      - name: Run Python tests
+        run: python -m pytest --cov=. --cov-report=xml
+
       - name: Collect coverage and generate report with grcov
-        uses: actions-rs/grcov@v0.1.4
+        uses: actions-rs/grcov@5fe6a05253e7b682e01c8097b6e3ea4ce1aaeacc
         id: coverage
 
-      - name: Upload coverage to codecov
+      - name: Upload Python coverage to codecov
+        uses: codecov/codecov-action@v1.0.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: pytests
+
+      - name: Upload Rust coverage to codecov
         uses: codecov/codecov-action@v1.0.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ${{ steps.coverage.outputs.report }}
+          flags: rusttests
 
   lints:
     name: Lints

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,14 +137,14 @@ jobs:
         id: coverage
 
       - name: Upload Python coverage to codecov
-        uses: codecov/codecov-action@v1.0.3
+        uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: pytests
 
       - name: Upload Rust coverage to codecov
-        uses: codecov/codecov-action@v1.0.3
+        uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,6 +142,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: pytests
+          fail_ci_if_error: true
 
       - name: Upload Rust coverage to codecov
         uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257
@@ -149,6 +150,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ${{ steps.coverage.outputs.report }}
           flags: rusttests
+          fail_ci_if_error: true
 
   lints:
     name: Lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,4 @@ harness = false
 [[bin]]
 name = "smrs"
 path = "src/bin/smrs.rs"
+bench = false

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -67,6 +67,8 @@ void kmerminhash_add_word(KmerMinHash *ptr, const char *word);
 
 double kmerminhash_compare(KmerMinHash *ptr, const KmerMinHash *other);
 
+double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance);
+
 double kmerminhash_containment_ignore_maxhash(KmerMinHash *ptr, const KmerMinHash *other);
 
 uint64_t kmerminhash_count_common(KmerMinHash *ptr, const KmerMinHash *other);
@@ -108,6 +110,8 @@ uint32_t kmerminhash_ksize(KmerMinHash *ptr);
 uint64_t kmerminhash_max_hash(KmerMinHash *ptr);
 
 void kmerminhash_merge(KmerMinHash *ptr, const KmerMinHash *other);
+
+bool kmerminhash_is_compatible(const KmerMinHash *ptr, const KmerMinHash *other);
 
 void kmerminhash_mins_push(KmerMinHash *ptr, uint64_t val);
 

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -422,6 +422,9 @@ class MinHash(RustObject):
         See https://en.wikipedia.org/wiki/Cosine_similarity
         """
 
+        if not (self.track_abundance and other.track_abundance) or ignore_abundance:
+            return self.jaccard(other)
+        else:
             return self._methodcall(lib.kmerminhash_similarity,
                                     other._get_objptr(),
                                     ignore_abundance)

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -405,9 +405,7 @@ class MinHash(RustObject):
             err = "must have same num: {} != {}".format(self.num, other.num)
             raise TypeError(err)
         return self._methodcall(lib.kmerminhash_compare, other._get_objptr())
-
-    def jaccard(self, other):
-        return self.compare(other)
+    jaccard = compare
 
     def similarity(self, other, ignore_abundance=False):
         """Calculate similarity of two sketches.
@@ -424,22 +422,12 @@ class MinHash(RustObject):
         See https://en.wikipedia.org/wiki/Cosine_similarity
         """
 
-        # if either signature is flat, calculate Jaccard only.
-        if not (self.track_abundance and other.track_abundance) or ignore_abundance:
-            return self.jaccard(other)
-        else:
-            # can we merge? if not, raise exception.
-            aa = copy.copy(self)
-            aa.merge(other)
+            return self._methodcall(lib.kmerminhash_similarity,
+                                    other._get_objptr(),
+                                    ignore_abundance)
 
-            a = self.get_mins(with_abundance=True)
-            b = other.get_mins(with_abundance=True)
-
-            prod = dotproduct(a, b)
-            prod = min(1.0, prod)
-
-            distance = 2 * math.acos(prod) / math.pi
-            return 1.0 - distance
+    def is_compatible(self, other):
+        return self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr())
 
     def contained_by(self, other):
         """\

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -67,29 +67,6 @@ def hash_murmur(kmer, seed=MINHASH_DEFAULT_SEED):
     return lib.hash_murmur(to_bytes(kmer), seed)
 
 
-def dotproduct(a, b, normalize=True):
-    """
-    Compute the dot product of two dictionaries {k: v} where v is
-    abundance.
-    """
-
-    if normalize:
-        norm_a = math.sqrt(sum([x * x for x in a.values()]))
-        norm_b = math.sqrt(sum([x * x for x in b.values()]))
-
-        if norm_a == 0.0 or norm_b == 0.0:
-            return 0.0
-    else:
-        norm_a = 1.0
-        norm_b = 1.0
-
-    prod = 0.0
-    for k, abundance in a.items():
-        prod += (float(abundance) / norm_a) * (b.get(k, 0) / norm_b)
-
-    return prod
-
-
 class MinHash(RustObject):
     def __init__(
         self,
@@ -422,6 +399,7 @@ class MinHash(RustObject):
         See https://en.wikipedia.org/wiki/Cosine_similarity
         """
 
+        # if either signature is flat, calculate Jaccard only.
         if not (self.track_abundance and other.track_abundance) or ignore_abundance:
             return self.jaccard(other)
         else:

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -126,11 +126,14 @@ def compare(args):
         sys.exit(-1)
 
     # if using --scaled, downsample appropriately
+    printed_scaled_msg = False
     if is_scaled:
         max_scaled = max(s.minhash.scaled for s in siglist)
         for s in siglist:
             if s.minhash.scaled != max_scaled:
-                notify('downsampling to scaled value of {}'.format(max_scaled))
+                if not printed_scaled_msg:
+                    notify('downsampling to scaled value of {}'.format(max_scaled))
+                    printed_scaled_msg = True
                 s.minhash = s.minhash.downsample_scaled(max_scaled)
 
     if len(siglist) == 0:

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -128,9 +128,10 @@ def compare(args):
     # if using --scaled, downsample appropriately
     if is_scaled:
         max_scaled = max(s.minhash.scaled for s in siglist)
-        notify('downsampling to scaled value of {}'.format(max_scaled))
         for s in siglist:
-            s.minhash = s.minhash.downsample_scaled(max_scaled)
+            if s.minhash.scaled != max_scaled:
+                notify('downsampling to scaled value of {}'.format(max_scaled))
+                s.minhash = s.minhash.downsample_scaled(max_scaled)
 
     if len(siglist) == 0:
         error('no signatures!')

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,9 @@ pub enum SourmashError {
     #[fail(display = "internal error: {}", message)]
     Internal { message: String },
 
+    #[fail(display = "must have same num: {} != {}", n1, n2)]
+    MismatchNum { n1: u32, n2: u32 },
+
     #[fail(display = "different ksizes cannot be compared")]
     MismatchKSizes,
 
@@ -53,6 +56,7 @@ pub enum SourmashErrorCode {
     MismatchSeed = 1_04,
     MismatchSignatureType = 1_05,
     NonEmptyMinHash = 1_06,
+    MismatchNum = 1_07,
     // Input sequence errors
     InvalidDNA = 11_01,
     InvalidProt = 11_02,
@@ -76,6 +80,7 @@ impl SourmashErrorCode {
             if let Some(err) = cause.downcast_ref::<SourmashError>() {
                 return match err {
                     SourmashError::Internal { .. } => SourmashErrorCode::Internal,
+                    SourmashError::MismatchNum { .. } => SourmashErrorCode::MismatchNum,
                     SourmashError::MismatchKSizes => SourmashErrorCode::MismatchKSizes,
                     SourmashError::MismatchDNAProt => SourmashErrorCode::MismatchDNAProt,
                     SourmashError::MismatchMaxHash => SourmashErrorCode::MismatchMaxHash,

--- a/src/ffi/minhash.rs
+++ b/src/ffi/minhash.rs
@@ -382,6 +382,23 @@ unsafe fn kmerminhash_merge(ptr: *mut KmerMinHash, other: *const KmerMinHash) ->
 }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn kmerminhash_is_compatible(
+    ptr: *const KmerMinHash,
+    other: *const KmerMinHash,
+) -> bool {
+    let mh = {
+        assert!(!ptr.is_null());
+        &*ptr
+    };
+    let other_mh = {
+        assert!(!other.is_null());
+        &*other
+    };
+
+    mh.check_compatible(other_mh).is_ok()
+}
+
 ffi_fn! {
 unsafe fn kmerminhash_add_from(ptr: *mut KmerMinHash, other: *const KmerMinHash)
     -> Result<()> {
@@ -462,5 +479,21 @@ unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash)
     };
 
     mh.compare(other_mh)
+}
+}
+
+ffi_fn! {
+unsafe fn kmerminhash_similarity(ptr: *mut KmerMinHash, other: *const KmerMinHash, ignore_abundance: bool)
+    -> Result<f64> {
+    let mh = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    let other_mh = {
+       assert!(!other.is_null());
+       &*other
+    };
+
+    mh.similarity(other_mh, ignore_abundance)
 }
 }

--- a/src/sketch/minhash.rs
+++ b/src/sketch/minhash.rs
@@ -504,15 +504,10 @@ impl KmerMinHash {
             let mut prod = 0;
             let mut other_iter = other.mins.iter().enumerate();
             let mut next_hash = other_iter.next();
-            let mut a_sq = 0;
+            let a_sq: u64 = abunds.iter().map(|a| (a * a)).sum();
             let b_sq: u64 = other_abunds.iter().map(|a| (a * a)).sum();
 
             for (i, hash) in self.mins.iter().enumerate() {
-                // Calling `get_unchecked` here is safe since `i` is a valid index
-                // (`i` came from a valid iterator call)
-                unsafe {
-                    a_sq += abunds.get_unchecked(i) * abunds.get_unchecked(i);
-                }
                 while let Some((j, k)) = next_hash {
                     match k.cmp(hash) {
                         Ordering::Less => next_hash = other_iter.next(),

--- a/src/sketch/minhash.rs
+++ b/src/sketch/minhash.rs
@@ -508,6 +508,8 @@ impl KmerMinHash {
             let b_sq: u64 = other_abunds.iter().map(|a| (a * a)).sum();
 
             for (i, hash) in self.mins.iter().enumerate() {
+                // Calling `get_unchecked` here is safe since `i` is a valid index
+                // (`i` came from a valid iterator call)
                 unsafe {
                     a_sq += abunds.get_unchecked(i) * abunds.get_unchecked(i);
                 }
@@ -518,6 +520,9 @@ impl KmerMinHash {
                                 next_hash = other_iter.next();
                                 continue;
                             } else if k == hash {
+                                // Calling `get_unchecked` here is safe since
+                                // both `i` and `j` are valid indices
+                                // (`i` and `j` came from valid iterator calls)
                                 unsafe {
                                     prod += abunds.get_unchecked(i) * other_abunds.get_unchecked(j);
                                 }

--- a/src/sketch/minhash.rs
+++ b/src/sketch/minhash.rs
@@ -513,23 +513,19 @@ impl KmerMinHash {
                 unsafe {
                     a_sq += abunds.get_unchecked(i) * abunds.get_unchecked(i);
                 }
-                loop {
-                    match next_hash {
-                        Some((j, k)) => {
-                            if k < hash {
-                                next_hash = other_iter.next();
-                                continue;
-                            } else if k == hash {
-                                // Calling `get_unchecked` here is safe since
-                                // both `i` and `j` are valid indices
-                                // (`i` and `j` came from valid iterator calls)
-                                unsafe {
-                                    prod += abunds.get_unchecked(i) * other_abunds.get_unchecked(j);
-                                }
+                while let Some((j, k)) = next_hash {
+                    match k.cmp(hash) {
+                        Ordering::Less => next_hash = other_iter.next(),
+                        Ordering::Equal => {
+                            // Calling `get_unchecked` here is safe since
+                            // both `i` and `j` are valid indices
+                            // (`i` and `j` came from valid iterator calls)
+                            unsafe {
+                                prod += abunds.get_unchecked(i) * other_abunds.get_unchecked(j);
                             }
                             break;
                         }
-                        None => break,
+                        Ordering::Greater => break,
                     }
                 }
             }

--- a/tests/minhash.rs
+++ b/tests/minhash.rs
@@ -67,8 +67,8 @@ fn compare() {
 
 #[test]
 fn similarity() -> Result<(), Box<dyn std::error::Error>> {
-    let mut a = KmerMinHash::new(5, 20, HashFunctions::murmur64_DNA, 42, 0, true);
-    let mut b = KmerMinHash::new(5, 20, HashFunctions::murmur64_DNA, 42, 0, true);
+    let mut a = KmerMinHash::new(5, 20, HashFunctions::murmur64_hp, 42, 0, true);
+    let mut b = KmerMinHash::new(5, 20, HashFunctions::murmur64_hp, 42, 0, true);
 
     a.add_hash(1);
     b.add_hash(1);
@@ -96,6 +96,30 @@ fn similarity_2() -> Result<(), Box<dyn std::error::Error>> {
         "{}",
         a.similarity(&b, false)?
     );
+
+    Ok(())
+}
+
+#[test]
+fn similarity_3() -> Result<(), Box<dyn std::error::Error>> {
+    let mut a = KmerMinHash::new(5, 20, HashFunctions::murmur64_dayhoff, 42, 0, true);
+    let mut b = KmerMinHash::new(5, 20, HashFunctions::murmur64_dayhoff, 42, 0, true);
+
+    a.add_hash(1);
+    a.add_hash(1);
+    a.add_hash(5);
+    a.add_hash(5);
+
+    b.add_hash(1);
+    b.add_hash(2);
+    b.add_hash(3);
+    b.add_hash(4);
+
+    assert!((a.similarity(&a, false)? - 1.0).abs() < 0.001);
+    assert!((a.similarity(&b, false)? - 0.23).abs() < 0.001);
+
+    assert!((a.similarity(&a, true)? - 1.0).abs() < 0.001);
+    assert!((a.similarity(&b, true)? - 0.2).abs() < 0.001);
 
     Ok(())
 }

--- a/tests/minhash.rs
+++ b/tests/minhash.rs
@@ -66,6 +66,21 @@ fn compare() {
 }
 
 #[test]
+fn similarity() -> Result<(), Box<dyn std::error::Error>> {
+    let mut a = KmerMinHash::new(5, 20, HashFunctions::murmur64_DNA, 42, 0, true);
+    let mut b = KmerMinHash::new(5, 20, HashFunctions::murmur64_DNA, 42, 0, true);
+
+    a.add_hash(1);
+    b.add_hash(1);
+    b.add_hash(2);
+
+    assert!((a.similarity(&a, false)? - 1.0).abs() < 0.001);
+    assert!((a.similarity(&b, false)? - 0.5).abs() < 0.001);
+
+    Ok(())
+}
+
+#[test]
 fn dayhoff() {
     let mut a = KmerMinHash::new(10, 6, HashFunctions::murmur64_dayhoff, 42, 0, false);
     let mut b = KmerMinHash::new(10, 6, HashFunctions::murmur64_protein, 42, 0, false);

--- a/tests/minhash.rs
+++ b/tests/minhash.rs
@@ -81,6 +81,26 @@ fn similarity() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn similarity_2() -> Result<(), Box<dyn std::error::Error>> {
+    let mut a = KmerMinHash::new(5, 5, HashFunctions::murmur64_DNA, 42, 0, true);
+    let mut b = KmerMinHash::new(5, 5, HashFunctions::murmur64_DNA, 42, 0, true);
+
+    a.add_sequence(b"ATGGA", false)?;
+    a.add_sequence(b"GGACA", false)?;
+
+    a.add_sequence(b"ATGGA", false)?;
+    b.add_sequence(b"ATGGA", false)?;
+
+    assert!(
+        (a.similarity(&b, false)? - 0.705).abs() < 0.001,
+        "{}",
+        a.similarity(&b, false)?
+    );
+
+    Ok(())
+}
+
+#[test]
 fn dayhoff() {
     let mut a = KmerMinHash::new(10, 6, HashFunctions::murmur64_dayhoff, 42, 0, false);
     let mut b = KmerMinHash::new(10, 6, HashFunctions::murmur64_protein, 42, 0, false);

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -45,7 +45,6 @@ import sourmash
 from sourmash._minhash import (
     MinHash,
     hash_murmur,
-    dotproduct,
     get_scaled_for_max_hash,
     get_max_hash_for_scaled,
 )
@@ -1000,47 +999,6 @@ def test_reviving_minhash():
 
     for m in mins:
         mh.add_hash(m)
-
-
-def test_dotproduct_1():
-    a = {'x': 1}
-    assert dotproduct(a, a, normalize=True) == 1.0
-
-    a = {'x': 1}
-    b = {'x': 1}
-    assert dotproduct(a, b, normalize=True) == 1.0
-
-    c = {'x': 1, 'y': 1}
-    prod = dotproduct(c, c, normalize=True)
-    assert round(prod, 2) == 1.0
-
-    # check a.c => 45 degree angle
-    a = {'x': 1}
-    c = {'x': 1, 'y': 1}
-
-    angle = 45
-    rad = math.radians(angle)
-    cosval = math.cos(rad)
-    prod = dotproduct(a, c, normalize=True)
-    assert round(prod, 2) == 0.71
-    assert round(cosval, 2) == round(prod, 2)
-
-    c = {'x': 1, 'y': 1}
-    d = {'x': 1, 'y': 1}
-    prod = dotproduct(c, d, normalize=True)
-    assert round(prod, 2) == 1.0
-
-    a = {'x': 1}
-    e = {'y': 1}
-    assert dotproduct(a, e, normalize=True) == 0.0
-
-
-def test_dotproduct_zeroes():
-    a = {'x': 1}
-    b = {}
-
-    assert dotproduct(a, b) == 0.0
-    assert dotproduct(b, a) == 0.0
 
 
 def test_mh_copy_and_clear(track_abundance):


### PR DESCRIPTION
Similarity calculations had to call `.merge()` (to check if minhashes are compatible), `.get_mins()` (which copies a lot of data) and calculate the `dotproduct` in Python, so moving this into Rust makes things... faster. I used [sourmash_benchmarks][0] to run a compare test, and for that benchmark (using 380 signatures from the genbank k51 SBT) it takes 30s now (down from 90s in `2.3.1`).

[0]: https://github.com/luizirber/sourmash_resources/blob/4ad31d87866049e1d291b7651af85c2e473309ec/README.md#compare

I also changed `compare` to avoid downsampling a signature if it is already at the right scaled.

(Incidentally, also avoids calling `.merge()` and leaking memory :see_no_evil:)

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
