### PR TITLE
add --labeltext to plot

### DIFF
--- a/sourmash/cli/plot.py
+++ b/sourmash/cli/plot.py
@@ -14,6 +14,10 @@ def subparser(subparsers):
         help='show sample labels on dendrogram/matrix'
     )
     subparser.add_argument(
+        '--labeltext',
+        help='filename containing list of labels (overrides signature names)'
+    )
+    subparser.add_argument(
         '--indices', action='store_false',
         help='show sample indices but not labels'
     )

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -161,7 +161,7 @@ def compare(args):
 
 
 def plot(args):
-    "Produce a clustering and plot."
+    "Produce a clustering matrix and plot."
     import matplotlib as mpl
     mpl.use('Agg')
     import numpy
@@ -177,10 +177,12 @@ def plot(args):
     D = numpy.load(open(D_filename, 'rb'))
     notify('...got {} x {} matrix.', *D.shape)
 
+    if args.labeltext:
+        labelfilename = args.labeltext
     notify('loading labels from {}', labelfilename)
     labeltext = [ x.strip() for x in open(labelfilename) ]
     if len(labeltext) != D.shape[0]:
-        error('{} labels != matrix size, exiting')
+        error('{} labels != matrix size, exiting', len(labeltext))
         sys.exit(-1)
 
     # build filenames, decide on PDF/PNG output
@@ -233,6 +235,7 @@ def plot(args):
         np_idx = numpy.array(sample_idx)
         D = D[numpy.ix_(np_idx, np_idx)]
         labeltext = [ labeltext[idx] for idx in sample_idx ]
+
     ### do clustering
     Y = sch.linkage(D, method='single')
     sch.dendrogram(Y, orientation='right', labels=labeltext)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -478,6 +478,68 @@ def test_do_plot_comparison_4_fail_not_distance():
         assert status != 0
 
 
+def test_plot_override_labeltext():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+        testdata2 = utils.get_test_data('genome-s11.fa.gz.sig')
+        testdata3 = utils.get_test_data('genome-s12.fa.gz.sig')
+        testdata4 = utils.get_test_data('genome-s10+s11.sig')
+        inp_sigs = [testdata1, testdata2, testdata3, testdata4]
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare'] + inp_sigs + \
+                                           ['-o', 'cmp', '-k', '21', '--dna'],
+                                           in_directory=location)
+
+        with open(os.path.join(location, 'new.labels.txt'), 'wt') as fp:
+            fp.write('a\nb\nc\nd\n')
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['plot', 'cmp',
+                                            '--labeltext', 'new.labels.txt'],
+                                           in_directory=location)
+
+        print(out)
+
+        assert 'loading labels from new.labels.txt' in err
+
+        expected = """\
+0\ta
+1\tb
+2\tc
+3\td"""
+        assert expected in out
+
+
+def test_plot_override_labeltext_fail():
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+        testdata2 = utils.get_test_data('genome-s11.fa.gz.sig')
+        testdata3 = utils.get_test_data('genome-s12.fa.gz.sig')
+        testdata4 = utils.get_test_data('genome-s10+s11.sig')
+        inp_sigs = [testdata1, testdata2, testdata3, testdata4]
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['compare'] + inp_sigs + \
+                                           ['-o', 'cmp', '-k', '21', '--dna'],
+                                           in_directory=location)
+
+        with open(os.path.join(location, 'new.labels.txt'), 'wt') as fp:
+            fp.write('a\nb\nc\n')
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['plot', 'cmp',
+                                            '--labeltext', 'new.labels.txt'],
+                                           in_directory=location,
+                                           fail_ok=True)
+
+        print(out)
+        print(err)
+        assert status != 0
+        assert 'loading labels from new.labels.txt' in err
+        assert '3 labels != matrix size, exiting' in err
+
+
 def test_plot_subsample_1():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')


### PR DESCRIPTION
Fixes #486. Also, bonus! Fixes an output bug that wasn't tested (error message when label number didn't match matrix size).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
