### PR TITLE
[MRG] set up publishing workflow for NPM and crates.io

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,6 +195,21 @@ jobs:
       - name: run wasm-pack
         run: wasm-pack build src/core -d ../../pkg
 
+      # Publish to NPM on tags
+      - name: Prepare node for NPM publishing
+        uses: actions/setup-node@v1
+        if: startsWith(github.ref, 'refs/tags/r')
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
+      # Publish to NPM on tags
+      - name: Publish to NPM
+        run: '(cd pkg && npm publish)'
+        if: startsWith(github.ref, 'refs/tags/r')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   wasm32-wasi:
     name: Run tests under wasm32-wasi
     runs-on: ubuntu-latest
@@ -245,6 +260,22 @@ jobs:
         with:
           command: publish
           args: --dry-run --manifest-path src/core/Cargo.toml
+
+      # Login to crates.io on tags
+      - name: login to crates.io
+        uses: actions-rs/cargo@v1
+        if: startsWith(github.ref, 'refs/tags/r')
+        with:
+          command: login
+          args: ${{ secrets.CRATES_IO_TOKEN }}
+
+      # Publish to crates.io on tags
+      - name: Publish to crates.io
+        uses: actions-rs/cargo@v1
+        if: startsWith(github.ref, 'refs/tags/r')
+        with:
+          command: publish
+          args: --manifest-path src/core/Cargo.toml
 
   minimum_rust_version:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,13 @@ SETUP_METADATA = {
     "setup_requires": [
         "setuptools>=38.6.0",
         "milksnake",
-        "setuptools_scm",
+        "setuptools_scm>=3.2.0",
         "setuptools_scm_git_archive",
     ],
-    "use_scm_version": {"write_to": "sourmash/version.py"},
+    "use_scm_version": {
+        "write_to": "sourmash/version.py",
+        "git_describe_command": "git describe --dirty --tags --long --match v* --first-parent"
+    },
     "zip_safe": False,
     "platforms": "any",
     "extras_require": {

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -3,11 +3,12 @@ name = "sourmash"
 version = "0.3.0"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 description = "MinHash sketches for genomic data"
-repository = "https://github.com/luizirber/sourmash-rust"
+repository = "https://github.com/dib-lab/sourmash"
 keywords = ["minhash", "bioinformatics"]
 categories = ["science", "algorithms", "data-structures"]
 license = "BSD-3-Clause"
 edition = "2018"
+readme = "README.md"
 autoexamples = false
 autobins = false
 


### PR DESCRIPTION
Set up GitHub Actions to publish the Rust crate to [crates.io][0] when there is a new tag. It also publishes the `wasm-pack` generated package (webassembly) to [NPM][1].

I also started using `r` as the prefix for Rust releases, like [`r0.3.0`][2]. This doesn't conflict with the sourmash regular versioning (which starts with `v`, as in [`v3.0.0`][3]).

And... using `r` triggered an error for calculating the Python version :rofl: 
So there is a [fix to `setuptools_scm`][4] to account only for `v` tags when calculating versions.

[0]: https://crates.io/crates/sourmash
[1]: https://www.npmjs.com/package/sourmash
[2]: https://github.com/dib-lab/sourmash/releases/tag/r0.3.0
[3]: https://github.com/dib-lab/sourmash/releases/tag/v3.0.0
[4]: https://github.com/pypa/setuptools_scm/pull/316

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
