### PR TITLE
Do add_many in Rust, use it in LCA _signatures

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -93,6 +93,8 @@ uint64_t kmerminhash_get_min_idx(KmerMinHash *ptr, uint64_t idx);
 
 const uint64_t *kmerminhash_get_mins(KmerMinHash *ptr);
 
+void kmerminhash_add_many(KmerMinHash *ptr, const uint64_t *hashes_ptr, uintptr_t insize);
+
 uintptr_t kmerminhash_get_mins_size(KmerMinHash *ptr);
 
 HashFunctions kmerminhash_hash_function(KmerMinHash *ptr);

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -68,6 +68,8 @@ def hash_murmur(kmer, seed=MINHASH_DEFAULT_SEED):
 
 
 class MinHash(RustObject):
+    __dealloc_func__ = lib.kmerminhash_free
+
     def __init__(
         self,
         n,
@@ -98,7 +100,6 @@ class MinHash(RustObject):
         self._objptr = lib.kmerminhash_new(
             n, ksize, is_protein, dayhoff, hp, seed, int(max_hash), track_abundance
         )
-        self.__dealloc_func__ = lib.kmerminhash_free
 
         if mins:
             if track_abundance:

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -191,11 +191,10 @@ class MinHash(RustObject):
         if isinstance(hashes, MinHash):
             self._methodcall(lib.kmerminhash_add_from, hashes._objptr)
         else:
-            for hash in hashes:
-                self._methodcall(lib.kmerminhash_add_hash, hash)
+            self._methodcall(lib.kmerminhash_add_many, list(hashes), len(hashes))
 
     def remove_many(self, hashes):
-        "Add many hashes in at once."
+        "Remove many hashes at once."
         self._methodcall(lib.kmerminhash_remove_many, list(hashes), len(hashes))
 
     def update(self, other):

--- a/sourmash/lca/lca_utils.py
+++ b/sourmash/lca/lca_utils.py
@@ -385,7 +385,7 @@ class LCA_Database(Index):
                 temp_sets[vv].add(k)
 
         for sig, vals in temp_sets.items():
-            sigd[sig].add_many(sorted(vals))
+            sigd[sig].add_many(vals)
 
         debug('=> {} signatures!', len(sigd))
         return sigd

--- a/sourmash/lca/lca_utils.py
+++ b/sourmash/lca/lca_utils.py
@@ -378,10 +378,14 @@ class LCA_Database(Index):
 
         debug('creating signatures for LCA DB...')
         sigd = defaultdict(minhash.copy_and_clear)
+        temp_sets = defaultdict(set)
 
         for (k, v) in self.hashval_to_idx.items():
             for vv in v:
-                sigd[vv].add_hash(k)
+                temp_sets[vv].add(k)
+
+        for sig, vals in temp_sets.items():
+            sigd[sig].add_many(sorted(vals))
 
         debug('=> {} signatures!', len(sigd))
         return sigd

--- a/sourmash/lca/lca_utils.py
+++ b/sourmash/lca/lca_utils.py
@@ -378,13 +378,13 @@ class LCA_Database(Index):
 
         debug('creating signatures for LCA DB...')
         sigd = defaultdict(minhash.copy_and_clear)
-        temp_sets = defaultdict(set)
+        temp_vals = defaultdict(list)
 
         for (k, v) in self.hashval_to_idx.items():
             for vv in v:
-                temp_sets[vv].add(k)
+                temp_vals[vv].append(k)
 
-        for sig, vals in temp_sets.items():
+        for sig, vals in temp_vals.items():
             sigd[sig].add_many(vals)
 
         debug('=> {} signatures!', len(sigd))

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -163,6 +163,30 @@ unsafe fn kmerminhash_get_mins(ptr: *mut KmerMinHash) -> Result<*const u64> {
 }
 
 ffi_fn! {
+unsafe fn kmerminhash_add_many(
+    ptr: *mut KmerMinHash,
+    hashes_ptr: *const u64,
+    insize: usize,
+  ) -> Result<()> {
+    let mh = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+
+    let hashes = {
+        assert!(!hashes_ptr.is_null());
+        slice::from_raw_parts(hashes_ptr as *mut u64, insize)
+    };
+
+    for hash in hashes {
+      mh.add_hash(*hash);
+    }
+
+    Ok(())
+}
+}
+
+ffi_fn! {
 unsafe fn kmerminhash_get_abunds(ptr: *mut KmerMinHash) -> Result<*const u64> {
     let mh = {
         assert!(!ptr.is_null());


### PR DESCRIPTION
Calling `.add_hash()` on a MinHash sketch is fine, but if you're calling it all the time it's better to pass a list of hashes and call `.add_many()` instead. Before this PR `add_many` just called `add_hash` for each hash it was passed, but now it will pass the full list to Rust (and that's way faster).

No changes for public APIs, and I changed the `_signatures` method in LCA to accumulate hashes for each sig first, and then set them all at once. This is way faster, but might use more intermediate memory (I'll evaluate this now).

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
