### PR TITLE
[MRG] update ipfshttpclient version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ install:
 before_script: pip install tox-travis
 
 jobs:
-  allow_failures:
-    - name: integration (ipfs/redis)
   include:
     - &check
       stage: check # do a pre-screen to make sure this is even worth testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,7 @@ script: tox -vv
 install:
   - source .travis/install_cargo.sh
 
-before_script: |
-  python -m pip install -U pip
-  python -m pip install tox-travis
-  python -m pip install -U tox
+before_script: pip install tox-travis
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 before_script: |
   python -m pip install -U pip
   python -m pip install tox-travis
+  python -m pip install -U tox
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ script: tox -vv
 install:
   - source .travis/install_cargo.sh
 
-before_script: pip install tox-travis
+before_script: |
+  python -m pip install -U pip
+  python -m pip install tox-travis
 
 jobs:
   allow_failures:

--- a/setup.py
+++ b/setup.py
@@ -83,8 +83,9 @@ SETUP_METADATA = {
                  "sphinxcontrib-napoleon", "nbsphinx",
                  "ipython"],
         '10x': ['bam2fasta==1.0.1'],
-        'storage': ["ipfshttpclient", "redis"]
+        'storage': ["ipfshttpclient==offset_fix", "redis"]
     },
+    "dependency_links": ["git+https://github.com/WouterGlorieux/py-ipfs-http-client.git@a73e4db661d991a81352bbd051648cae3d63cd51#egg=ipfshttpclient-offset_fix"],
     "include_package_data": True,
     "classifiers": CLASSIFIERS,
     "milksnake_tasks": [build_native],

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,9 @@ SETUP_METADATA = {
                  "sphinxcontrib-napoleon", "nbsphinx",
                  "ipython"],
         '10x': ['bam2fasta==1.0.1'],
-        'storage': ["ipfshttpclient==offset_fix", "redis"]
+        'storage': ["ipfshttpclient @ git+https://github.com/WouterGlorieux/py-ipfs-http-client.git@a73e4db661d991a81352bbd051648cae3d63cd51#egg=ipfshttpclient",
+                    "redis"]
     },
-    "dependency_links": ["git+https://github.com/WouterGlorieux/py-ipfs-http-client.git@a73e4db661d991a81352bbd051648cae3d63cd51#egg=ipfshttpclient-offset_fix"],
     "include_package_data": True,
     "classifiers": CLASSIFIERS,
     "milksnake_tasks": [build_native],

--- a/setup.py
+++ b/setup.py
@@ -83,8 +83,7 @@ SETUP_METADATA = {
                  "sphinxcontrib-napoleon", "nbsphinx",
                  "ipython"],
         '10x': ['bam2fasta==1.0.1'],
-        'storage': ["ipfshttpclient @ git+https://github.com/WouterGlorieux/py-ipfs-http-client.git@a73e4db661d991a81352bbd051648cae3d63cd51#egg=ipfshttpclient",
-                    "redis"]
+        'storage': ["ipfshttpclient>=0.4.13", "redis"]
     },
     "include_package_data": True,
     "classifiers": CLASSIFIERS,

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,9 @@ deps=
 commands=
   make coverage
   codecov --gcov-glob third-party
+
+[testenv:py27]
+extras =
+  test
+  doc
+  10x

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,3 @@ deps=
 commands=
   make coverage
   codecov --gcov-glob third-party
-
-[testenv:py27]
-extras =
-  test
-  doc
-  10x

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ extras =
   10x
   storage
 deps=
+  pip>=19.3.1
   codecov
 commands=
   make coverage


### PR DESCRIPTION
~~`ipfshttpclient` is broken for large files, this is an ugly solution until https://github.com/ipfs/py-ipfs-http-client/pull/194 is merged and released.~~

Fixed in 0.4.13.

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
