### PR TITLE
use python 3.7 in RTD build

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,3 +3,4 @@ channels:
   - defaults
 dependencies:
   - rust
+  - python =3.7


### PR DESCRIPTION
I noticed the RTD build failed, and it was because Python 3.8 was being used. Since `khmer` (and many other projects) don't have 3.8 wheels yet, it goes over the time limit that RTD imposes (15 minutes) because it has to build everything from source.

Using 3.7 brings [build time down to 403 seconds][0], which still leave enough time to avoid hitting the limit in the near future.

[0]: https://readthedocs.org/projects/sourmash/builds/10210318/

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
