### PR TITLE
[WIP] Add a 'display_lineage' function to lca_utils.py

### DIFF
--- a/sourmash/lca/lca_utils.py
+++ b/sourmash/lca/lca_utils.py
@@ -101,6 +101,12 @@ def zip_lineage(lineage, include_strain=True, truncate_empty=False):
     return row
 
 
+def display_lineage(lineage, include_strain=True, truncate_empty=True):
+    return ";".join(zip_lineage(lineage,
+                                include_strain=include_strain,
+                                truncate_empty=truncate_empty))
+
+
 # filter function toreplace blank/na/null with 'unassigned'
 filter_null = lambda x: 'unassigned' if x.strip() in \
   ('[Blank]', 'na', 'null', '') else x


### PR DESCRIPTION
This is a convenience function to do `";".join(lca_utils.zip_lineage(lineage))`.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
