### PR TITLE
Fix read the docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+conda:
+  environment: doc/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,3 +10,12 @@ sphinx:
 
 conda:
   environment: doc/environment.yml
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc
+  system_packages: true

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,10 +1,5 @@
 channels:
   - conda-forge
-  - bioconda
   - defaults
 dependencies:
   - rust
-  - pip
-  - python=3.7
-  - pip:
-    - -e ../.[doc]

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,0 +1,10 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - rust
+  - pip
+  - python=3.7
+  - pip:
+    - -e ../.[doc]

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,6 +1,5 @@
 # Releasing a new version of sourmash
 
-
 These are adapted from the khmer release docs, originally written by
 Michael Crusoe.
 
@@ -10,6 +9,9 @@ Remember to update release numbers/RC in:
 
 ## Testing a release
 
+ 0\. First things first: check if Read the Docs is building properly for
+ master. Build on https://readthedocs.org/projects/sourmash/builds/ should be
+ passing, and also check if https://sourmash.readthedocs.io/en/latest/ is updated.
 
  1\. The below should be done in a clean checkout:
 ```
@@ -19,7 +21,7 @@ cd sourmash
 ```
 2\. Set your new version number and release candidate (you might want to check https://github.com/dib-lab/sourmash/releases for next version number):
 ```
-new_version=1.0.0
+new_version=3.0.0
 rc=rc1
 ```
  and then tag the release candidate with the new version number prefixed by


### PR DESCRIPTION
This PR uses the [conda support][0] to install Rust and fix the build errors in Read the Docs.

(Also add step 0 to release docs: check if docs are building before cutting a new release!)

[0]: https://docs.readthedocs.io/en/stable/guides/conda.html

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
