### PR TITLE
Compute oxidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ all: build
 
 build: .PHONY
 	$(PYTHON) setup.py build_ext -i
-	cargo build
 
 clean:
 	$(PYTHON) setup.py clean --all

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -19,6 +19,7 @@ def load_sequences():
 class TimeMinHashSuite:
     def setup(self):
         self.mh = MinHash(500, 21, track_abundance=False)
+        self.protein_mh = MinHash(500, 21, is_protein=True, track_abundance=False)
         self.sequences = load_sequences()
 
         self.populated_mh = MinHash(500, 21, track_abundance=False)
@@ -30,6 +31,12 @@ class TimeMinHashSuite:
         sequences = self.sequences
         for seq in sequences:
             mh.add_sequence(seq)
+
+    def time_add_protein(self):
+        mh = self.protein_mh
+        sequences = self.sequences
+        for seq in sequences:
+            mh.add_protein(seq)
 
     def time_get_mins(self):
         mh = self.populated_mh
@@ -74,12 +81,11 @@ class TimeMinHashSuite:
         for i in range(500):
             mh += other_mh
 
-    # TODO: add_protein
-
 
 class PeakmemMinHashSuite:
     def setup(self):
         self.mh = MinHash(500, 21, track_abundance=True)
+        self.protein_mh = MinHash(500, 21, is_protein=True, track_abundance=True)
         self.sequences = load_sequences()
 
     def peakmem_add_sequence(self):
@@ -87,6 +93,12 @@ class PeakmemMinHashSuite:
         sequences = self.sequences
         for seq in sequences:
             mh.add_sequence(seq)
+
+    def peakmem_add_protein(self):
+        mh = self.protein_mh
+        sequences = self.sequences
+        for seq in sequences:
+            mh.add_protein(seq)
 
     def peakmem_add_hash(self):
         mh = self.mh

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -31,12 +31,15 @@ enum SourmashErrorCode {
   SOURMASH_ERROR_CODE_INVALID_DNA = 1101,
   SOURMASH_ERROR_CODE_INVALID_PROT = 1102,
   SOURMASH_ERROR_CODE_INVALID_CODON_LENGTH = 1103,
+  SOURMASH_ERROR_CODE_INVALID_HASH_FUNCTION = 1104,
   SOURMASH_ERROR_CODE_IO = 100001,
   SOURMASH_ERROR_CODE_UTF8_ERROR = 100002,
   SOURMASH_ERROR_CODE_PARSE_INT = 100003,
   SOURMASH_ERROR_CODE_SERDE_ERROR = 100004,
 };
 typedef uint32_t SourmashErrorCode;
+
+typedef struct ComputeParameters ComputeParameters;
 
 typedef struct KmerMinHash KmerMinHash;
 
@@ -53,6 +56,46 @@ typedef struct {
   bool owned;
 } SourmashStr;
 
+ComputeParameters *computeparams_new(void);
+
+void computeparams_free(ComputeParameters *ptr);
+
+uint64_t computeparams_seed(ComputeParameters *ptr);
+
+void computeparams_set_seed(ComputeParameters *ptr, uint64_t seed);
+
+const uint32_t* computeparams_ksizes(ComputeParameters *ptr, uintptr_t *size);
+
+void computeparams_set_ksizes(ComputeParameters *ptr, const uint32_t *ksizes_ptr, uintptr_t insize);
+
+bool computeparams_protein(ComputeParameters *ptr);
+
+void computeparams_set_protein(ComputeParameters *ptr, bool protein);
+
+bool computeparams_dayhoff(ComputeParameters *ptr);
+
+void computeparams_set_dayhoff(ComputeParameters *ptr, bool dayhoff);
+
+bool computeparams_hp(ComputeParameters *ptr);
+
+void computeparams_set_hp(ComputeParameters *ptr, bool hp);
+
+bool computeparams_dna(ComputeParameters *ptr);
+
+void computeparams_set_dna(ComputeParameters *ptr, bool dna);
+
+bool computeparams_track_abundance(ComputeParameters *ptr);
+
+void computeparams_set_track_abundance(ComputeParameters *ptr, bool track);
+
+uint32_t computeparams_num_hashes(ComputeParameters *ptr);
+
+void computeparams_set_num_hashes(ComputeParameters *ptr, uint32_t num);
+
+uint64_t computeparams_scaled(ComputeParameters *ptr);
+
+void computeparams_set_scaled(ComputeParameters *ptr, uint64_t scaled);
+
 uint64_t hash_murmur(const char *kmer, uint64_t seed);
 
 void kmerminhash_abunds_push(KmerMinHash *ptr, uint64_t val);
@@ -62,6 +105,8 @@ void kmerminhash_add_from(KmerMinHash *ptr, const KmerMinHash *other);
 void kmerminhash_add_hash(KmerMinHash *ptr, uint64_t h);
 
 void kmerminhash_add_sequence(KmerMinHash *ptr, const char *sequence, bool force);
+
+void kmerminhash_add_protein(KmerMinHash *ptr, const char *sequence);
 
 void kmerminhash_add_word(KmerMinHash *ptr, const char *word);
 
@@ -168,11 +213,17 @@ void nodegraph_update(Nodegraph *ptr, Nodegraph *optr);
 
 Nodegraph *nodegraph_with_tables(uintptr_t ksize, uintptr_t starting_size, uintptr_t n_tables);
 
+void signature_add_sequence(Signature *ptr, const char *sequence, bool force);
+
+void signature_add_protein(Signature *ptr, const char *sequence);
+
 bool signature_eq(Signature *ptr, Signature *other);
 
 KmerMinHash *signature_first_mh(Signature *ptr);
 
 void signature_free(Signature *ptr);
+
+Signature *signature_from_params(ComputeParameters *params);
 
 SourmashStr signature_get_filename(Signature *ptr);
 
@@ -181,6 +232,8 @@ SourmashStr signature_get_license(Signature *ptr);
 KmerMinHash **signature_get_mhs(Signature *ptr, uintptr_t *size);
 
 SourmashStr signature_get_name(Signature *ptr);
+
+uintptr_t signature_len(Signature *ptr);
 
 Signature *signature_new(void);
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ DEBUG_BUILD = os.environ.get("SOURMASH_DEBUG") == "1"
 
 
 def build_native(spec):
-    cmd = ["cargo", "build", "--lib"]
+    cmd = ["cargo", "build", "--manifest-path", "src/core/Cargo.toml", "--lib"]
 
     target = "debug"
     if not DEBUG_BUILD:

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -454,38 +454,7 @@ class MinHash(RustObject):
             )
 
     def add_protein(self, sequence):
-        ksize = self.ksize // 3
-        if len(sequence) < ksize:
-            return
-
-        aa_kmers = (sequence[i:i + ksize] for i in range(0, len(sequence) - ksize + 1))
-        if self.is_protein:
-            for aa_kmer in aa_kmers:
-                self._methodcall(
-                    lib.kmerminhash_add_word, to_bytes(aa_kmer)
-        )
-        elif self.dayhoff:
-            for aa_kmer in aa_kmers:
-                dayhoff_kmer = ''
-                for aa in aa_kmer:
-                    data = rustcall(lib.sourmash_aa_to_dayhoff, to_bytes(aa))
-                    dayhoff_letter = data.decode('utf-8')
-                    dayhoff_kmer += dayhoff_letter
-                self._methodcall(
-                    lib.kmerminhash_add_word, to_bytes(dayhoff_kmer)
-                )
-        elif self.hp:
-            for aa_kmer in aa_kmers:
-                hp_kmer = ''
-                for aa in aa_kmer:
-                    data = rustcall(lib.sourmash_aa_to_hp, to_bytes(aa))
-                    hp_letter = data.decode('utf-8')
-                    hp_kmer += hp_letter
-                self._methodcall(
-                    lib.kmerminhash_add_word, to_bytes(hp_kmer)
-                )
-        else:
-            raise ValueError("Invalid protein type")
+        self._methodcall(lib.kmerminhash_add_protein, to_bytes(sequence))
 
     def is_molecule_type(self, molecule):
         if self.is_protein and molecule == 'protein':

--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -6,12 +6,24 @@ from sourmash._minhash import get_minhash_default_seed
 from sourmash.cli.utils import add_construct_moltype_args
 
 
+def ksize_parser(ksizes):
+    # get list of k-mer sizes for which to compute sketches
+    if ',' in ksizes:
+        ksizes = ksizes.split(',')
+        ksizes = list(map(int, ksizes))
+    else:
+        ksizes = [int(ksizes)]
+
+    return ksizes
+
+
 def subparser(subparsers):
     subparser = subparsers.add_parser('compute')
 
     sketch_args = subparser.add_argument_group('Sketching options')
     sketch_args.add_argument(
         '-k', '--ksizes', default='21,31,51',
+        type=ksize_parser,
         help='comma-separated list of k-mer sizes; default=%(default)s'
     )
     sketch_args.add_argument(

--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -95,7 +95,7 @@ def subparser(subparsers):
         help='recompute signatures even if the file exists'
     )
     file_args.add_argument(
-        '-o', '--output', type=FileType('wt'),
+        '-o', '--output',
         help='output computed signatures to this file'
     )
     file_args.add_argument(

--- a/sourmash/command_compute.py
+++ b/sourmash/command_compute.py
@@ -10,6 +10,7 @@ import random
 import screed
 import time
 
+from . import sourmash_args
 from .signature import SourmashSignature, save_signatures
 from .logging import notify, error, set_quiet
 from .utils import RustObject
@@ -273,15 +274,15 @@ def build_siglist(sig, filename, name=None):
     return [sig]
 
 
-def save_siglist(siglist, output_fp, filename=None):
+def save_siglist(siglist, sigfile_name, filename=None):
     # save!
-    if output_fp:
-        sigfile_name = output_fp.name
-        save_signatures(siglist, output_fp)
+    if sigfile_name:
+        with sourmash_args.FileOutput(sigfile_name, 'w') as fp:
+            save_signatures(siglist, fp)
     else:
         if filename is None:
             raise Exception("internal error, filename is None")
-        with open(filename, 'w') as fp:
+        with sourmash_args.FileOutput(filename, 'w') as fp:
             sigfile_name = filename
             save_signatures(siglist, fp)
     notify(

--- a/sourmash/exceptions.py
+++ b/sourmash/exceptions.py
@@ -31,7 +31,9 @@ def _make_exceptions():
             pass
 
         code = getattr(lib, attr)
-        if code < 100 or code > 10000:
+        if code == 1104:
+            exceptions_by_code[code] = ValueError
+        elif code < 100 or code > 10000:
             Exc.__name__ = attr[20:].title().replace('_', '')
             Exc.code = getattr(lib, attr)
             globals()[Exc.__name__] = Exc

--- a/sourmash/signature.py
+++ b/sourmash/signature.py
@@ -155,6 +155,20 @@ class SourmashSignature(RustObject):
             else:
                 raise
 
+    def add_sequence(self, sequence, force=False):
+        self._methodcall(lib.signature_add_sequence, to_bytes(sequence), force)
+
+    def add_protein(self, sequence):
+        self._methodcall(lib.signature_add_protein, to_bytes(sequence))
+
+    @staticmethod
+    def from_params(params):
+        ptr = rustcall(lib.signature_from_params, params._get_objptr())
+        return SourmashSignature._from_objptr(ptr)
+
+    def __len__(self):
+        return self._methodcall(lib.signature_len)
+
     def __getstate__(self):  # enable pickling
         return (
             self.minhash,

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -19,6 +19,7 @@ bench = false
 
 [features]
 from-finch = ["finch"]
+parallel = ["rayon"]
 
 #[build-dependencies]
 #cbindgen = "~0.6.7"
@@ -34,6 +35,7 @@ log = "0.4.8"
 md5 = "0.7.0"
 murmurhash3 = "0.0.5"
 once_cell = "1.2.0"
+rayon = { version = "1.0", optional = true }
 serde = "1.0.103"
 serde_derive = "1.0.103"
 serde_json = "1.0.44"
@@ -66,4 +68,8 @@ default-features = false
 
 [[bench]]
 name = "index"
+harness = false
+
+[[bench]]
+name = "compute"
 harness = false

--- a/src/core/benches/compute.rs
+++ b/src/core/benches/compute.rs
@@ -1,0 +1,96 @@
+#[macro_use]
+extern crate criterion;
+
+use std::fs::File;
+use std::io::{Cursor, Read};
+
+use needletail::parse_sequence_reader;
+use sourmash::cmd::ComputeParameters;
+use sourmash::signature::Signature;
+
+use criterion::Criterion;
+
+fn add_sequence(c: &mut Criterion) {
+    let cp = ComputeParameters::default();
+    let template_sig = Signature::from_params(&cp);
+
+    let mut data: Vec<u8> = vec![];
+    let mut f = File::open("../../tests/test-data/ecoli.genes.fna").unwrap();
+    let _ = f.read_to_end(&mut data);
+
+    let data = data.repeat(10);
+
+    let data_upper = data.to_ascii_uppercase();
+    let data_lower = data.to_ascii_lowercase();
+    let data_errors: Vec<u8> = data
+        .iter()
+        .enumerate()
+        .map(|(i, x)| if i % 89 == 1 { 'N' as u8 } else { *x })
+        .collect();
+
+    let mut group = c.benchmark_group("add_sequence");
+    group.sample_size(10);
+
+    group.bench_function("valid", |b| {
+        b.iter(|| {
+            let fasta_data = Cursor::new(data_upper.clone());
+            let mut sig = template_sig.clone();
+            parse_sequence_reader(
+                fasta_data,
+                |_| {},
+                |rec| {
+                    sig.add_sequence(&rec.seq, false).unwrap();
+                },
+            )
+            .unwrap();
+        });
+    });
+
+    group.bench_function("lowercase", |b| {
+        b.iter(|| {
+            let fasta_data = Cursor::new(data_lower.clone());
+            let mut sig = template_sig.clone();
+            parse_sequence_reader(
+                fasta_data,
+                |_| {},
+                |rec| {
+                    sig.add_sequence(&rec.seq, false).unwrap();
+                },
+            )
+            .unwrap();
+        });
+    });
+
+    group.bench_function("invalid kmers", |b| {
+        b.iter(|| {
+            let fasta_data = Cursor::new(data_errors.clone());
+            let mut sig = template_sig.clone();
+            parse_sequence_reader(
+                fasta_data,
+                |_| {},
+                |rec| {
+                    sig.add_sequence(&rec.seq, true).unwrap();
+                },
+            )
+            .unwrap();
+        });
+    });
+
+    group.bench_function("force with valid kmers", |b| {
+        b.iter(|| {
+            let fasta_data = Cursor::new(data_upper.clone());
+            let mut sig = template_sig.clone();
+            parse_sequence_reader(
+                fasta_data,
+                |_| {},
+                |rec| {
+                    sig.add_sequence(&rec.seq, true).unwrap();
+                },
+            )
+            .unwrap();
+        });
+    });
+}
+
+criterion_group!(compute, add_sequence);
+criterion_main!(compute);

--- a/src/core/src/cmd.rs
+++ b/src/core/src/cmd.rs
@@ -1,37 +1,9 @@
 use failure::Error;
 
 use crate::index::MHBT;
-
-/* FIXME bring back after succint-rs changes
-pub fn count_unique(index_path: &str) -> Result<(), Error> {
-    let index = MHBT::from_path(index_path)?;
-
-    info!("Loaded index: {}", index_path);
-
-    let mut hll = pdatastructs::hyperloglog::HyperLogLog::new(16);
-
-    let mut total_hashes = 0u64;
-
-    for (n, sig) in index.signatures().iter().enumerate() {
-        if n % 1000 == 0 {
-            info!("Processed {} signatures", n);
-            info!("Unique hashes in {}: {}", index_path, hll.count());
-            info!("Total hashes in {}: {}", index_path, total_hashes);
-        };
-        if let Sketch::MinHash(mh) = &sig.signatures[0] {
-            for hash in mh.mins() {
-                hll.add(&hash);
-                total_hashes += 1;
-            }
-        }
-    }
-
-    info!("Unique k-mers in {}: {}", index_path, hll.count());
-    info!("Total hashes in {}: {}", index_path, total_hashes);
-
-    Ok(())
-}
-*/
+use crate::signature::Signature;
+use crate::sketch::minhash::{max_hash_for_scaled, HashFunctions, KmerMinHash};
+use crate::sketch::Sketch;
 
 pub fn prepare(index_path: &str) -> Result<(), Error> {
     let mut index = MHBT::from_path(index_path)?;
@@ -42,4 +14,161 @@ pub fn prepare(index_path: &str) -> Result<(), Error> {
     index.save_file(index_path, None)?;
 
     Ok(())
+}
+
+impl Signature {
+    pub fn from_params(params: &ComputeParameters) -> Signature {
+        let template = build_template(&params);
+
+        Signature::builder()
+            .hash_function("0.murmur64")
+            .name(params.merge.clone())
+            .filename(None)
+            .signatures(template)
+            .build()
+    }
+}
+
+pub struct ComputeParameters {
+    pub ksizes: Vec<u32>,
+    pub check_sequence: bool,
+    pub dna: bool,
+    pub dayhoff: bool,
+    pub hp: bool,
+    pub singleton: bool,
+    pub count_valid_reads: usize,
+    pub barcodes_file: Option<String>, // TODO: check
+    pub line_count: usize,
+    pub rename_10x_barcodes: Option<bool>,    // TODO: check
+    pub write_barcode_meta_csv: Option<bool>, // TODO: check
+    pub save_fastas: Option<bool>,            // TODO: check
+    pub scaled: u64,
+    pub force: bool,
+    pub output: Option<String>, // TODO: check
+    pub num_hashes: u32,
+    pub protein: bool,
+    pub name_from_first: bool,
+    pub seed: u64,
+    pub input_is_protein: bool,
+    pub merge: Option<String>,
+    pub track_abundance: bool,
+    pub randomize: bool,
+    pub license: String,
+    pub input_is_10x: bool,
+    pub processes: usize,
+}
+
+impl Default for ComputeParameters {
+    fn default() -> Self {
+        ComputeParameters {
+            ksizes: vec![21, 31, 51],
+            check_sequence: false,
+            dna: true,
+            dayhoff: false,
+            hp: false,
+            singleton: false,
+            count_valid_reads: 0,
+            barcodes_file: None,
+            line_count: 1500,
+            rename_10x_barcodes: None,
+            write_barcode_meta_csv: None,
+            save_fastas: None,
+            scaled: 0,
+            force: false,
+            output: None,
+            num_hashes: 500,
+            protein: false,
+            name_from_first: false,
+            seed: 42,
+            input_is_protein: false,
+            merge: None,
+            track_abundance: false,
+            randomize: false,
+            license: "CC0".into(),
+            input_is_10x: false,
+            processes: 2,
+        }
+    }
+}
+
+pub fn build_template(params: &ComputeParameters) -> Vec<Sketch> {
+    let max_hash = max_hash_for_scaled(params.scaled).unwrap_or(0);
+
+    params
+        .ksizes
+        .iter()
+        .flat_map(|k| {
+            let mut ksigs = vec![];
+
+            if params.protein {
+                ksigs.push(Sketch::MinHash(
+                    KmerMinHash::builder()
+                        .num(params.num_hashes)
+                        .ksize(*k)
+                        .hash_function(HashFunctions::murmur64_protein)
+                        .max_hash(max_hash)
+                        .seed(params.seed)
+                        .abunds(if params.track_abundance {
+                            Some(vec![])
+                        } else {
+                            None
+                        })
+                        .build(),
+                ));
+            }
+
+            if params.dayhoff {
+                ksigs.push(Sketch::MinHash(
+                    KmerMinHash::builder()
+                        .num(params.num_hashes)
+                        .ksize(*k)
+                        .hash_function(HashFunctions::murmur64_dayhoff)
+                        .max_hash(max_hash)
+                        .seed(params.seed)
+                        .abunds(if params.track_abundance {
+                            Some(vec![])
+                        } else {
+                            None
+                        })
+                        .build(),
+                ));
+            }
+
+            if params.hp {
+                ksigs.push(Sketch::MinHash(
+                    KmerMinHash::builder()
+                        .num(params.num_hashes)
+                        .ksize(*k)
+                        .hash_function(HashFunctions::murmur64_hp)
+                        .max_hash(max_hash)
+                        .seed(params.seed)
+                        .abunds(if params.track_abundance {
+                            Some(vec![])
+                        } else {
+                            None
+                        })
+                        .build(),
+                ));
+            }
+
+            if params.dna {
+                ksigs.push(Sketch::MinHash(
+                    KmerMinHash::builder()
+                        .num(params.num_hashes)
+                        .ksize(*k)
+                        .hash_function(HashFunctions::murmur64_DNA)
+                        .max_hash(max_hash)
+                        .seed(params.seed)
+                        .abunds(if params.track_abundance {
+                            Some(vec![])
+                        } else {
+                            None
+                        })
+                        .build(),
+                ));
+            }
+
+            ksigs
+        })
+        .collect()
 }

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -24,6 +24,9 @@ pub enum SourmashError {
     #[fail(display = "different signatures cannot be compared")]
     MismatchSignatureType,
 
+    #[fail(display = "Invalid hash function: {}", function)]
+    InvalidHashFunction { function: String },
+
     #[fail(display = "Can only set {} if the MinHash is empty", message)]
     NonEmptyMinHash { message: String },
 
@@ -61,6 +64,7 @@ pub enum SourmashErrorCode {
     InvalidDNA = 11_01,
     InvalidProt = 11_02,
     InvalidCodonLength = 11_03,
+    InvalidHashFunction = 11_04,
     // external errors
     Io = 100_001,
     Utf8Error = 100_002,
@@ -93,6 +97,9 @@ impl SourmashErrorCode {
                     SourmashError::InvalidProt { .. } => SourmashErrorCode::InvalidProt,
                     SourmashError::InvalidCodonLength { .. } => {
                         SourmashErrorCode::InvalidCodonLength
+                    }
+                    SourmashError::InvalidHashFunction { .. } => {
+                        SourmashErrorCode::InvalidHashFunction
                     }
                     SourmashError::SerdeError => SourmashErrorCode::SerdeError,
                 };

--- a/src/core/src/ffi/cmd/compute.rs
+++ b/src/core/src/ffi/cmd/compute.rs
@@ -1,0 +1,195 @@
+use std::slice;
+
+use crate::cmd::ComputeParameters;
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_new() -> *mut ComputeParameters {
+    Box::into_raw(Box::new(ComputeParameters::default())) as _
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_free(ptr: *mut ComputeParameters) {
+    if ptr.is_null() {
+        return;
+    }
+    Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_seed(ptr: *mut ComputeParameters) -> u64 {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.seed
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_seed(ptr: *mut ComputeParameters, new_seed: u64) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.seed = new_seed;
+}
+
+ffi_fn! {
+unsafe fn computeparams_ksizes(ptr: *mut ComputeParameters, size: *mut usize) -> Result<*const u32> {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    let output = cp.ksizes.clone();
+    *size = output.len();
+
+    Ok(Box::into_raw(output.into_boxed_slice()) as *const u32)
+}
+}
+
+ffi_fn! {
+unsafe fn computeparams_set_ksizes(
+    ptr: *mut ComputeParameters,
+    ksizes_ptr: *const u32,
+    insize: usize,
+  ) -> Result<()> {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+
+    let ksizes = {
+        assert!(!ksizes_ptr.is_null());
+        slice::from_raw_parts(ksizes_ptr as *const u32, insize)
+    };
+
+    cp.ksizes = ksizes.into();
+
+    Ok(())
+}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_protein(ptr: *mut ComputeParameters) -> bool {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.protein
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_protein(ptr: *mut ComputeParameters, v: bool) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.protein = v;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_dayhoff(ptr: *mut ComputeParameters) -> bool {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.dayhoff
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_dayhoff(ptr: *mut ComputeParameters, v: bool) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.dayhoff = v;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_hp(ptr: *mut ComputeParameters) -> bool {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.hp
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_hp(ptr: *mut ComputeParameters, v: bool) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.hp = v;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_dna(ptr: *mut ComputeParameters) -> bool {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.dna
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_dna(ptr: *mut ComputeParameters, v: bool) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.dna = v;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_track_abundance(ptr: *mut ComputeParameters) -> bool {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.track_abundance
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_track_abundance(ptr: *mut ComputeParameters, v: bool) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.track_abundance = v;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_num_hashes(ptr: *mut ComputeParameters) -> u32 {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.num_hashes
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_num_hashes(ptr: *mut ComputeParameters, num: u32) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.num_hashes = num;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_scaled(ptr: *mut ComputeParameters) -> u64 {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.scaled
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn computeparams_set_scaled(ptr: *mut ComputeParameters, scaled: u64) {
+    let cp = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    cp.scaled = scaled;
+}

--- a/src/core/src/ffi/cmd/mod.rs
+++ b/src/core/src/ffi/cmd/mod.rs
@@ -1,0 +1,1 @@
+pub mod compute;

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -75,6 +75,23 @@ unsafe fn kmerminhash_add_sequence(ptr: *mut KmerMinHash, sequence: *const c_cha
 }
 }
 
+ffi_fn! {
+unsafe fn kmerminhash_add_protein(ptr: *mut KmerMinHash, sequence: *const c_char) ->
+    Result<()> {
+    let mh = {
+        assert!(!ptr.is_null());
+        &mut *ptr
+    };
+    let c_str = {
+        assert!(!sequence.is_null());
+
+        CStr::from_ptr(sequence)
+    };
+
+    mh.add_protein(c_str.to_bytes())
+}
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn kmerminhash_add_hash(ptr: *mut KmerMinHash, h: u64) {
     let mh = {

--- a/src/core/src/ffi/mod.rs
+++ b/src/core/src/ffi/mod.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 pub mod utils;
 
+pub mod cmd;
 pub mod minhash;
 pub mod nodegraph;
 pub mod signature;

--- a/src/core/src/sketch/ukhs.rs
+++ b/src/core/src/sketch/ukhs.rs
@@ -32,4 +32,8 @@ impl SigsTrait for FlatUKHS {
     fn add_sequence(&mut self, _seq: &[u8], _force: bool) -> Result<(), Error> {
         unimplemented!()
     }
+
+    fn add_protein(&mut self, _seq: &[u8]) -> Result<(), Error> {
+        unimplemented!()
+    }
 }

--- a/src/core/src/wasm.rs
+++ b/src/core/src/wasm.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 use serde_json;
 
 use crate::signature::SigsTrait;
-use crate::sketch::minhash::{HashFunctions, KmerMinHash};
+use crate::sketch::minhash::{max_hash_for_scaled, HashFunctions, KmerMinHash};
 
 #[wasm_bindgen]
 impl KmerMinHash {
@@ -20,10 +20,8 @@ impl KmerMinHash {
     ) -> KmerMinHash {
         let max_hash = if num != 0 {
             0
-        } else if scaled == 0 {
-            u64::max_value()
         } else {
-            u64::max_value() / scaled as u64
+            max_hash_for_scaled(scaled as u64).unwrap()
         };
 
         // TODO: at most one of (prot, dayhoff, hp) should be true

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -1,5 +1,5 @@
 use sourmash::signature::SigsTrait;
-use sourmash::sketch::minhash::{HashFunctions, KmerMinHash};
+use sourmash::sketch::minhash::{max_hash_for_scaled, HashFunctions, KmerMinHash};
 
 #[test]
 fn throws_error() {
@@ -134,4 +134,9 @@ fn dayhoff() {
 
     assert_eq!(a.size(), 2);
     assert_eq!(b.size(), 2);
+}
+
+#[test]
+fn max_for_scaled() {
+    assert_eq!(max_hash_for_scaled(100), Some(184467440737095520));
 }

--- a/src/core/tests/signature.rs
+++ b/src/core/tests/signature.rs
@@ -4,7 +4,9 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 
+use sourmash::cmd::ComputeParameters;
 use sourmash::signature::Signature;
+use sourmash::signature::SigsTrait;
 
 #[test]
 fn load_signature() {
@@ -28,4 +30,78 @@ fn load_signature() {
         assert_eq!(name, "s10+s11");
     }
     assert_eq!(sig.signatures.len(), 4);
+}
+
+#[test]
+fn signature_from_computeparams() {
+    let params = ComputeParameters {
+        ksizes: vec![2, 3, 4],
+        num_hashes: 3,
+        ..Default::default()
+    };
+
+    let mut sig = Signature::from_params(&params);
+    sig.add_sequence(b"ATGC", false).unwrap();
+
+    assert_eq!(sig.signatures.len(), 3);
+    dbg!(&sig.signatures);
+    assert_eq!(sig.signatures[0].size(), 3);
+    assert_eq!(sig.signatures[1].size(), 2);
+    assert_eq!(sig.signatures[2].size(), 1);
+}
+
+#[test]
+fn signature_slow_path() {
+    let params = ComputeParameters {
+        ksizes: vec![2, 3, 4],
+        num_hashes: 3,
+        ..Default::default()
+    };
+
+    let mut sig = Signature::from_params(&params);
+    sig.add_sequence(b"ATGCN", true).unwrap();
+
+    assert_eq!(sig.signatures.len(), 3);
+    dbg!(&sig.signatures);
+    assert_eq!(sig.signatures[0].size(), 3);
+    assert_eq!(sig.signatures[1].size(), 2);
+    assert_eq!(sig.signatures[2].size(), 1);
+}
+
+#[test]
+fn signature_add_sequence_protein() {
+    let params = ComputeParameters {
+        ksizes: vec![3, 6],
+        num_hashes: 3,
+        protein: true,
+        dna: false,
+        ..Default::default()
+    };
+
+    let mut sig = Signature::from_params(&params);
+    sig.add_sequence(b"ATGCAT", false).unwrap();
+
+    assert_eq!(sig.signatures.len(), 2);
+    dbg!(&sig.signatures);
+    assert_eq!(sig.signatures[0].size(), 3);
+    assert_eq!(sig.signatures[1].size(), 1);
+}
+
+#[test]
+fn signature_add_protein() {
+    let params = ComputeParameters {
+        ksizes: vec![3, 6],
+        num_hashes: 3,
+        protein: true,
+        dna: false,
+        ..Default::default()
+    };
+
+    let mut sig = Signature::from_params(&params);
+    sig.add_protein(b"AGY").unwrap();
+
+    assert_eq!(sig.signatures.len(), 2);
+    dbg!(&sig.signatures);
+    assert_eq!(sig.signatures[0].size(), 3);
+    assert_eq!(sig.signatures[1].size(), 2);
 }

--- a/tests/test_sourmash_compute.py
+++ b/tests/test_sourmash_compute.py
@@ -16,6 +16,9 @@ import sourmash
 from sourmash import MinHash
 from sourmash.sbt import SBT, Node
 from sourmash.sbtmh import SigLeaf, load_sbt_index
+from sourmash.command_compute import ComputeParameters
+from sourmash.cli.compute import subparser
+from sourmash.cli import SourmashParser
 
 from sourmash import signature
 from sourmash import VERSION
@@ -879,3 +882,25 @@ def test_do_sourmash_check_knowngood_protein_comparisons():
         good_trans = list(signature.load_signatures(knowngood))[0]
 
         assert sig2_trans.similarity(good_trans) == 1.0
+
+
+def test_compute_parameters():
+    args_list = ["compute", "-k", "21,31", "--singleton", "--protein", "--no-dna", "input_file"]
+
+    parser = SourmashParser(prog='sourmash')
+    subp = parser.add_subparsers(title="instruction", dest="cmd", metavar="cmd")
+    subparser(subp)
+
+    args = parser.parse_args(args_list)
+
+    params = ComputeParameters.from_args(args)
+
+    assert params.ksizes == [21, 31]
+    assert params.protein == True
+    assert params.dna == False
+    assert params.seed == 42
+    assert params.dayhoff == False
+    assert params.hp == False
+    assert params.num_hashes == 500
+    assert params.scaled == 0
+    assert params.track_abundance == False


### PR DESCRIPTION
This PR expose functionality in a way that doesn't requiring moving all the Python compute code into Rust.

- I moved the internal functions from compute (`make_minhashes`, `add_seq`, `build_siglist`, `save_siglist`) to the outside scope, and made all the arguments explicit. It would be hard to refactor otherwise...
- `add_sequence` and `add_protein` methods for `SourmashSignature`. The idea here is to only cross the FFI layer once for each sequence, and being able to control better what can be improved on the Rust side (like using [rayon] for parallelization?).
- `add_protein` in `MinHash` was also moved to Rust, and it is 100x faster :rofl:  /cc @olgabot 
- Benchmarks in Python (for `add_protein`) and in Rust (for `add_sequence`)
- [`add_sequence` in Rust][9] is way simpler, and way faster. Turns out doing simpler things and letting the compiler optimize was better than my micro-optimizations =P
  * but there is still a trick: I pre-calculate the reverse complement for the full sequence, and then while moving the k-mer window forward for the sequence I move another one backwards for the RC. The code for that is not complicated, but I need to add a comment to explain it (because it is not obvious at first sight what is happening).
    ```rust
    let kmer = &sequence[i..i + ksize];
    let krc = &rc[len - ksize - i..len - i];
    ```

[9]: https://github.com/dib-lab/sourmash/pull/845/files#diff-018d093626fb4e52b6f45234edbd0209R645-R678

Funny bits:
- It is a gigantic PR because the `ComputeParameters` setters and getters are... a lot. But it's also very repetitive code (and maybe could become a macro, but then it becomes harder to reason about/fix bugs later).
- #245 explodes the `args` in the `compute` function signature, but since Rust doesn't have default arguments for functions I went in the other direction there (collapsing all the args into a `ComputeParameters` struct). Python's default arguments are so nice.

Previous blurb: <details>
I'm using this branch for implementing [`decoct compute`][0] and figuring out how to:
1) expose functionality in a way that doesn't requiring moving all the Python compute code into Rust
2) allows some parallelization if using the Rust compute parts (implemented with [rayon])
</details>

[0]: https://github.com/luizirber/decoct/blob/cfd252e9e315257cff68964bce17e615b99b7326/src/cmd.rs#L24
[rayon]: https://docs.rs/rayon/1.3.0/rayon/

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
