### PR TITLE
Trigger new Software Heritage archival snapshot on new tags

### DIFF
--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,0 +1,18 @@
+name: Metadata checks 
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Trigger new archival in software heritage on new tags
+        if: startsWith(github.ref, 'refs/tags/')
+        run: curl https://archive.softwareheritage.org/api/1/origin/save/git/url/https://github.com/dib-lab/sourmash.git/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -302,3 +302,10 @@ jobs:
         with:
           command: test
           args: --no-fail-fast
+
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger new archival in software heritage on new tags
+        if: startsWith(github.ref, 'refs/tags/')
+        run: curl https://archive.softwareheritage.org/api/1/origin/save/git/url/https://github.com/dib-lab/sourmash.git/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -302,10 +302,3 @@ jobs:
         with:
           command: test
           args: --no-fail-fast
-
-  archive:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger new archival in software heritage on new tags
-        if: startsWith(github.ref, 'refs/tags/')
-        run: curl https://archive.softwareheritage.org/api/1/origin/save/git/url/https://github.com/dib-lab/sourmash.git/


### PR DESCRIPTION
The [Software Heritage] project has an API for triggering new snapshots of the code. I added a new job to GitHub Actions to trigger it on new tags.

[Software Heritage]: https://www.softwareheritage.org/

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
