### PR TITLE
Refactor and oxidize downsampling code in sbtmh.py

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -110,13 +110,13 @@ void kmerminhash_add_protein(KmerMinHash *ptr, const char *sequence);
 
 void kmerminhash_add_word(KmerMinHash *ptr, const char *word);
 
-double kmerminhash_compare(KmerMinHash *ptr, const KmerMinHash *other);
+double kmerminhash_compare(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 
-double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance);
+double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance, bool downsample);
 
 double kmerminhash_containment_ignore_maxhash(KmerMinHash *ptr, const KmerMinHash *other);
 
-uint64_t kmerminhash_count_common(KmerMinHash *ptr, const KmerMinHash *other);
+uint64_t kmerminhash_count_common(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 
 bool kmerminhash_dayhoff(KmerMinHash *ptr);
 

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -14,6 +14,7 @@ MINHASH_DEFAULT_SEED = 42
 
 
 def get_minhash_default_seed():
+    "Return the default seed value used for the MurmurHash hashing function."
     return MINHASH_DEFAULT_SEED
 
 
@@ -23,10 +24,12 @@ MINHASH_MAX_HASH = 0xFFFFFFFFFFFFFFFF
 
 
 def get_minhash_max_hash():
+    "Return the maximum hash value."
     return MINHASH_MAX_HASH
 
 
 def get_max_hash_for_scaled(scaled):
+    "Convert a 'scaled' value into a 'max_hash' value."
     if scaled == 0:
         return 0
     elif scaled == 1:
@@ -36,6 +39,7 @@ def get_max_hash_for_scaled(scaled):
 
 
 def get_scaled_for_max_hash(max_hash):
+    "Convert a 'max_hash' value into a 'scaled' value."
     if max_hash == 0:
         return 0
     return int(round(get_minhash_max_hash() / max_hash, 0))

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -382,6 +382,7 @@ class MinHash(RustObject):
         return common, max(size, 1)
 
     def compare(self, other, downsample=False):
+        "Compare two sketches, w/o abundance; calculates Jaccard similarity."
         if self.num != other.num:
             err = "must have same num: {} != {}".format(self.num, other.num)
             raise TypeError(err)
@@ -404,7 +405,8 @@ class MinHash(RustObject):
         """
 
         # if either signature is flat, calculate Jaccard only.
-        if not (self.track_abundance and other.track_abundance) or ignore_abundance:
+        both_track_abundance = self.track_abundance and other.track_abundance
+        if not both_track_abundance or ignore_abundance:
             return self.compare(other, downsample)
         else:
             return self._methodcall(lib.kmerminhash_similarity,

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -395,8 +395,8 @@ class MinHash(RustObject):
         If the sketches are not abundance weighted, or ignore_abundance=True,
         compute Jaccard similarity.
 
-        If the sketches are abundance weighted, calculate a distance metric
-        based on the cosine similarity.
+        If the sketches are abundance weighted, calculate the angular
+        similarity, a distance metric based on the cosine similarity.
 
         Note, because the term frequencies (tf-idf weights) cannot be negative,
         the angle will never be < 0deg or > 90deg.

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -525,6 +525,7 @@ def categorize(args):
         results = []
         search_fn = SearchMinHashesFindBest().search
 
+        # note, "ignore self" here may prevent using newer 'tree.search' fn.
         for leaf in tree.find(search_fn, query, args.threshold):
             if leaf.data.md5sum() != query.md5sum(): # ignore self.
                 similarity = query.similarity(
@@ -852,13 +853,14 @@ def watch(args):
     notify('Computing signature for k={}, {} from stdin', ksize, moltype)
 
     def do_search():
-        search_fn = SearchMinHashesFindBest().search
-
         results = []
         streamsig = sig.SourmashSignature(E, filename='stdin', name=args.name)
-        for leaf in tree.find(search_fn, streamsig, args.threshold):
-            results.append((streamsig.similarity(leaf.data),
-                            leaf.data))
+        for similarity, match, _ in tree.search(streamsig,
+                                                threshold=args.threshold,
+                                                best_only=True,
+                                                ignore_abundance=True,
+                                                do_containment=False):
+            results.append((similarity, match))
 
         return results
 

--- a/sourmash/compare.py
+++ b/sourmash/compare.py
@@ -39,40 +39,13 @@ def compare_serial(siglist, ignore_abundance, downsample=False):
     return similarities
 
 
-def similarity(sig1, sig2, ignore_abundance, downsample):
-    """Compute similarity with the other MinHash signature.
-    This function is separated from the SourmashSignature to
-    avoid pickling the whole class during the pool map
-
-    :param sig1 first signature
-    :param sig2 other signature to compare with
-    :param boolean ignore_abundance
-        If the sketches are not abundance weighted, or ignore_abundance=True,
-        compute Jaccard similarity.
-
-        If the sketches are abundance weighted, calculate a distance metric
-        based on the cosine similarity.
-    :param boolean downsample by max_hash if True
-    :return: float similarity of the two signatures
-    """
-
-    try:
-        sig = sig1.minhash.similarity(sig2.minhash, ignore_abundance)
-        return sig
-    except ValueError as e:
-        if 'mismatch in max_hash' in str(e) and downsample:
-            xx = sig1.minhash.downsample_max_hash(sig2.minhash)
-            yy = sig2.minhash.downsample_max_hash(sig1.minhash)
-            sig = similarity(xx, yy, ignore_abundance, False)
-            return sig
-        else:
-            raise
-
-
 def similarity_args_unpack(args, ignore_abundance, downsample):
-    """Helper function to unpack the arguments. Written to use in pool.imap as it
-    can only be given one argument."""
-    return similarity(*args, ignore_abundance=ignore_abundance, downsample=downsample)
+    """Helper function to unpack the arguments. Written to use in pool.imap
+    as it can only be given one argument."""
+    sig1, sig2 = args
+    return sig1.similarity(sig2,
+                           ignore_abundance=ignore_abundance,
+                           downsample=downsample)
 
 
 def get_similarities_at_index(index, ignore_abundance, downsample, siglist):

--- a/sourmash/compare.py
+++ b/sourmash/compare.py
@@ -19,8 +19,8 @@ def compare_serial(siglist, ignore_abundance, downsample=False):
         If the sketches are not abundance weighted, or ignore_abundance=True,
         compute Jaccard similarity.
 
-        If the sketches are abundance weighted, calculate a distance metric
-        based on the cosine similarity.
+        If the sketches are abundance weighted, calculate the angular
+        similarity.
     :param boolean downsample by max_hash if True
     :return: np.array similarity matrix
     """
@@ -58,8 +58,8 @@ def get_similarities_at_index(index, ignore_abundance, downsample, siglist):
         If the sketches are not abundance weighted, or ignore_abundance=True,
         compute Jaccard similarity.
 
-        If the sketches are abundance weighted, calculate a distance metric
-        based on the cosine similarity.
+        If the sketches are abundance weighted, calculate the angular
+        similarity.
     :param boolean downsample by max_hash if True
     :param siglist list of signatures
     :return: list of similarities for the combinations of signature at index with
@@ -89,8 +89,8 @@ def compare_parallel(siglist, ignore_abundance, downsample, n_jobs):
         If the sketches are not abundance weighted, or ignore_abundance=True,
         compute Jaccard similarity.
 
-        If the sketches are abundance weighted, calculate a distance metric
-        based on the cosine similarity.
+        If the sketches are abundance weighted, calculate the angular
+        similarity.
     :param boolean downsample by max_hash if True
     :param int n_jobs number of processes to run the similarity calculations on
     :return: np.array similarity matrix
@@ -169,8 +169,8 @@ def compare_all_pairs(siglist, ignore_abundance, downsample=False, n_jobs=None):
         If the sketches are not abundance weighted, or ignore_abundance=True,
         compute Jaccard similarity.
 
-        If the sketches are abundance weighted, calculate a distance metric
-        based on the cosine similarity.
+        If the sketches are abundance weighted, calculate the angular
+        similarity.
     :param boolean downsample by max_hash if True
     :param int n_jobs number of processes to run the similarity calculations on,
     if number of jobs is None or 1, compare serially, otherwise parallely.

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -280,16 +280,6 @@ class SBT(Index):
         best_only = kwargs['best_only']
         unload_data = kwargs.get('unload_data', False)
 
-        search_fn = search_minhashes
-        query_match = lambda x: query.similarity(
-            x, downsample=True, ignore_abundance=ignore_abundance)
-        if do_containment:
-            search_fn = search_minhashes_containment
-            query_match = lambda x: query.contained_by(x, downsample=True)
-        
-        if best_only:            # this needs to be reset for each SBT
-            search_fn = SearchMinHashesFindBest().search
-
         # figure out scaled value of tree, downsample query if needed.
         leaf = next(iter(self.leaves()))
         tree_mh = leaf.data.minhash
@@ -300,6 +290,17 @@ class SBT(Index):
             resampled_query_mh = tree_query.minhash
             resampled_query_mh = resampled_query_mh.downsample_scaled(tree_mh.scaled)
             tree_query = SourmashSignature(resampled_query_mh)
+
+        # define both search function and post-search calculation function
+        search_fn = search_minhashes
+        query_match = lambda x: tree_query.similarity(
+            x, downsample=False, ignore_abundance=ignore_abundance)
+        if do_containment:
+            search_fn = search_minhashes_containment
+            query_match = lambda x: tree_query.contained_by(x, downsample=True)
+
+        if best_only:            # this needs to be reset for each SBT
+            search_fn = SearchMinHashesFindBest().search
 
         # now, search!
         results = []

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -107,29 +107,7 @@ def _max_jaccard_underneath_internal_node(node, hashes):
     return max_score
 
 
-def _similarity_downsample(mh_1, mh_2):
-    "calculate Jaccard similarity w/downsampling, if needed"
-    max_scaled = max(mh_1.scaled, mh_2.scaled)
-    if mh_1.scaled != max_scaled:
-        mh_1 = mh_1.downsample_scaled(max_scaled)
-    if mh_2.scaled != max_scaled:
-        mh_2 = mh_2.downsample_scaled(max_scaled)
-
-    return mh_1.similarity(mh_2)
-
-
-def _count_common_downsample(mh_1, mh_2):
-    "calculate common hashes, with downsampling if needed"
-    max_scaled = max(mh_1.scaled, mh_2.scaled)
-    if mh_1.scaled != max_scaled:
-        mh_1 = mh_1.downsample_scaled(max_scaled)
-    if mh_2.scaled != max_scaled:
-        mh_2 = mh_2.downsample_scaled(max_scaled)
-
-    return mh_1.count_common(mh_2)
-
-
-def search_minhashes(node, sig, threshold, results=None, downsample=True):
+def search_minhashes(node, sig, threshold, results=None):
     """\
     Default tree search function, searching for best Jaccard similarity.
     """
@@ -137,10 +115,7 @@ def search_minhashes(node, sig, threshold, results=None, downsample=True):
     score = 0
 
     if isinstance(node, SigLeaf):
-        if downsample:
-            score = _similarity_downsample(sig.minhash, node.data.minhash)
-        else:
-            score = node.data.minhash.similarity(sig.minhash)
+        score = node.data.minhash.similarity(sig.minhash)
     else:  # Node minhash comparison
         score = _max_jaccard_underneath_internal_node(node, mins)
 
@@ -154,19 +129,15 @@ def search_minhashes(node, sig, threshold, results=None, downsample=True):
 
 
 class SearchMinHashesFindBest(object):
-    def __init__(self, downsample=True):
+    def __init__(self):
         self.best_match = 0.
-        self.downsample = downsample
 
     def search(self, node, sig, threshold, results=None):
         mins = sig.minhash.get_mins()
         score = 0
 
         if isinstance(node, SigLeaf):
-            if self.downsample:
-                score = _similarity_downsample(sig.minhash, node.data.minhash)
-            else:
-                score = node.data.minhash.similarity(sig.minhash)
+            score = node.data.minhash.similarity(sig.minhash)
         else:  # internal object, not leaf.
             score = _max_jaccard_underneath_internal_node(node, mins)
 
@@ -188,10 +159,7 @@ def search_minhashes_containment(node, sig, threshold, results=None, downsample=
     mins = sig.minhash.get_mins()
 
     if isinstance(node, SigLeaf):
-        if downsample:
-            matches = _count_common_downsample(sig.minhash, node.data.minhash)
-        else:
-            matches = node.data.minhash.count_common(sig.minhash)
+        matches = node.data.minhash.count_common(sig.minhash, downsample)
     else:  # Node or Leaf, Nodegraph by minhash comparison
         get = node.data.get
         matches = sum(1 for value in mins if get(value))
@@ -214,8 +182,7 @@ class GatherMinHashes(object):
             return 0
 
         if isinstance(node, SigLeaf):
-            matches = _count_common_downsample(node.data.minhash,
-                                               query.minhash)
+            matches = query.minhash.count_common(node.data.minhash, True)
         else:  # Nodegraph by minhash comparison
             mins = query.minhash.get_mins()
             get = node.data.get

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -109,18 +109,13 @@ def _max_jaccard_underneath_internal_node(node, hashes):
 
 def _similarity_downsample(mh_1, mh_2):
     "calculate Jaccard similarity w/downsampling, if needed"
-    try:
-        score = mh_2.similarity(mh_1)
-    except Exception as e:
-        if 'mismatch in max_hash' in str(e):
-            xx = mh_1.downsample_max_hash(mh_1)
-            yy = mh_2.downsample_max_hash(mh_2)
+    max_scaled = max(mh_1.scaled, mh_2.scaled)
+    if mh_1.scaled != max_scaled:
+        mh_1 = mh_1.downsample_scaled(max_scaled)
+    if mh_2.scaled != max_scaled:
+        mh_2 = mh_2.downsample_scaled(max_scaled)
 
-            score = yy.similarity(xx)
-        else:
-            raise
-
-    return score
+    return mh_1.similarity(mh_2)
 
 
 def _count_common_downsample(mh_1, mh_2):

--- a/sourmash/signature.py
+++ b/sourmash/signature.py
@@ -129,31 +129,18 @@ class SourmashSignature(RustObject):
 
     def similarity(self, other, ignore_abundance=False, downsample=False):
         "Compute similarity with the other signature."
-        try:
-            return self.minhash.similarity(other.minhash, ignore_abundance)
-        except ValueError as e:
-            if "mismatch in max_hash" in str(e) and downsample:
-                xx = self.minhash.downsample_max_hash(other.minhash)
-                yy = other.minhash.downsample_max_hash(self.minhash)
-                return xx.similarity(yy, ignore_abundance)
-            else:
-                raise
+        return self.minhash.similarity(other.minhash,
+                                       ignore_abundance=ignore_abundance,
+                                       downsample=downsample)
 
     def jaccard(self, other):
         "Compute Jaccard similarity with the other MinHash signature."
-        return self.minhash.similarity(other.minhash, True)
+        return self.minhash.similarity(other.minhash, ignore_abundance=True,
+                                       downsample=False)
 
     def contained_by(self, other, downsample=False):
         "Compute containment by the other signature. Note: ignores abundance."
-        try:
-            return self.minhash.contained_by(other.minhash)
-        except ValueError as e:
-            if "mismatch in max_hash" in str(e) and downsample:
-                xx = self.minhash.downsample_max_hash(other.minhash)
-                yy = other.minhash.downsample_max_hash(self.minhash)
-                return xx.contained_by(yy)
-            else:
-                raise
+        return self.minhash.contained_by(other.minhash, downsample)
 
     def add_sequence(self, sequence, force=False):
         self._methodcall(lib.signature_add_sequence, to_bytes(sequence), force)

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 description = "MinHash sketches for genomic data"
 repository = "https://github.com/dib-lab/sourmash"

--- a/src/core/src/errors.rs
+++ b/src/core/src/errors.rs
@@ -15,8 +15,8 @@ pub enum SourmashError {
     #[fail(display = "DNA/prot minhashes cannot be compared")]
     MismatchDNAProt,
 
-    #[fail(display = "mismatch in max_hash; comparison fail")]
-    MismatchMaxHash,
+    #[fail(display = "mismatch in scaled; comparison fail")]
+    MismatchScaled,
 
     #[fail(display = "mismatch in seed; comparison fail")]
     MismatchSeed,
@@ -55,7 +55,7 @@ pub enum SourmashErrorCode {
     // Compatibility errors
     MismatchKSizes = 1_01,
     MismatchDNAProt = 1_02,
-    MismatchMaxHash = 1_03,
+    MismatchScaled = 1_03,
     MismatchSeed = 1_04,
     MismatchSignatureType = 1_05,
     NonEmptyMinHash = 1_06,
@@ -87,7 +87,7 @@ impl SourmashErrorCode {
                     SourmashError::MismatchNum { .. } => SourmashErrorCode::MismatchNum,
                     SourmashError::MismatchKSizes => SourmashErrorCode::MismatchKSizes,
                     SourmashError::MismatchDNAProt => SourmashErrorCode::MismatchDNAProt,
-                    SourmashError::MismatchMaxHash => SourmashErrorCode::MismatchMaxHash,
+                    SourmashError::MismatchScaled => SourmashErrorCode::MismatchScaled,
                     SourmashError::MismatchSeed => SourmashErrorCode::MismatchSeed,
                     SourmashError::MismatchSignatureType => {
                         SourmashErrorCode::MismatchSignatureType

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -471,7 +471,7 @@ unsafe fn kmerminhash_add_from(ptr: *mut KmerMinHash, other: *const KmerMinHash)
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_count_common(ptr: *mut KmerMinHash, other: *const KmerMinHash)
+unsafe fn kmerminhash_count_common(ptr: *mut KmerMinHash, other: *const KmerMinHash, downsample: bool)
     -> Result<u64> {
     let mh = {
         assert!(!ptr.is_null());
@@ -482,7 +482,7 @@ unsafe fn kmerminhash_count_common(ptr: *mut KmerMinHash, other: *const KmerMinH
        &*other
     };
 
-    mh.count_common(other_mh)
+    mh.count_common(other_mh, downsample)
 }
 }
 
@@ -522,7 +522,7 @@ unsafe fn kmerminhash_containment_ignore_maxhash(ptr: *mut KmerMinHash, other: *
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash)
+unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash, downsample: bool)
     -> Result<f64> {
     let mh = {
         assert!(!ptr.is_null());
@@ -533,12 +533,12 @@ unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash)
        &*other
     };
 
-    mh.compare(other_mh)
+    mh.compare(other_mh, downsample)
 }
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_similarity(ptr: *mut KmerMinHash, other: *const KmerMinHash, ignore_abundance: bool)
+unsafe fn kmerminhash_similarity(ptr: *mut KmerMinHash, other: *const KmerMinHash, ignore_abundance: bool, downsample: bool)
     -> Result<f64> {
     let mh = {
         assert!(!ptr.is_null());
@@ -549,6 +549,6 @@ unsafe fn kmerminhash_similarity(ptr: *mut KmerMinHash, other: *const KmerMinHas
        &*other
     };
 
-    mh.similarity(other_mh, ignore_abundance)
+    mh.similarity(other_mh, ignore_abundance, downsample)
 }
 }

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -190,7 +190,7 @@ impl SigStore<Signature> {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &ng.signatures[0] {
             if let Sketch::MinHash(omh) = &ong.signatures[0] {
-                return mh.count_common(&omh).unwrap() as u64;
+                return mh.count_common(&omh, false).unwrap() as u64;
             }
         }
         unimplemented!();
@@ -247,7 +247,7 @@ impl Comparable<SigStore<Signature>> for SigStore<Signature> {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &ng.signatures[0] {
             if let Sketch::MinHash(omh) = &ong.signatures[0] {
-                return mh.compare(&omh).unwrap();
+                return mh.compare(&omh, false).unwrap();
             }
         }
 
@@ -270,7 +270,7 @@ impl Comparable<SigStore<Signature>> for SigStore<Signature> {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &ng.signatures[0] {
             if let Sketch::MinHash(omh) = &ong.signatures[0] {
-                let common = mh.count_common(&omh).unwrap();
+                let common = mh.count_common(&omh, false).unwrap();
                 let size = mh.mins.len();
                 return common as f64 / size as f64;
             }
@@ -285,7 +285,7 @@ impl Comparable<Signature> for Signature {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &self.signatures[0] {
             if let Sketch::MinHash(omh) = &other.signatures[0] {
-                return mh.compare(&omh).unwrap();
+                return mh.compare(&omh, false).unwrap();
             }
         }
 
@@ -305,7 +305,7 @@ impl Comparable<Signature> for Signature {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &self.signatures[0] {
             if let Sketch::MinHash(omh) = &other.signatures[0] {
-                let common = mh.count_common(&omh).unwrap();
+                let common = mh.count_common(&omh, false).unwrap();
                 let size = mh.mins.len();
                 return common as f64 / size as f64;
             }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -769,7 +769,7 @@ impl SigsTrait for KmerMinHash {
                     }
                     last_position_check += 1;
                 }
-                return true;
+                true
             };
 
             for i in 0..=len - ksize {

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -470,7 +470,7 @@ impl KmerMinHash {
                     other.abunds.is_some(),
                 );
                 new_mh.add_many(&other.mins)?;
-                return self.count_common(&new_mh, false);
+                self.count_common(&new_mh, false)
             } else {
                 // other.max_hash < self.max_hash
                 let mut new_mh = KmerMinHash::new(
@@ -482,7 +482,7 @@ impl KmerMinHash {
                     self.abunds.is_some(),
                 );
                 new_mh.add_many(&self.mins)?;
-                return new_mh.count_common(other, false);
+                new_mh.count_common(other, false)
             }
         } else {
             self.check_compatible(other)?;
@@ -556,7 +556,7 @@ impl KmerMinHash {
                     other.abunds.is_some(),
                 );
                 new_mh.add_many(&other.mins)?;
-                return self.compare(&new_mh, false);
+                self.compare(&new_mh, false)
             } else {
                 // other.max_hash < self.max_hash
                 let mut new_mh = KmerMinHash::new(
@@ -568,7 +568,7 @@ impl KmerMinHash {
                     self.abunds.is_some(),
                 );
                 new_mh.add_many(&self.mins)?;
-                return new_mh.compare(other, false);
+                new_mh.compare(other, false)
             }
         } else {
             self.check_compatible(other)?;
@@ -598,7 +598,7 @@ impl KmerMinHash {
                     other.abunds.is_some(),
                 );
                 new_mh.add_many_with_abund(&other.to_vec_abunds())?;
-                return self.compare(&new_mh, false);
+                self.compare(&new_mh, false)
             } else {
                 // other.max_hash < self.max_hash
                 let mut new_mh = KmerMinHash::new(
@@ -610,7 +610,7 @@ impl KmerMinHash {
                     self.abunds.is_some(),
                 );
                 new_mh.add_many_with_abund(&self.to_vec_abunds())?;
-                return new_mh.compare(other, false);
+                new_mh.compare(other, false)
             }
         } else {
             self.check_compatible(other)?;

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -458,11 +458,38 @@ impl KmerMinHash {
         Ok(())
     }
 
-    pub fn count_common(&self, other: &KmerMinHash) -> Result<u64, Error> {
-        self.check_compatible(other)?;
-        let iter = Intersection::new(self.mins.iter(), other.mins.iter());
+    pub fn count_common(&self, other: &KmerMinHash, downsample: bool) -> Result<u64, Error> {
+        if downsample && self.max_hash != other.max_hash {
+            if self.max_hash < other.max_hash {
+                let mut new_mh = KmerMinHash::new(
+                    other.num,
+                    other.ksize,
+                    other.hash_function,
+                    other.seed,
+                    self.max_hash,
+                    other.abunds.is_some(),
+                );
+                new_mh.add_many(&other.mins)?;
+                return self.count_common(&new_mh, false);
+            } else {
+                // other.max_hash < self.max_hash
+                let mut new_mh = KmerMinHash::new(
+                    self.num,
+                    self.ksize,
+                    self.hash_function,
+                    self.seed,
+                    other.max_hash,
+                    self.abunds.is_some(),
+                );
+                new_mh.add_many(&self.mins)?;
+                return new_mh.count_common(other, false);
+            }
+        } else {
+            self.check_compatible(other)?;
+            let iter = Intersection::new(self.mins.iter(), other.mins.iter());
 
-        Ok(iter.count() as u64)
+            Ok(iter.count() as u64)
+        }
     }
 
     pub fn intersection(&self, other: &KmerMinHash) -> Result<(Vec<u64>, u64), Error> {
@@ -516,67 +543,128 @@ impl KmerMinHash {
         Ok((it2.count() as u64, combined_mh.mins.len() as u64))
     }
 
-    pub fn compare(&self, other: &KmerMinHash) -> Result<f64, Error> {
-        self.check_compatible(other)?;
-        if let Ok((common, size)) = self.intersection_size(other) {
-            Ok(common as f64 / u64::max(1, size) as f64)
+    // compare two minhashes, ignoring abundance.
+    pub fn compare(&self, other: &KmerMinHash, downsample: bool) -> Result<f64, Error> {
+        if downsample && self.max_hash != other.max_hash {
+            if self.max_hash < other.max_hash {
+                let mut new_mh = KmerMinHash::new(
+                    other.num,
+                    other.ksize,
+                    other.hash_function,
+                    other.seed,
+                    self.max_hash,
+                    other.abunds.is_some(),
+                );
+                new_mh.add_many(&other.mins)?;
+                return self.compare(&new_mh, false);
+            } else {
+                // other.max_hash < self.max_hash
+                let mut new_mh = KmerMinHash::new(
+                    self.num,
+                    self.ksize,
+                    self.hash_function,
+                    self.seed,
+                    other.max_hash,
+                    self.abunds.is_some(),
+                );
+                new_mh.add_many(&self.mins)?;
+                return new_mh.compare(other, false);
+            }
         } else {
-            Ok(0.0)
-        }
-    }
-
-    pub fn similarity(&self, other: &KmerMinHash, ignore_abundance: bool) -> Result<f64, Error> {
-        self.check_compatible(other)?;
-
-        if ignore_abundance {
+            self.check_compatible(other)?;
             if let Ok((common, size)) = self.intersection_size(other) {
                 Ok(common as f64 / u64::max(1, size) as f64)
             } else {
                 Ok(0.0)
             }
-        } else {
-            if self.abunds.is_none() || other.abunds.is_none() {
-                // TODO: throw error, we need abundance for this
-                unimplemented!()
+        }
+    }
+
+    // compare two minhashes, with abundance.
+    pub fn similarity(
+        &self,
+        other: &KmerMinHash,
+        ignore_abundance: bool,
+        downsample: bool,
+    ) -> Result<f64, Error> {
+        if downsample && self.max_hash != other.max_hash {
+            if self.max_hash < other.max_hash {
+                let mut new_mh = KmerMinHash::new(
+                    other.num,
+                    other.ksize,
+                    other.hash_function,
+                    other.seed,
+                    self.max_hash,
+                    other.abunds.is_some(),
+                );
+                new_mh.add_many_with_abund(&other.to_vec_abunds())?;
+                return self.compare(&new_mh, false);
+            } else {
+                // other.max_hash < self.max_hash
+                let mut new_mh = KmerMinHash::new(
+                    self.num,
+                    self.ksize,
+                    self.hash_function,
+                    self.seed,
+                    other.max_hash,
+                    self.abunds.is_some(),
+                );
+                new_mh.add_many_with_abund(&self.to_vec_abunds())?;
+                return new_mh.compare(other, false);
             }
+        } else {
+            self.check_compatible(other)?;
 
-            let abunds = self.abunds.as_ref().unwrap();
-            let other_abunds = other.abunds.as_ref().unwrap();
+            if ignore_abundance {
+                if let Ok((common, size)) = self.intersection_size(other) {
+                    Ok(common as f64 / u64::max(1, size) as f64)
+                } else {
+                    Ok(0.0)
+                }
+            } else {
+                if self.abunds.is_none() || other.abunds.is_none() {
+                    // TODO: throw error, we need abundance for this
+                    unimplemented!()
+                }
 
-            let mut prod = 0;
-            let mut other_iter = other.mins.iter().enumerate();
-            let mut next_hash = other_iter.next();
-            let a_sq: u64 = abunds.iter().map(|a| (a * a)).sum();
-            let b_sq: u64 = other_abunds.iter().map(|a| (a * a)).sum();
+                let abunds = self.abunds.as_ref().unwrap();
+                let other_abunds = other.abunds.as_ref().unwrap();
 
-            for (i, hash) in self.mins.iter().enumerate() {
-                while let Some((j, k)) = next_hash {
-                    match k.cmp(hash) {
-                        Ordering::Less => next_hash = other_iter.next(),
-                        Ordering::Equal => {
-                            // Calling `get_unchecked` here is safe since
-                            // both `i` and `j` are valid indices
-                            // (`i` and `j` came from valid iterator calls)
-                            unsafe {
-                                prod += abunds.get_unchecked(i) * other_abunds.get_unchecked(j);
+                let mut prod = 0;
+                let mut other_iter = other.mins.iter().enumerate();
+                let mut next_hash = other_iter.next();
+                let a_sq: u64 = abunds.iter().map(|a| (a * a)).sum();
+                let b_sq: u64 = other_abunds.iter().map(|a| (a * a)).sum();
+
+                for (i, hash) in self.mins.iter().enumerate() {
+                    while let Some((j, k)) = next_hash {
+                        match k.cmp(hash) {
+                            Ordering::Less => next_hash = other_iter.next(),
+                            Ordering::Equal => {
+                                // Calling `get_unchecked` here is safe since
+                                // both `i` and `j` are valid indices
+                                // (`i` and `j` came from valid iterator calls)
+                                unsafe {
+                                    prod += abunds.get_unchecked(i) * other_abunds.get_unchecked(j);
+                                }
+                                break;
                             }
-                            break;
+                            Ordering::Greater => break,
                         }
-                        Ordering::Greater => break,
                     }
                 }
+
+                let norm_a = (a_sq as f64).sqrt();
+                let norm_b = (b_sq as f64).sqrt();
+
+                if norm_a == 0. || norm_b == 0. {
+                    return Ok(0.0);
+                }
+
+                let prod = f64::min(prod as f64 / (norm_a * norm_b), 1.);
+                let distance = 2. * prod.acos() / PI;
+                Ok(1. - distance)
             }
-
-            let norm_a = (a_sq as f64).sqrt();
-            let norm_b = (b_sq as f64).sqrt();
-
-            if norm_a == 0. || norm_b == 0. {
-                return Ok(0.0);
-            }
-
-            let prod = f64::min(prod as f64 / (norm_a * norm_b), 1.);
-            let distance = 2. * prod.acos() / PI;
-            Ok(1. - distance)
         }
     }
 
@@ -600,6 +688,22 @@ impl KmerMinHash {
 
     pub fn mins(&self) -> Vec<u64> {
         self.mins.clone()
+    }
+
+    fn to_vec_abunds(&self) -> Vec<(u64, u64)> {
+        if let Some(abunds) = &self.abunds {
+            self.mins
+                .iter()
+                .cloned()
+                .zip(abunds.iter().cloned())
+                .collect()
+        } else {
+            self.mins
+                .iter()
+                .cloned()
+                .zip(std::iter::repeat(1))
+                .collect()
+        }
     }
 }
 

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::f64::consts::PI;
 use std::iter::{Iterator, Peekable};
 use std::str;
 
@@ -598,7 +597,7 @@ impl KmerMinHash {
                     other.abunds.is_some(),
                 );
                 new_mh.add_many_with_abund(&other.to_vec_abunds())?;
-                self.compare(&new_mh, false)
+                self.similarity(&new_mh, ignore_abundance, false)
             } else {
                 // other.max_hash < self.max_hash
                 let mut new_mh = KmerMinHash::new(
@@ -610,7 +609,7 @@ impl KmerMinHash {
                     self.abunds.is_some(),
                 );
                 new_mh.add_many_with_abund(&self.to_vec_abunds())?;
-                new_mh.compare(other, false)
+                new_mh.similarity(other, ignore_abundance, false)
             }
         } else {
             self.check_compatible(other)?;
@@ -660,10 +659,8 @@ impl KmerMinHash {
                 if norm_a == 0. || norm_b == 0. {
                     return Ok(0.0);
                 }
-
-                let prod = f64::min(prod as f64 / (norm_a * norm_b), 1.);
-                let distance = 2. * prod.acos() / PI;
-                Ok(1. - distance)
+                let prod = prod as f64 / (norm_a * norm_b);
+                Ok(prod)
             }
         }
     }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::f64::consts::PI;
 use std::iter::{Iterator, Peekable};
 use std::str;
 
@@ -579,7 +580,8 @@ impl KmerMinHash {
         }
     }
 
-    // compare two minhashes, with abundance.
+    // compare two minhashes, with abundance;
+    // calculate their angular similarity.
     pub fn similarity(
         &self,
         other: &KmerMinHash,
@@ -659,8 +661,9 @@ impl KmerMinHash {
                 if norm_a == 0. || norm_b == 0. {
                     return Ok(0.0);
                 }
-                let prod = prod as f64 / (norm_a * norm_b);
-                Ok(prod)
+                let prod = f64::min(prod as f64 / (norm_a * norm_b), 1.);
+                let distance = 2. * prod.acos() / PI;
+                Ok(1. - distance)
             }
         }
     }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -738,7 +738,7 @@ impl SigsTrait for KmerMinHash {
             return Err(SourmashError::MismatchDNAProt.into());
         }
         if self.max_hash != other.max_hash {
-            return Err(SourmashError::MismatchMaxHash.into());
+            return Err(SourmashError::MismatchScaled.into());
         }
         if self.seed != other.seed {
             return Err(SourmashError::MismatchSeed.into());

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -47,22 +47,18 @@ fn compare() {
         .unwrap();
     b.add_sequence(b"TGCCGCCCAGCACCGGGTGACTAGGTTGAGCCATGATTAACCTGCAATGA", false)
         .unwrap();
-    assert_eq!(a.compare(&b).unwrap(), 1.0);
-    //    assert_eq!(b.compare(&b).unwrap(), 1.0);
-    assert_eq!(b.compare(&a).unwrap(), 1.0);
-    //    assert_eq!(a.compare(&a).unwrap(), 1.0);
+    assert_eq!(a.compare(&b, false).unwrap(), 1.0);
+    assert_eq!(b.compare(&a, false).unwrap(), 1.0);
 
     b.add_sequence(b"TGCCGCCCAGCACCGGGTGACTAGGTTGAGCCATGATTAACCTGCAATGA", false)
         .unwrap();
-    assert_eq!(a.compare(&b).unwrap(), 1.0);
-    //    assert_eq!(b.compare(&b).unwrap(), 1.0);
-    assert_eq!(b.compare(&a).unwrap(), 1.0);
-    //    assert_eq!(a.compare(&a).unwrap(), 1.0);
+    assert_eq!(a.compare(&b, false).unwrap(), 1.0);
+    assert_eq!(b.compare(&a, false).unwrap(), 1.0);
 
     b.add_sequence(b"GATTGGTGCACACTTAACTGGGTGCCGCGCTGGTGCTGATCCATGAAGTT", false)
         .unwrap();
-    assert!(a.compare(&b).unwrap() >= 0.3);
-    assert!(b.compare(&a).unwrap() >= 0.3);
+    assert!(a.compare(&b, false).unwrap() >= 0.3);
+    assert!(b.compare(&a, false).unwrap() >= 0.3);
 }
 
 #[test]
@@ -87,8 +83,8 @@ fn similarity() -> Result<(), Box<dyn std::error::Error>> {
     b.add_hash(1);
     b.add_hash(2);
 
-    assert!((a.similarity(&a, false)? - 1.0).abs() < 0.001);
-    assert!((a.similarity(&b, false)? - 0.5).abs() < 0.001);
+    assert!((a.similarity(&a, false, false)? - 1.0).abs() < 0.001);
+    assert!((a.similarity(&b, false, false)? - 0.5).abs() < 0.001);
 
     Ok(())
 }
@@ -105,9 +101,9 @@ fn similarity_2() -> Result<(), Box<dyn std::error::Error>> {
     b.add_sequence(b"ATGGA", false)?;
 
     assert!(
-        (a.similarity(&b, false)? - 0.705).abs() < 0.001,
+        (a.similarity(&b, false, false)? - 0.705).abs() < 0.001,
         "{}",
-        a.similarity(&b, false)?
+        a.similarity(&b, false, false)?
     );
 
     Ok(())
@@ -128,11 +124,11 @@ fn similarity_3() -> Result<(), Box<dyn std::error::Error>> {
     b.add_hash(3);
     b.add_hash(4);
 
-    assert!((a.similarity(&a, false)? - 1.0).abs() < 0.001);
-    assert!((a.similarity(&b, false)? - 0.23).abs() < 0.001);
+    assert!((a.similarity(&a, false, false)? - 1.0).abs() < 0.001);
+    assert!((a.similarity(&b, false, false)? - 0.23).abs() < 0.001);
 
-    assert!((a.similarity(&a, true)? - 1.0).abs() < 0.001);
-    assert!((a.similarity(&b, true)? - 0.2).abs() < 0.001);
+    assert!((a.similarity(&a, true, false)? - 1.0).abs() < 0.001);
+    assert!((a.similarity(&b, true, false)? - 0.2).abs() < 0.001);
 
     Ok(())
 }

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -65,8 +65,7 @@ fn compare() {
 fn invalid_dna() {
     let mut a = KmerMinHash::new(20, 3, HashFunctions::murmur64_DNA, 42, 0, false);
 
-    a.add_sequence(b"AAANNCCCTN", true)
-        .unwrap();
+    a.add_sequence(b"AAANNCCCTN", true).unwrap();
     assert_eq!(a.mins().len(), 3);
 
     let mut b = KmerMinHash::new(20, 3, HashFunctions::murmur64_DNA, 42, 0, false);

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -303,7 +303,9 @@ def test_mh_similarity_downsample(track_abundance):
     b = MinHash(0, 20, max_hash=100, track_abundance=track_abundance)
     for i in range(0, 80, 4):
         for j in range(i):                # add abundances
-            b.add_hash(i)
+            b.add_hash(80 - i)
+
+    print(b.get_mins(True))
 
     # error, incompatible max hash
     with pytest.raises(ValueError):
@@ -322,11 +324,13 @@ def test_mh_similarity_downsample(track_abundance):
     x = a.similarity(b, ignore_abundance=True, downsample=True)
     y = b.similarity(a, ignore_abundance=True, downsample=True)
     assert x == y
+    print(x)
 
     # downsample=True => no error; values should match either way
     x = a.similarity(b, ignore_abundance=False, downsample=True)
     y = b.similarity(a, ignore_abundance=False, downsample=True)
     assert x == y
+    print(y)
 
 
 def test_basic_dna_bad(track_abundance):

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -294,6 +294,41 @@ def test_scaled(track_abundance):
         mh = MinHash(2, 4, track_abundance=track_abundance, scaled=2)
 
 
+def test_mh_similarity_downsample(track_abundance):
+    a = MinHash(0, 20, max_hash=50, track_abundance=track_abundance)
+    for i in range(0, 40, 2):
+        for j in range(i):                # add abundances
+            a.add_hash(i)
+
+    b = MinHash(0, 20, max_hash=100, track_abundance=track_abundance)
+    for i in range(0, 80, 4):
+        for j in range(i):                # add abundances
+            b.add_hash(i)
+
+    # error, incompatible max hash
+    with pytest.raises(ValueError):
+        a.similarity(b, ignore_abundance=True, downsample=False)
+
+    with pytest.raises(ValueError):
+        a.similarity(b, ignore_abundance=False, downsample=False)
+
+    with pytest.raises(ValueError):
+        b.similarity(a, ignore_abundance=True, downsample=False)
+
+    with pytest.raises(ValueError):
+        b.similarity(a, ignore_abundance=False, downsample=False)
+
+    # downsample=True => no error; values should match either way
+    x = a.similarity(b, ignore_abundance=True, downsample=True)
+    y = b.similarity(a, ignore_abundance=True, downsample=True)
+    assert x == y
+
+    # downsample=True => no error; values should match either way
+    x = a.similarity(b, ignore_abundance=False, downsample=True)
+    y = b.similarity(a, ignore_abundance=False, downsample=True)
+    assert x == y
+
+
 def test_basic_dna_bad(track_abundance):
     # test behavior on bad DNA
     mh = MinHash(1, 4, track_abundance=track_abundance)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -329,6 +329,19 @@ def test_mh_cosine_similarity():
     assert round(a.similarity(b), 4) == 0.9356
 
 
+def test_mh_cosine_similarity_2():
+    # check actual cos similarity for a second non-trivial case
+    a = MinHash(0, 20, max_hash=100, track_abundance=True)
+    b = MinHash(0, 20, max_hash=100, track_abundance=True)
+    a.set_abundances({ 1:5, 3:3, 5:2, 8:2, 70:70 })
+    b.set_abundances({ 1:3, 3:2, 5:1, 6:1, 8:1, 10:1, 70:70 })
+
+    assert round(a.similarity(b), 4) == 0.9991
+
+    # ignore_abundance => jaccard
+    assert a.similarity(b, ignore_abundance=True) == 5. / 7.
+
+
 def test_mh_similarity_downsample_cosine_value():
     # test downsample=True argument to MinHash.similarity
 
@@ -337,8 +350,8 @@ def test_mh_similarity_downsample_cosine_value():
     # max_hash = 100
     b = MinHash(0, 20, max_hash=100, track_abundance=True)
 
-    a.set_abundances({ 1:5, 3:3, 5:2, 8:2, 70:1 })
-    b.set_abundances({ 1:3, 3:2, 5:1, 6:1, 8:1, 10:1, 70:1 })
+    a.set_abundances({ 1:5, 3:3, 5:2, 8:2, 70:70 })
+    b.set_abundances({ 1:3, 3:2, 5:1, 6:1, 8:1, 10:1, 70:70 })
 
     # the hash=70 will be truncated by downsampling
     cos = a.similarity(b, downsample=True)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -133,7 +133,7 @@ def test_roundtrip_empty(track_abundance):
 
 def test_roundtrip_max_hash(track_abundance):
     e = sourmash.MinHash(n=0, ksize=20, track_abundance=track_abundance,
-                             max_hash=10)
+                         max_hash=10)
     e.add_hash(5)
     sig = SourmashSignature(e)
     s = save_signatures([sig])
@@ -149,7 +149,7 @@ def test_roundtrip_max_hash(track_abundance):
 
 def test_roundtrip_seed(track_abundance):
     e = sourmash.MinHash(n=1, ksize=20, track_abundance=track_abundance,
-                             seed=10)
+                         seed=10)
     e.add_hash(5)
     sig = SourmashSignature(e)
     s = save_signatures([sig])
@@ -165,9 +165,9 @@ def test_roundtrip_seed(track_abundance):
 
 def test_similarity_downsample(track_abundance):
     e = sourmash.MinHash(n=0, ksize=20, track_abundance=track_abundance,
-                             max_hash=2**63)
+                         max_hash=2**63)
     f = sourmash.MinHash(n=0, ksize=20, track_abundance=track_abundance,
-                             max_hash=2**2)
+                         max_hash=2**2)
 
     e.add_hash(1)
     e.add_hash(5)
@@ -180,8 +180,10 @@ def test_similarity_downsample(track_abundance):
     ee = SourmashSignature(e)
     ff = SourmashSignature(f)
 
-    with pytest.raises(ValueError):       # mismatch in max_hash
+    with pytest.raises(ValueError) as e:       # mismatch in max_hash
         ee.similarity(ff)
+
+    assert 'mismatch in scaled; comparison fail' in str(e.value)
 
     x = ee.similarity(ff, downsample=True)
     assert round(x, 1) == 1.0

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -2079,6 +2079,35 @@ def test_do_sourmash_sbt_search_bestonly():
         assert 'short.fa' in out
 
 
+def test_do_sourmash_sbt_search_bestonly_scaled():
+    # as currently implemented, the query signature will be automatically
+    # downsampled to match the tree.
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', testdata1, testdata2,
+                                            '--scaled', '1'],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['index', '-k', '31', 'zzz',
+                                            'short.fa.sig',
+                                            'short2.fa.sig',
+                                            '--scaled', '10'],
+                                           in_directory=location)
+
+        assert os.path.exists(os.path.join(location, 'zzz.sbt.json'))
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['search', '--best-only',
+                                            'short.fa.sig', 'zzz'],
+                                           in_directory=location)
+        print(out)
+
+        assert 'short.fa' in out
+
+
 def test_sbt_search_order_dependence():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('genome-s10.fa.gz')


### PR DESCRIPTION
The downsampling code we use in MinHash comparisons is ugly, so refactoring it makes sense. This does a fairly broad cleanup based on adding a `downsample` bool option to the `similarity` functions. 

More specifically, this PR:
* adds 'downsample' boolean parameters to rust `compare`, `similarity`, and `count_common` functions;
* adds explicit tests for a few non-trivial angular distance calculations
* refactors 'sourmash watch' to use new Index.search function instead of SBT-specific interface
* simplifies and cleans up sbt and sbtmh functionality around downsampling in searches, and removes some unused functionality that is confusing.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
