### PR TITLE
[MRG] refactor argparse.FileType out of sourmash argument handling.

### DIFF
--- a/sourmash/cli/categorize.py
+++ b/sourmash/cli/categorize.py
@@ -29,7 +29,7 @@ def subparser(subparsers):
     add_moltype_args(subparser)
 
     # TODO: help messages in these
-    subparser.add_argument('--csv', type=argparse.FileType('at'))
+    subparser.add_argument('--csv', help='output summary CSV to this file')
     subparser.add_argument('--load-csv', default=None)
 
 

--- a/sourmash/cli/compare.py
+++ b/sourmash/cli/compare.py
@@ -1,7 +1,5 @@
 """compare genomes"""
 
-from argparse import FileType
-
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 
 
@@ -29,7 +27,7 @@ def subparser(subparsers):
         help='compare all signatures underneath directories'
     )
     subparser.add_argument(
-        '--csv', metavar='F', type=FileType('w'),
+        '--csv', metavar='F',
         help='write matrix to specified file in CSV format (with column '
         'headers)'
     )

--- a/sourmash/cli/gather.py
+++ b/sourmash/cli/gather.py
@@ -1,8 +1,6 @@
 """search a metagenome signature for multiple non-
                                   overlapping matches"""
 
-from argparse import FileType
-
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 
 
@@ -25,11 +23,11 @@ def subparser(subparsers):
         help='search all signatures underneath directories'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
+        '-o', '--output', metavar='FILE',
         help='output CSV containing matches to this file'
     )
     subparser.add_argument(
-        '--save-matches', metavar='FILE', type=FileType('wt'),
+        '--save-matches', metavar='FILE',
         help='save the matched signatures from the database to the '
         'specified file'
     )
@@ -38,7 +36,7 @@ def subparser(subparsers):
         help='threshold (in bp) for reporting results (default=50,000)'
     )
     subparser.add_argument(
-        '--output-unassigned', metavar='FILE', type=FileType('wt'),
+        '--output-unassigned', metavar='FILE',
         help='output unassigned portions of the query as a signature to the '
         'specified file'
     )

--- a/sourmash/cli/import_csv.py
+++ b/sourmash/cli/import_csv.py
@@ -1,6 +1,5 @@
 """'sourmash import_csv' description goes here"""
 
-from argparse import FileType
 import sys
 
 
@@ -8,9 +7,8 @@ def subparser(subparsers):
     subparser = subparsers.add_parser('import_csv')
     subparser.add_argument('mash_csvfile', help='CSV file with mash sketches')
     subparser.add_argument(
-        '-o', '--output', type=FileType('wt'),
-        default=sys.stdout,
-        help='save signature generated from data here'
+        '-o', '--output',
+        help='save signature generated from data to this file (default stdout)'
     )
 
 

--- a/sourmash/cli/lca/classify.py
+++ b/sourmash/cli/lca/classify.py
@@ -1,7 +1,5 @@
 """classify genomes"""
 
-from argparse import FileType
-
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('classify')
@@ -17,9 +15,8 @@ def subparser(subparsers):
         help='output debugging output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        help='output CSV to the specified file; by default output to terminal '
-        '(standard output)'
+        '-o', '--output', metavar='FILE', default='-',
+        help='output CSV to the specified file; by default output to stdout'
     )
     subparser.add_argument('--scaled', type=float)
     subparser.add_argument(

--- a/sourmash/cli/lca/gather.py
+++ b/sourmash/cli/lca/gather.py
@@ -1,7 +1,5 @@
 """classify metagenomes"""
 
-from argparse import FileType
-
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('gather')
@@ -15,11 +13,11 @@ def subparser(subparsers):
         help='output debugging output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
+        '-o', '--output', metavar='FILE',
         help='output CSV containing matches to this file'
     )
     subparser.add_argument(
-        '--output-unassigned', metavar='FILE', type=FileType('wt'),
+        '--output-unassigned', metavar='FILE',
         help='output unassigned portions of the query as a signature to this '
         'file'
     )

--- a/sourmash/cli/lca/summarize.py
+++ b/sourmash/cli/lca/summarize.py
@@ -1,7 +1,5 @@
 """summarize mixture"""
 
-from argparse import FileType
-
 
 def subparser(subparsers):
     subparser = subparsers.add_parser('summarize')
@@ -13,7 +11,7 @@ def subparser(subparsers):
         help='load all signatures underneath directories'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
+        '-o', '--output', metavar='FILE',
         help='file to which CSV output will be written'
     )
     subparser.add_argument('--scaled', metavar='FLOAT', type=float)

--- a/sourmash/cli/search.py
+++ b/sourmash/cli/search.py
@@ -1,7 +1,5 @@
 """search a signature against a list of signatures"""
 
-from argparse import FileType
-
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 
 
@@ -27,7 +25,7 @@ def subparser(subparsers):
         help='minimum threshold for reporting matches; default=0.08'
     )
     subparser.add_argument(
-        '--save-matches', metavar='FILE', type=FileType('wt'),
+        '--save-matches', metavar='FILE',
         help='output matching signatures to the specified file'
     )
     subparser.add_argument(
@@ -52,7 +50,7 @@ def subparser(subparsers):
         help='downsample query to this scaled factor (yields greater speed)'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
+        '-o', '--output', metavar='FILE',
         help='output CSV containing matches to this file'
     )
     add_ksize_arg(subparser, 31)

--- a/sourmash/cli/sig/describe.py
+++ b/sourmash/cli/sig/describe.py
@@ -1,6 +1,5 @@
 """show details of signature"""
 
-from argparse import FileType
 import csv
 
 import sourmash
@@ -15,79 +14,11 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '--csv', metavar='FILE', type=FileType('wt'),
+        '--csv', metavar='FILE',
         help='output information to a CSV file'
     )
 
 
-def describe(signatures, quiet=True, csvout=None):
-    siglist = []
-    for sigfile in signatures:
-        this_siglist = []
-        try:
-            this_siglist = sourmash.load_signatures(sigfile, quiet=quiet, do_raise=True)
-            for k in this_siglist:
-                siglist.append((k, sigfile))
-        except Exception as exc:
-            error('\nError while reading signatures from {}:'.format(sigfile))
-            error(str(exc))
-            error('(continuing)')
-
-        notify('loaded {} signatures from {}...', len(siglist), sigfile,
-               end='\r')
-
-    notify('loaded {} signatures total.', len(siglist))
-
-    w = None
-    if csvout:
-        w = csv.DictWriter(
-            csvout, [
-                'signature_file', 'md5', 'ksize', 'moltype', 'num', 'scaled',
-                'n_hashes', 'seed', 'with_abundance','name', 'filename',
-                'license'
-            ],
-            extrasaction='ignore'
-        )
-        w.writeheader()
-
-    # extract info, write as appropriate.
-    for (sig, signature_file) in siglist:
-        mh = sig.minhash
-        ksize = mh.ksize
-        moltype = 'DNA'
-        if mh.is_protein:
-            if mh.dayhoff:
-                moltype = 'dayhoff'
-            elif mh.hp:
-                moltype = 'hp'
-            else:
-                moltype = 'protein'
-        scaled = mh.scaled
-        num = mh.num
-        seed = mh.seed
-        n_hashes = len(mh)
-        with_abundance = 0
-        if mh.track_abundance:
-            with_abundance = 1
-        md5 = sig.md5sum()
-        name = sig.name()
-        filename = sig.filename
-        license = sig.license
-
-        if w:
-            w.writerow(locals())
-
-        print_results('''\
----
-signature filename: {signature_file}
-signature: {name}
-source file: {filename}
-md5: {md5}
-k={ksize} molecule={moltype} num={num} scaled={scaled} seed={seed} track_abundance={with_abundance}
-size: {n_hashes}
-signature license: {license}
-''', **locals())
-
-
 def main(args):
-    describe(args.signatures, quiet=args.quiet, csvout=args.csv)
+    import sourmash
+    return sourmash.sig.__main__.describe(args)

--- a/sourmash/cli/sig/downsample.py
+++ b/sourmash/cli/sig/downsample.py
@@ -1,6 +1,5 @@
 """downsample one or more signatures"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
@@ -22,8 +21,7 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        default=sys.stdout,
+        '-o', '--output', metavar='FILE',
         help='output signature to this file'
     )
     add_ksize_arg(subparser, 31)

--- a/sourmash/cli/sig/downsample.py
+++ b/sourmash/cli/sig/downsample.py
@@ -22,7 +22,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '-o', '--output', metavar='FILE',
-        help='output signature to this file'
+        help='output signature to this file (default stdout)'
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/sourmash/cli/sig/export.py
+++ b/sourmash/cli/sig/export.py
@@ -14,8 +14,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '-o', '--output', metavar='FILE',
-        default=sys.stdout,
-        help='output signature to this file'
+        help='output signature to this file (default stdout)'
     )
     add_ksize_arg(subparser, 31)
     add_moltype_args(subparser)

--- a/sourmash/cli/sig/export.py
+++ b/sourmash/cli/sig/export.py
@@ -1,6 +1,5 @@
 """export a signature, e.g. to mash"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
@@ -14,7 +13,7 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
+        '-o', '--output', metavar='FILE',
         default=sys.stdout,
         help='output signature to this file'
     )

--- a/sourmash/cli/sig/extract.py
+++ b/sourmash/cli/sig/extract.py
@@ -1,6 +1,5 @@
 """extract one or more signatures"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
@@ -14,8 +13,7 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        default=sys.stdout,
+        '-o', '--output', metavar='FILE',
         help='output signature to this file'
     )
     subparser.add_argument(

--- a/sourmash/cli/sig/extract.py
+++ b/sourmash/cli/sig/extract.py
@@ -14,7 +14,7 @@ def subparser(subparsers):
     )
     subparser.add_argument(
         '-o', '--output', metavar='FILE',
-        help='output signature to this file'
+        help='output signature to this file (default stdout)'
     )
     subparser.add_argument(
         '--md5', default=None,

--- a/sourmash/cli/sig/filter.py
+++ b/sourmash/cli/sig/filter.py
@@ -1,6 +1,5 @@
 """filter k-mers on abundance"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
@@ -14,9 +13,8 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        default=sys.stdout,
-        help='output signature to this file'
+        '-o', '--output', metavar='FILE',
+        help='output signature to this file (default stdout)'
     )
     subparser.add_argument(
         '--md5', type=str, default=None,

--- a/sourmash/cli/sig/flatten.py
+++ b/sourmash/cli/sig/flatten.py
@@ -1,6 +1,5 @@
 """remove abundances"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
@@ -14,9 +13,8 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        default=sys.stdout,
-        help='output signature to this file'
+        '-o', '--output', metavar='FILE',
+        help='output signature to this file (default stdout)'
     )
     subparser.add_argument(
         '--md5', default=None,

--- a/sourmash/cli/sig/ingest.py
+++ b/sourmash/cli/sig/ingest.py
@@ -1,6 +1,5 @@
 """import a mash or other signature"""
 
-from argparse import FileType
 import sys
 
 
@@ -15,9 +14,8 @@ def subparser(subparsers):
             help='suppress non-error output'
         )
         subparser.add_argument(
-            '-o', '--output', metavar='FILE', type=FileType('wt'),
-            default=sys.stdout,
-            help='output signature to this file'
+            '-o', '--output', metavar='FILE',
+            help='output signature to this file (default stdout)'
         )
 
 

--- a/sourmash/cli/sig/intersect.py
+++ b/sourmash/cli/sig/intersect.py
@@ -1,6 +1,5 @@
 """intersect one or more signatures"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
@@ -14,9 +13,8 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        default=sys.stdout,
-        help='output signature to this file'
+        '-o', '--output', metavar='FILE',
+        help='output signature to this file (default stdout)'
     )
     subparser.add_argument(
         '-A', '--abundances-from', metavar='FILE',

--- a/sourmash/cli/sig/merge.py
+++ b/sourmash/cli/sig/merge.py
@@ -1,6 +1,5 @@
 """merge one or more signatures"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
@@ -14,9 +13,8 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        default=sys.stdout,
-        help='output signature to this file'
+        '-o', '--output', metavar='FILE',
+        help='output signature to this file (default stdout)'
     )
     subparser.add_argument(
         '--flatten', action='store_true',

--- a/sourmash/cli/sig/subtract.py
+++ b/sourmash/cli/sig/subtract.py
@@ -1,6 +1,5 @@
 """subtract one or more signatures"""
 
-from argparse import FileType
 import sys
 
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
@@ -15,9 +14,8 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', metavar='FILE', type=FileType('wt'),
-        default=sys.stdout,
-        help='output signature to this file'
+        '-o', '--output', metavar='FILE',
+        help='output signature to this file (default stdout)'
     )
     subparser.add_argument(
         '--flatten', action='store_true',

--- a/sourmash/cli/watch.py
+++ b/sourmash/cli/watch.py
@@ -1,7 +1,5 @@
 """classify a stream of sequences"""
 
-from argparse import FileType
-
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 
 
@@ -14,7 +12,7 @@ def subparser(subparsers):
         help='suppress non-error output'
     )
     subparser.add_argument(
-        '-o', '--output', type=FileType('wt'),
+        '-o', '--output',
         help='save signature generated from data here'
     )
     subparser.add_argument(

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -282,7 +282,8 @@ def import_csv(args):
             notify('loaded signature: {} {}', name, s.md5sum()[:8])
 
         notify('saving {} signatures to JSON', len(siglist))
-        sig.save_signatures(siglist, args.output)
+        with FileOutput(args.output, 'wt') as outfp:
+            sig.save_signatures(siglist, outfp)
 
 
 def dump(args):

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -16,7 +16,7 @@ from . import sourmash_args
 from .logging import notify, error, print_results, set_quiet
 from .sbtmh import SearchMinHashesFindBest, SigLeaf
 
-from .sourmash_args import DEFAULT_LOAD_K
+from .sourmash_args import DEFAULT_LOAD_K, FileOutput
 
 DEFAULT_N = 500
 WATERMARK_SIZE = 10000
@@ -149,14 +149,15 @@ def compare(args):
 
     # output CSV?
     if args.csv:
-        w = csv.writer(args.csv)
-        w.writerow(labeltext)
+        with FileOutput(args.csv, 'wt') as csv_fp:
+            w = csv.writer(csv_fp)
+            w.writerow(labeltext)
 
-        for i in range(len(labeltext)):
-            y = []
-            for j in range(len(labeltext)):
-                y.append('{}'.format(similarity[i][j]))
-            args.csv.write(','.join(y) + '\n')
+            for i in range(len(labeltext)):
+                y = []
+                for j in range(len(labeltext)):
+                    y.append('{}'.format(similarity[i][j]))
+                w.writerow(y)
 
 
 def plot(args):

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -465,20 +465,21 @@ def search(args):
 
     if args.output:
         fieldnames = ['similarity', 'name', 'filename', 'md5']
-        w = csv.DictWriter(args.output, fieldnames=fieldnames)
 
-        w.writeheader()
-        for sr in results:
-            d = dict(sr._asdict())
-            del d['match']
-            w.writerow(d)
+        with FileOutput(args.output, 'wt') as fp:
+            w = csv.DictWriter(fp, fieldnames=fieldnames)
+
+            w.writeheader()
+            for sr in results:
+                d = dict(sr._asdict())
+                del d['match']
+                w.writerow(d)
 
     # save matching signatures upon request
     if args.save_matches:
-        outname = args.save_matches.name
-        notify('saving all matched signatures to "{}"', outname)
-        sig.save_signatures([ sr.match for sr in results ],
-                            args.save_matches)
+        notify('saving all matched signatures to "{}"', args.save_matches)
+        with FileOutput(args.save_matches, 'wt') as fp:
+            sig.save_signatures([ sr.match for sr in results ], fp)
 
 
 def categorize(args):

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -509,6 +509,12 @@ def categorize(args):
     loader = sourmash_args.LoadSingleSignatures(inp_files,
                                                 args.ksize, moltype)
 
+    csv_w = None
+    csv_fp = None
+    if args.csv:
+        csv_fp = open(args.csv, 'wt')
+        csv_w = csv.writer(csv_fp)
+
     for queryfile, query, query_moltype, query_ksize in loader:
         notify('loaded query: {}... (k={}, {})', query.name()[:30],
                query_ksize, query_moltype)
@@ -534,15 +540,17 @@ def categorize(args):
         else:
             notify('for {}, no match found', query.name())
 
-        if args.csv:
-            w = csv.writer(args.csv)
-            w.writerow([queryfile, query.name(), best_hit_query_name,
-                        best_hit_sim])
+        if csv_w:
+            csv_w.writerow([queryfile, query.name(), best_hit_query_name,
+                           best_hit_sim])
 
     if loader.skipped_ignore:
         notify('skipped/ignore: {}', loader.skipped_ignore)
     if loader.skipped_nosig:
         notify('skipped/nosig: {}', loader.skipped_nosig)
+
+    if csv_fp:
+        csv_fp.close()
 
 
 def gather(args):

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -625,24 +625,25 @@ def gather(args):
         fieldnames = ['intersect_bp', 'f_orig_query', 'f_match',
                       'f_unique_to_query', 'f_unique_weighted',
                       'average_abund', 'median_abund', 'std_abund', 'name', 'filename', 'md5']
-        w = csv.DictWriter(args.output, fieldnames=fieldnames)
-        w.writeheader()
-        for result in found:
-            d = dict(result._asdict())
-            del d['match']                 # actual signature not in CSV.
-            w.writerow(d)
+
+        with FileOutput(args.output, 'wt') as fp:
+            w = csv.DictWriter(fp, fieldnames=fieldnames)
+            w.writeheader()
+            for result in found:
+                d = dict(result._asdict())
+                del d['match']                 # actual signature not in CSV.
+                w.writerow(d)
 
     if found and args.save_matches:
-        outname = args.save_matches.name
-        notify('saving all matches to "{}"', outname)
-        sig.save_signatures([ r.match for r in found ], args.save_matches)
+        notify('saving all matches to "{}"', args.save_matches)
+        with FileOutput(args.save_matches, 'wt') as fp:
+            sig.save_signatures([ r.match for r in found ], fp)
 
     if args.output_unassigned:
         if not len(query.minhash):
             notify('no unassigned hashes! not saving.')
         else:
-            outname = args.output_unassigned.name
-            notify('saving unassigned hashes to "{}"', outname)
+            notify('saving unassigned hashes to "{}"', args.output_unassigned)
 
             with_abundance = next_query.minhash.track_abundance
             e = MinHash(ksize=query.minhash.ksize, n=0, max_hash=new_max_hash,
@@ -653,8 +654,8 @@ def gather(args):
             else:
                 e.add_many(next_query.minhash.get_mins())
 
-            sig.save_signatures([ sig.SourmashSignature(e) ],
-                                args.output_unassigned)
+            with FileOutput(args.output_unassigned, 'wt') as fp:
+                sig.save_signatures([ sig.SourmashSignature(e) ], fp)
 
 
 def multigather(args):

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -881,9 +881,11 @@ def watch(args):
                similarity)
 
     if args.output:
-        notify('saving signature to {}', args.output.name)
-        streamsig = sig.SourmashSignature(E, filename='stdin', name=args.name)
-        sig.save_signatures([streamsig], args.output)
+        notify('saving signature to {}', args.output)
+        with FileOutput(args.output, 'wt') as fp:
+            streamsig = sig.SourmashSignature(E, filename='stdin',
+                                              name=args.name)
+        sig.save_signatures([streamsig], fp)
 
 
 def migrate(args):

--- a/sourmash/lca/command_classify.py
+++ b/sourmash/lca/command_classify.py
@@ -110,11 +110,9 @@ def classify(args):
 
     # set up output
     csvfp = csv.writer(sys.stdout)
-    if args.output:
-        notify("outputting classifications to '{}'", args.output.name)
-        csvfp = csv.writer(args.output)
-    else:
-        notify("outputting classifications to stdout")
+    notify("outputting classifications to {}", args.output)
+    with sourmash_args.FileOutput(args.output, 'wt') as outfp:
+        csvfp = csv.writer(outfp)
     csvfp.writerow(['ID','status'] + list(lca_utils.taxlist()))
 
     # for each query, gather all the matches across databases

--- a/sourmash/lca/command_gather.py
+++ b/sourmash/lca/command_gather.py
@@ -244,17 +244,18 @@ def gather_main(args):
         fieldnames = ['intersect_bp', 'f_match', 'f_unique_to_query', 'f_unique_weighted',
                       'average_abund', 'name', 'n_equal_matches'] + list(lca_utils.taxlist())
 
-        w = csv.DictWriter(args.output, fieldnames=fieldnames)
-        w.writeheader()
-        for result in found:
-            lineage = result.lineage
-            d = dict(result._asdict())
-            del d['lineage']
+        with sourmash_args.FileOutput(args.output, 'wt') as csv_fp:
+            w = csv.DictWriter(csv_fp, fieldnames=fieldnames)
+            w.writeheader()
+            for result in found:
+                lineage = result.lineage
+                d = dict(result._asdict())
+                del d['lineage']
 
-            for (rank, value) in lineage:
-                d[rank] = value
+                for (rank, value) in lineage:
+                    d[rank] = value
 
-            w.writerow(d)
+                w.writerow(d)
 
     if args.output_unassigned:
         if not found:
@@ -262,13 +263,13 @@ def gather_main(args):
         elif not remaining_mins:
             notify('no unassigned hashes! not saving.')
         else:
-            outname = args.output_unassigned.name
-            notify('saving unassigned hashes to "{}"', outname)
+            notify('saving unassigned hashes to "{}"', args.output_unassigned)
 
             e = query_sig.minhash.copy_and_clear()
             e.add_many(remaining_mins)
 
-            save_signatures([ SourmashSignature(e) ], args.output_unassigned)
+            with sourmash_args.FileOutput(args.output_unassigned, 'wt') as fp:
+                save_signatures([ SourmashSignature(e) ], fp)
 
 
 if __name__ == '__main__':

--- a/sourmash/lca/command_summarize.py
+++ b/sourmash/lca/command_summarize.py
@@ -131,14 +131,15 @@ def summarize_main(args):
 
     # CSV:
     if args.output:
-        w = csv.writer(args.output)
-        headers = ['count'] + list(lca_utils.taxlist())
-        w.writerow(headers)
+        with sourmash_args.FileOutput(args.output, 'wt') as csv_fp:
+            w = csv.writer(csv_fp)
+            headers = ['count'] + list(lca_utils.taxlist())
+            w.writerow(headers)
 
-        for (lineage, count) in lineage_counts.items():
-            debug('lineage:', lineage)
-            row = [count] + lca_utils.zip_lineage(lineage)
-            w.writerow(row)
+            for (lineage, count) in lineage_counts.items():
+                debug('lineage:', lineage)
+                row = [count] + lca_utils.zip_lineage(lineage)
+                w.writerow(row)
 
 
 if __name__ == '__main__':

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -8,6 +8,7 @@ import json
 
 import sourmash
 import copy
+from sourmash.sourmash_args import FileOutput
 
 from ..logging import set_quiet, error, notify, set_quiet, print_results, debug
 from .. import sourmash_args
@@ -394,14 +395,8 @@ def rename(args):
             sigobj._name = args.name
             outlist.append(sigobj)
 
-    if args.output:
-        fp = open(args.output, 'wt')
-    else:
-        fp = sys.stdout
-
-    sourmash.save_signatures(outlist, fp=fp)
-    if args.output:
-        fp.close()
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures(outlist, fp=fp)
 
     notify("set name to '{}' on {} signatures", args.name, len(outlist))
 
@@ -437,11 +432,8 @@ def extract(args):
         error("no matching signatures!")
         sys.exit(-1)
 
-    if args.output:
-        with open(args.output, 'wt') as fp:
-            sourmash.save_signatures(outlist, fp=fp)
-    else:
-        sourmash.save_signatures(outlist, fp=sys.stdout)
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures(outlist, fp=fp)
 
     notify("extracted {} signatures from {} file(s)", len(outlist),
            len(args.signatures))
@@ -592,12 +584,8 @@ def downsample(args):
 
             output_list.append(sigobj)
 
-    if args.output:
-        fp = open(args.output, 'wt')
+    with FileOutput(args.output, 'wt') as fp:
         sourmash.save_signatures(output_list, fp=fp)
-        fp.close()
-    else:
-        sourmash.save_signatures(output_list, fp=sys.stdout)
 
     notify("loaded and downsampled {} signatures", total_loaded)
 

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -82,8 +82,10 @@ def describe(args):
 
     # write CSV?
     w = None
+    csv_fp = None
     if args.csv:
-        w = csv.DictWriter(args.csv,
+        csv_fp = open(args.csv, 'wt')
+        w = csv.DictWriter(csv_fp,
                            ['signature_file', 'md5', 'ksize', 'moltype', 'num',
                             'scaled', 'n_hashes', 'seed', 'with_abundance',
                             'name', 'filename', 'license'],
@@ -127,6 +129,9 @@ k={ksize} molecule={moltype} num={num} scaled={scaled} seed={seed} track_abundan
 size: {n_hashes}
 signature license: {license}
 ''', **locals())
+
+    if csv_fp:
+        csv_fp.close()
 
 
 def overlap(args):
@@ -432,7 +437,11 @@ def extract(args):
         error("no matching signatures!")
         sys.exit(-1)
 
-    sourmash.save_signatures(outlist, fp=args.output)
+    if args.output:
+        with open(args.output, 'wt') as fp:
+            sourmash.save_signatures(outlist, fp=fp)
+    else:
+        sourmash.save_signatures(outlist, fp=sys.stdout)
 
     notify("extracted {} signatures from {} file(s)", len(outlist),
            len(args.signatures))
@@ -583,7 +592,12 @@ def downsample(args):
 
             output_list.append(sigobj)
 
-    sourmash.save_signatures(output_list, fp=args.output)
+    if args.output:
+        fp = open(args.output, 'wt')
+        sourmash.save_signatures(output_list, fp=fp)
+        fp.close()
+    else:
+        sourmash.save_signatures(output_list, fp=sys.stdout)
 
     notify("loaded and downsampled {} signatures", total_loaded)
 
@@ -640,7 +654,8 @@ def export(args):
     ll = list(mh.get_mins())
     x['sketches'] = [{ 'hashes': ll }]
 
-    print(json.dumps(x), file=args.output)
+    with open(args.output, 'wt') as fp:
+        print(json.dumps(x), file=fp)
     notify("exported signature {} ({})", ss.name(), ss.md5sum()[:8])
 
 

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -265,7 +265,8 @@ def merge(args):
 
     merged_sigobj = sourmash.SourmashSignature(mh)
 
-    sourmash.save_signatures([merged_sigobj], fp=args.output)
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures([merged_sigobj], fp=fp)
 
     notify('loaded and merged {} signatures', total_loaded)
 
@@ -324,7 +325,8 @@ def intersect(args):
         intersect_mh.set_abundances(abund_mins)
         intersect_sigobj = sourmash.SourmashSignature(intersect_mh)
 
-    sourmash.save_signatures([intersect_sigobj], fp=args.output)
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures([intersect_sigobj], fp=fp)
 
     notify('loaded and intersected {} signatures', total_loaded)
 
@@ -373,7 +375,8 @@ def subtract(args):
 
     subtract_sigobj = sourmash.SourmashSignature(subtract_mh)
 
-    sourmash.save_signatures([subtract_sigobj], fp=args.output)
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures([subtract_sigobj], fp=fp)
 
     notify('loaded and subtracted {} signatures', total_loaded)
 
@@ -484,7 +487,8 @@ def filter(args):
 
         outlist.extend(siglist)
 
-    sourmash.save_signatures(outlist, fp=args.output)
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures(outlist, fp=fp)
 
     notify("loaded {} total that matched ksize & molecule type",
            total_loaded)
@@ -524,7 +528,8 @@ def flatten(args):
 
         outlist.extend(siglist)
 
-    sourmash.save_signatures(outlist, fp=args.output)
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures(outlist, fp=fp)
 
     notify("loaded {} total that matched ksize & molecule type",
            total_loaded)
@@ -617,7 +622,8 @@ def sig_import(args):
         s = sourmash.SourmashSignature(mh, filename=filename)
         siglist.append(s)
 
-    sourmash.save_signatures(siglist, args.output)
+    with FileOutput(args.output, 'wt') as fp:
+        sourmash.save_signatures(siglist, fp)
 
 
 def export(args):

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -642,7 +642,7 @@ def export(args):
     ll = list(mh.get_mins())
     x['sketches'] = [{ 'hashes': ll }]
 
-    with open(args.output, 'wt') as fp:
+    with FileOutput(args.output, 'wt') as fp:
         print(json.dumps(x), file=fp)
     notify("exported signature {} ({})", ss.name(), ss.md5sum()[:8])
 

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -303,3 +303,46 @@ def load_dbs_and_sigs(filenames, query, is_similarity_query, traverse=False):
         print('')
 
     return databases
+
+
+class FileOutput(object):
+    """A context manager for file outputs that handles sys.stdout gracefully.
+
+    Usage:
+
+       with FileOutput(filename, mode) as fp:
+          ...
+
+    does what you'd expect, but it handles the situation where 'filename'
+    is '-' or None. This makes it nicely compatible with argparse usage,
+    e.g.
+
+    p = argparse.ArgumentParser()
+    p.add_argument('--output')
+    args = p.parse_args()
+    ...
+    with FileOutput(args.output, 'wt') as fp:
+       ...
+
+    will properly handle no argument or '-' as sys.stdout.
+    """
+    def __init__(self, filename, mode='wt'):
+        self.filename = filename
+        self.mode = mode
+        self.fp = None
+
+    def open(self):
+        if self.filename == '-' or self.filename is None:
+            return sys.stdout
+        self.fp = open(self.filename, self.mode)
+        return self.fp
+
+    def __enter__(self):
+        return self.open()
+
+    def __exit__(self, type, value, traceback):
+        # do we need to handle exceptions here?
+        if self.fp:
+            self.fp.close()
+
+        return False

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -202,9 +202,20 @@ def test_do_compare_output_csv():
                                            in_directory=location)
 
         with open(os.path.join(location, 'xxx')) as fp:
-            lines = fp.readlines()
-            assert len(lines) == 3
-            assert lines[1:] == [u'1.0,0.93\n', '0.93,1.0\n']
+            r = iter(csv.reader(fp))
+            row = next(r)
+            print(row)
+            row = next(r)
+            print(row)
+            assert float(row[0]) == 1.0
+            assert float(row[1]) == 0.93
+            row = next(r)
+            assert float(row[0]) == 0.93
+            assert float(row[1]) == 1.0
+
+            # exactly three lines
+            with pytest.raises(StopIteration) as e:
+                next(r)
 
 
 def test_do_compare_downsample():

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -204,7 +204,7 @@ def test_do_compare_output_csv():
         with open(os.path.join(location, 'xxx')) as fp:
             lines = fp.readlines()
             assert len(lines) == 3
-            assert lines[1:] == ['1.0,0.93\n', '0.93,1.0\n']
+            assert lines[1:] == [u'1.0,0.93\n', '0.93,1.0\n']
 
 
 def test_do_compare_downsample():


### PR DESCRIPTION
`argparse.FileType('wt')` is annoying because it opens the specified file immediately upon argument parsing, which overwrites it. As shown in #571, this can destroy outputs unnecessarily.

This PR changes most of the `FileType` arguments in sourmash to string filenames, which are only opened at the time of write. I add a `FileOutput` context manager that behaves properly wrt default arguments encountered in the wild.

Fixes #571, overwriting files even on error.
May pave the way for `--inplace` behavior, ref #625.
Also cleans up an accidental duplication of  the `describe` implementation 😆

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
