### PR TITLE
Use tarpaulin instead of grcov

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,7 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-filter: covered
-output-type: lcov
-output-file: ./lcov.info
-prefix-dir: /home/user/build/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,42 +111,11 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Coverage with tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
         with:
-          python-version: "3.8"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[test]
-        env:
-          'CARGO_INCREMENTAL': '0'
-          'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
-
-      - name: Run Rust tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast --all --all-features
-        env:
-          'CARGO_INCREMENTAL': '0'
-          'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
-
-      - name: Run Python tests
-        run: python -m pytest --cov=. --cov-report=xml
-
-      - name: Collect coverage and generate report with grcov
-        uses: actions-rs/grcov@5fe6a05253e7b682e01c8097b6e3ea4ce1aaeacc
-        id: coverage
-
-      - name: Upload Python coverage to codecov
-        uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: pytests
-          fail_ci_if_error: true
+          version: '0.9.0'
+          args: '-- --no-fail-fast --all --all-features --test-threads 1'
 
       - name: Upload Rust coverage to codecov
         uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,7 +121,6 @@ jobs:
         uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ steps.coverage.outputs.report }}
           flags: rusttests
           fail_ci_if_error: true
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,13 +108,13 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - name: Coverage with tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '-- --no-fail-fast --all --all-features --test-threads 1'
+          args: '--all --all-features -- --test-threads 1'
 
       - name: Upload Rust coverage to codecov
         uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,6 @@ jobs:
       - name: Coverage with tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.9.0'
           args: '-- --no-fail-fast --all --all-features --test-threads 1'
 
       - name: Upload Rust coverage to codecov

--- a/src/core/tests/signature.rs
+++ b/src/core/tests/signature.rs
@@ -53,19 +53,20 @@ fn signature_from_computeparams() {
 #[test]
 fn signature_slow_path() {
     let params = ComputeParameters {
-        ksizes: vec![2, 3, 4],
+        ksizes: vec![2, 3, 4, 5],
         num_hashes: 3,
         ..Default::default()
     };
 
     let mut sig = Signature::from_params(&params);
-    sig.add_sequence(b"ATGCN", true).unwrap();
+    sig.add_sequence(b"ATGCTN", true).unwrap();
 
-    assert_eq!(sig.signatures.len(), 3);
+    assert_eq!(sig.signatures.len(), 4);
     dbg!(&sig.signatures);
     assert_eq!(sig.signatures[0].size(), 3);
-    assert_eq!(sig.signatures[1].size(), 2);
-    assert_eq!(sig.signatures[2].size(), 1);
+    assert_eq!(sig.signatures[1].size(), 3);
+    assert_eq!(sig.signatures[2].size(), 2);
+    assert_eq!(sig.signatures[3].size(), 1);
 }
 
 #[test]


### PR DESCRIPTION
Rust coverage reports are very finicky, trying out https://github.com/actions-rs/tarpaulin/ instead

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
