### PR TITLE
Ignore .sig and .sbt files for repo language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ tests/test-data/*.sig  linguist-detectable=false
 tests/test-data/*/*.sig  linguist-detectable=false
 tests/test-data/*/*/*.sig  linguist-detectable=false
 tests/test-data/.sbt.v2/*.sbt  linguist-detectable=false
+include/sourmash.h  linguist-language=C

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 .git_archival.txt  export-subst
+tests/test-data/*.sig  linguist-detectable=false
+tests/test-data/*/*.sig  linguist-detectable=false
+tests/test-data/*/*/*.sig  linguist-detectable=false
+tests/test-data/.sbt.v2/*.sbt  linguist-detectable=false


### PR DESCRIPTION
How is this not bothering you?!?!

<img width="994" alt="Screen Shot 2020-01-15 at 4 01 01 PM" src="https://user-images.githubusercontent.com/566823/72471369-85fddc80-37b0-11ea-8927-133111b0ff81.png">

Just kidding, it was an easy change, and should make the repo's language stats summary a bit less bonkers.