### PR TITLE
[WIP] oxidize downsampling in various similarity functions

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -110,13 +110,13 @@ void kmerminhash_add_protein(KmerMinHash *ptr, const char *sequence);
 
 void kmerminhash_add_word(KmerMinHash *ptr, const char *word);
 
-double kmerminhash_compare(KmerMinHash *ptr, const KmerMinHash *other);
+double kmerminhash_compare(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 
 double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance);
 
 double kmerminhash_containment_ignore_maxhash(KmerMinHash *ptr, const KmerMinHash *other);
 
-uint64_t kmerminhash_count_common(KmerMinHash *ptr, const KmerMinHash *other);
+uint64_t kmerminhash_count_common(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 
 bool kmerminhash_dayhoff(KmerMinHash *ptr);
 

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -112,7 +112,7 @@ void kmerminhash_add_word(KmerMinHash *ptr, const char *word);
 
 double kmerminhash_compare(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 
-double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance);
+double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance, bool downsample);
 
 double kmerminhash_containment_ignore_maxhash(KmerMinHash *ptr, const KmerMinHash *other);
 

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -410,23 +410,17 @@ class MinHash(RustObject):
     def is_compatible(self, other):
         return self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr())
 
-    def contained_by(self, other):
+    def contained_by(self, other, downsample=False):
         """\
         Calculate how much of self is contained by other.
         """
         if not len(self):
             return 0.0
 
-        return self.count_common(other) / len(self)
+        return self.count_common(other, downsample) / len(self)
 
     def containment_ignore_maxhash(self, other):
-        if len(self) == 0:
-            return 0.0
-
-        if not isinstance(other, MinHash):
-            raise TypeError("Must be a MinHash!")
-
-        return self._methodcall(lib.kmerminhash_containment_ignore_maxhash, other._get_objptr())
+        return self.contained_by(other, downsample=True)
 
     def __iadd__(self, other):
         if not isinstance(other, MinHash):

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -291,10 +291,10 @@ class MinHash(RustObject):
         except SourmashError as e:
             raise ValueError(e.message)
 
-    def count_common(self, other):
+    def count_common(self, other, downsample=False):
         if not isinstance(other, MinHash):
             raise TypeError("Must be a MinHash!")
-        return self._methodcall(lib.kmerminhash_count_common, other._get_objptr())
+        return self._methodcall(lib.kmerminhash_count_common, other._get_objptr(), downsample)
 
     def downsample_n(self, new_num):
         if self.num and self.num < new_num:
@@ -381,7 +381,7 @@ class MinHash(RustObject):
         if self.num != other.num:
             err = "must have same num: {} != {}".format(self.num, other.num)
             raise TypeError(err)
-        return self._methodcall(lib.kmerminhash_compare, other._get_objptr())
+        return self._methodcall(lib.kmerminhash_compare, other._get_objptr(), False)
     jaccard = compare
 
     def similarity(self, other, ignore_abundance=False):

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -377,14 +377,14 @@ class MinHash(RustObject):
 
         return common, max(size, 1)
 
-    def compare(self, other):
+    def compare(self, other, downsample=False):
         if self.num != other.num:
             err = "must have same num: {} != {}".format(self.num, other.num)
             raise TypeError(err)
-        return self._methodcall(lib.kmerminhash_compare, other._get_objptr(), False)
+        return self._methodcall(lib.kmerminhash_compare, other._get_objptr(), downsample)
     jaccard = compare
 
-    def similarity(self, other, ignore_abundance=False):
+    def similarity(self, other, ignore_abundance=False, downsample=False):
         """Calculate similarity of two sketches.
 
         If the sketches are not abundance weighted, or ignore_abundance=True,
@@ -401,11 +401,11 @@ class MinHash(RustObject):
 
         # if either signature is flat, calculate Jaccard only.
         if not (self.track_abundance and other.track_abundance) or ignore_abundance:
-            return self.jaccard(other)
+            return self.compare(other, downsample)
         else:
             return self._methodcall(lib.kmerminhash_similarity,
                                     other._get_objptr(),
-                                    ignore_abundance)
+                                    ignore_abundance, downsample)
 
     def is_compatible(self, other):
         return self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr())

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -525,6 +525,7 @@ def categorize(args):
         results = []
         search_fn = SearchMinHashesFindBest().search
 
+        # note, "ignore self" here may prevent using newer 'tree.search' fn.
         for leaf in tree.find(search_fn, query, args.threshold):
             if leaf.data.md5sum() != query.md5sum(): # ignore self.
                 similarity = query.similarity(
@@ -852,13 +853,14 @@ def watch(args):
     notify('Computing signature for k={}, {} from stdin', ksize, moltype)
 
     def do_search():
-        search_fn = SearchMinHashesFindBest().search
-
         results = []
         streamsig = sig.SourmashSignature(E, filename='stdin', name=args.name)
-        for leaf in tree.find(search_fn, streamsig, args.threshold):
-            results.append((streamsig.similarity(leaf.data),
-                            leaf.data))
+        for similarity, match, _ in tree.search(streamsig,
+                                                threshold=args.threshold,
+                                                best_only=True,
+                                                ignore_abundance=True,
+                                                do_containment=False):
+            results.append((similarity, match))
 
         return results
 

--- a/sourmash/compare.py
+++ b/sourmash/compare.py
@@ -55,6 +55,7 @@ def similarity(sig1, sig2, ignore_abundance, downsample):
     :param boolean downsample by max_hash if True
     :return: float similarity of the two signatures
     """
+    # @CTB
 
     try:
         sig = sig1.minhash.similarity(sig2.minhash, ignore_abundance)

--- a/sourmash/compare.py
+++ b/sourmash/compare.py
@@ -39,41 +39,13 @@ def compare_serial(siglist, ignore_abundance, downsample=False):
     return similarities
 
 
-def similarity(sig1, sig2, ignore_abundance, downsample):
-    """Compute similarity with the other MinHash signature.
-    This function is separated from the SourmashSignature to
-    avoid pickling the whole class during the pool map
-
-    :param sig1 first signature
-    :param sig2 other signature to compare with
-    :param boolean ignore_abundance
-        If the sketches are not abundance weighted, or ignore_abundance=True,
-        compute Jaccard similarity.
-
-        If the sketches are abundance weighted, calculate a distance metric
-        based on the cosine similarity.
-    :param boolean downsample by max_hash if True
-    :return: float similarity of the two signatures
-    """
-    # @CTB
-
-    try:
-        sig = sig1.minhash.similarity(sig2.minhash, ignore_abundance)
-        return sig
-    except ValueError as e:
-        if 'mismatch in max_hash' in str(e) and downsample:
-            xx = sig1.minhash.downsample_max_hash(sig2.minhash)
-            yy = sig2.minhash.downsample_max_hash(sig1.minhash)
-            sig = similarity(xx, yy, ignore_abundance, False)
-            return sig
-        else:
-            raise
-
-
 def similarity_args_unpack(args, ignore_abundance, downsample):
-    """Helper function to unpack the arguments. Written to use in pool.imap as it
-    can only be given one argument."""
-    return similarity(*args, ignore_abundance=ignore_abundance, downsample=downsample)
+    """Helper function to unpack the arguments. Written to use in pool.imap
+    as it can only be given one argument."""
+    sig1, sig2 = args
+    return sig1.similarity(sig2,
+                           ignore_abundance=ignore_abundance,
+                           downsample=downsample)
 
 
 def get_similarities_at_index(index, ignore_abundance, downsample, siglist):

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -280,16 +280,6 @@ class SBT(Index):
         best_only = kwargs['best_only']
         unload_data = kwargs.get('unload_data', False)
 
-        search_fn = search_minhashes
-        query_match = lambda x: query.similarity(
-            x, downsample=True, ignore_abundance=ignore_abundance)
-        if do_containment:
-            search_fn = search_minhashes_containment
-            query_match = lambda x: query.contained_by(x, downsample=True)
-        
-        if best_only:            # this needs to be reset for each SBT
-            search_fn = SearchMinHashesFindBest().search
-
         # figure out scaled value of tree, downsample query if needed.
         leaf = next(iter(self.leaves()))
         tree_mh = leaf.data.minhash
@@ -300,6 +290,17 @@ class SBT(Index):
             resampled_query_mh = tree_query.minhash
             resampled_query_mh = resampled_query_mh.downsample_scaled(tree_mh.scaled)
             tree_query = SourmashSignature(resampled_query_mh)
+
+        # define both search function and post-search calculation function
+        search_fn = search_minhashes
+        query_match = lambda x: tree_query.similarity(
+            x, downsample=False, ignore_abundance=ignore_abundance)
+        if do_containment:
+            search_fn = search_minhashes_containment
+            query_match = lambda x: tree_query.contained_by(x, downsample=True)
+
+        if best_only:            # this needs to be reset for each SBT
+            search_fn = SearchMinHashesFindBest().search
 
         # now, search!
         results = []

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -137,10 +137,7 @@ def search_minhashes(node, sig, threshold, results=None, downsample=True):
     score = 0
 
     if isinstance(node, SigLeaf):
-        if downsample:
-            score = _similarity_downsample(sig.minhash, node.data.minhash)
-        else:
-            score = node.data.minhash.similarity(sig.minhash)
+        score = node.data.minhash.similarity(sig.minhash, downsample)
     else:  # Node minhash comparison
         score = _max_jaccard_underneath_internal_node(node, mins)
 
@@ -163,10 +160,7 @@ class SearchMinHashesFindBest(object):
         score = 0
 
         if isinstance(node, SigLeaf):
-            if self.downsample:
-                score = _similarity_downsample(sig.minhash, node.data.minhash)
-            else:
-                score = node.data.minhash.similarity(sig.minhash)
+            score = node.data.minhash.similarity(sig.minhash, self.downsample)
         else:  # internal object, not leaf.
             score = _max_jaccard_underneath_internal_node(node, mins)
 

--- a/sourmash/sbtmh.py
+++ b/sourmash/sbtmh.py
@@ -107,7 +107,7 @@ def _max_jaccard_underneath_internal_node(node, hashes):
     return max_score
 
 
-def search_minhashes(node, sig, threshold, results=None, downsample=True):
+def search_minhashes(node, sig, threshold, results=None):
     """\
     Default tree search function, searching for best Jaccard similarity.
     """
@@ -115,7 +115,7 @@ def search_minhashes(node, sig, threshold, results=None, downsample=True):
     score = 0
 
     if isinstance(node, SigLeaf):
-        score = node.data.minhash.similarity(sig.minhash, downsample)
+        score = node.data.minhash.similarity(sig.minhash)
     else:  # Node minhash comparison
         score = _max_jaccard_underneath_internal_node(node, mins)
 
@@ -129,16 +129,15 @@ def search_minhashes(node, sig, threshold, results=None, downsample=True):
 
 
 class SearchMinHashesFindBest(object):
-    def __init__(self, downsample=True):
+    def __init__(self):
         self.best_match = 0.
-        self.downsample = downsample
 
     def search(self, node, sig, threshold, results=None):
         mins = sig.minhash.get_mins()
         score = 0
 
         if isinstance(node, SigLeaf):
-            score = node.data.minhash.similarity(sig.minhash, self.downsample)
+            score = node.data.minhash.similarity(sig.minhash)
         else:  # internal object, not leaf.
             score = _max_jaccard_underneath_internal_node(node, mins)
 

--- a/sourmash/signature.py
+++ b/sourmash/signature.py
@@ -129,22 +129,18 @@ class SourmashSignature(RustObject):
 
     def similarity(self, other, ignore_abundance=False, downsample=False):
         "Compute similarity with the other signature."
-        try:
-            return self.minhash.similarity(other.minhash, ignore_abundance)
-        except ValueError as e:
-            if "mismatch in max_hash" in str(e) and downsample:
-                xx = self.minhash.downsample_max_hash(other.minhash)
-                yy = other.minhash.downsample_max_hash(self.minhash)
-                return xx.similarity(yy, ignore_abundance)
-            else:
-                raise
+        return self.minhash.similarity(other.minhash,
+                                       ignore_abundance=ignore_abundance,
+                                       downsample=downsample)
 
     def jaccard(self, other):
         "Compute Jaccard similarity with the other MinHash signature."
-        return self.minhash.similarity(other.minhash, True)
+        return self.minhash.similarity(other.minhash, ignore_abundance=True,
+                                       downsample=False)
 
     def contained_by(self, other, downsample=False):
         "Compute containment by the other signature. Note: ignores abundance."
+        # @CTB
         try:
             return self.minhash.contained_by(other.minhash)
         except ValueError as e:

--- a/sourmash/signature.py
+++ b/sourmash/signature.py
@@ -140,16 +140,7 @@ class SourmashSignature(RustObject):
 
     def contained_by(self, other, downsample=False):
         "Compute containment by the other signature. Note: ignores abundance."
-        # @CTB
-        try:
-            return self.minhash.contained_by(other.minhash)
-        except ValueError as e:
-            if "mismatch in max_hash" in str(e) and downsample:
-                xx = self.minhash.downsample_max_hash(other.minhash)
-                yy = other.minhash.downsample_max_hash(self.minhash)
-                return xx.contained_by(yy)
-            else:
-                raise
+        return self.minhash.contained_by(other.minhash, downsample)
 
     def add_sequence(self, sequence, force=False):
         self._methodcall(lib.signature_add_sequence, to_bytes(sequence), force)

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -538,7 +538,7 @@ unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash, 
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_similarity(ptr: *mut KmerMinHash, other: *const KmerMinHash, ignore_abundance: bool)
+unsafe fn kmerminhash_similarity(ptr: *mut KmerMinHash, other: *const KmerMinHash, ignore_abundance: bool, downsample: bool)
     -> Result<f64> {
     let mh = {
         assert!(!ptr.is_null());
@@ -549,6 +549,6 @@ unsafe fn kmerminhash_similarity(ptr: *mut KmerMinHash, other: *const KmerMinHas
        &*other
     };
 
-    mh.similarity(other_mh, ignore_abundance)
+    mh.similarity(other_mh, ignore_abundance, downsample)
 }
 }

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -471,7 +471,7 @@ unsafe fn kmerminhash_add_from(ptr: *mut KmerMinHash, other: *const KmerMinHash)
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_count_common(ptr: *mut KmerMinHash, other: *const KmerMinHash)
+unsafe fn kmerminhash_count_common(ptr: *mut KmerMinHash, other: *const KmerMinHash, downsample: bool)
     -> Result<u64> {
     let mh = {
         assert!(!ptr.is_null());
@@ -482,7 +482,7 @@ unsafe fn kmerminhash_count_common(ptr: *mut KmerMinHash, other: *const KmerMinH
        &*other
     };
 
-    mh.count_common(other_mh)
+    mh.count_common(other_mh, downsample)
 }
 }
 
@@ -522,7 +522,7 @@ unsafe fn kmerminhash_containment_ignore_maxhash(ptr: *mut KmerMinHash, other: *
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash)
+unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash, downsample: bool)
     -> Result<f64> {
     let mh = {
         assert!(!ptr.is_null());
@@ -533,7 +533,7 @@ unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash)
        &*other
     };
 
-    mh.compare(other_mh)
+    mh.compare(other_mh, downsample)
 }
 }
 

--- a/src/core/src/index/mod.rs
+++ b/src/core/src/index/mod.rs
@@ -190,7 +190,7 @@ impl SigStore<Signature> {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &ng.signatures[0] {
             if let Sketch::MinHash(omh) = &ong.signatures[0] {
-                return mh.count_common(&omh).unwrap() as u64;
+                return mh.count_common(&omh, false).unwrap() as u64;
             }
         }
         unimplemented!();
@@ -247,7 +247,7 @@ impl Comparable<SigStore<Signature>> for SigStore<Signature> {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &ng.signatures[0] {
             if let Sketch::MinHash(omh) = &ong.signatures[0] {
-                return mh.compare(&omh).unwrap();
+                return mh.compare(&omh, false).unwrap();
             }
         }
 
@@ -270,7 +270,7 @@ impl Comparable<SigStore<Signature>> for SigStore<Signature> {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &ng.signatures[0] {
             if let Sketch::MinHash(omh) = &ong.signatures[0] {
-                let common = mh.count_common(&omh).unwrap();
+                let common = mh.count_common(&omh, false).unwrap();
                 let size = mh.mins.len();
                 return common as f64 / size as f64;
             }
@@ -285,7 +285,7 @@ impl Comparable<Signature> for Signature {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &self.signatures[0] {
             if let Sketch::MinHash(omh) = &other.signatures[0] {
-                return mh.compare(&omh).unwrap();
+                return mh.compare(&omh, false).unwrap();
             }
         }
 
@@ -305,7 +305,7 @@ impl Comparable<Signature> for Signature {
         // TODO: better matching here, what if it is not a mh?
         if let Sketch::MinHash(mh) = &self.signatures[0] {
             if let Sketch::MinHash(omh) = &other.signatures[0] {
-                let common = mh.count_common(&omh).unwrap();
+                let common = mh.count_common(&omh, false).unwrap();
                 let size = mh.mins.len();
                 return common as f64 / size as f64;
             }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -470,8 +470,9 @@ impl KmerMinHash {
                     other.abunds.is_some(),
                 );
                 new_mh.add_many(&other.mins)?;
-                return self.count_common(&new_mh, false)
-            } else { // other.max_hash < self.max_hash
+                return self.count_common(&new_mh, false);
+            } else {
+                // other.max_hash < self.max_hash
                 let mut new_mh = KmerMinHash::new(
                     self.num,
                     self.ksize,
@@ -481,10 +482,9 @@ impl KmerMinHash {
                     self.abunds.is_some(),
                 );
                 new_mh.add_many(&self.mins)?;
-                return new_mh.count_common(other, false)
+                return new_mh.count_common(other, false);
             }
-        }
-        else{
+        } else {
             self.check_compatible(other)?;
             let iter = Intersection::new(self.mins.iter(), other.mins.iter());
 
@@ -556,8 +556,9 @@ impl KmerMinHash {
                     other.abunds.is_some(),
                 );
                 new_mh.add_many(&other.mins)?;
-                return self.compare(&new_mh, false)
-            } else { // other.max_hash < self.max_hash
+                return self.compare(&new_mh, false);
+            } else {
+                // other.max_hash < self.max_hash
                 let mut new_mh = KmerMinHash::new(
                     self.num,
                     self.ksize,
@@ -567,10 +568,9 @@ impl KmerMinHash {
                     self.abunds.is_some(),
                 );
                 new_mh.add_many(&self.mins)?;
-                return new_mh.compare(other, false)
+                return new_mh.compare(other, false);
             }
-        }
-        else {
+        } else {
             self.check_compatible(other)?;
             if let Ok((common, size)) = self.intersection_size(other) {
                 Ok(common as f64 / u64::max(1, size) as f64)
@@ -581,7 +581,12 @@ impl KmerMinHash {
     }
 
     // compare two minhashes, with abundance.
-    pub fn similarity(&self, other: &KmerMinHash, ignore_abundance: bool, downsample: bool) -> Result<f64, Error> {
+    pub fn similarity(
+        &self,
+        other: &KmerMinHash,
+        ignore_abundance: bool,
+        downsample: bool,
+    ) -> Result<f64, Error> {
         if downsample && self.max_hash != other.max_hash {
             if self.max_hash < other.max_hash {
                 let mut new_mh = KmerMinHash::new(
@@ -592,9 +597,10 @@ impl KmerMinHash {
                     self.max_hash,
                     other.abunds.is_some(),
                 );
-                //new_mh.add_many_with_abund(&other.abunds)?;
-                return self.compare(&new_mh, false)
-            } else { // other.max_hash < self.max_hash
+                new_mh.add_many_with_abund(&other.to_vec_abunds())?;
+                return self.compare(&new_mh, false);
+            } else {
+                // other.max_hash < self.max_hash
                 let mut new_mh = KmerMinHash::new(
                     self.num,
                     self.ksize,
@@ -603,11 +609,10 @@ impl KmerMinHash {
                     other.max_hash,
                     self.abunds.is_some(),
                 );
-                //new_mh.add_many_with_abund(&self.abunds)?;
-                return new_mh.compare(other, false)
+                new_mh.add_many_with_abund(&self.to_vec_abunds())?;
+                return new_mh.compare(other, false);
             }
-        }
-        else {
+        } else {
             self.check_compatible(other)?;
 
             if ignore_abundance {
@@ -683,6 +688,22 @@ impl KmerMinHash {
 
     pub fn mins(&self) -> Vec<u64> {
         self.mins.clone()
+    }
+
+    fn to_vec_abunds(&self) -> Vec<(u64, u64)> {
+        if let Some(abunds) = &self.abunds {
+            self.mins
+                .iter()
+                .cloned()
+                .zip(abunds.iter().cloned())
+                .collect()
+        } else {
+            self.mins
+                .iter()
+                .cloned()
+                .zip(std::iter::repeat(1))
+                .collect()
+        }
     }
 }
 

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -458,11 +458,16 @@ impl KmerMinHash {
         Ok(())
     }
 
-    pub fn count_common(&self, other: &KmerMinHash) -> Result<u64, Error> {
-        self.check_compatible(other)?;
-        let iter = Intersection::new(self.mins.iter(), other.mins.iter());
+    pub fn count_common(&self, other: &KmerMinHash, downsample: bool) -> Result<u64, Error> {
+        if downsample {
+            Ok(0 as u64)
+        }
+        else{
+            self.check_compatible(other)?;
+            let iter = Intersection::new(self.mins.iter(), other.mins.iter());
 
-        Ok(iter.count() as u64)
+            Ok(iter.count() as u64)
+        }
     }
 
     pub fn intersection(&self, other: &KmerMinHash) -> Result<(Vec<u64>, u64), Error> {
@@ -516,12 +521,17 @@ impl KmerMinHash {
         Ok((it2.count() as u64, combined_mh.mins.len() as u64))
     }
 
-    pub fn compare(&self, other: &KmerMinHash) -> Result<f64, Error> {
-        self.check_compatible(other)?;
-        if let Ok((common, size)) = self.intersection_size(other) {
-            Ok(common as f64 / u64::max(1, size) as f64)
-        } else {
+    pub fn compare(&self, other: &KmerMinHash, downsample: bool) -> Result<f64, Error> {
+        if downsample {
             Ok(0.0)
+        }
+        else {
+            self.check_compatible(other)?;
+            if let Ok((common, size)) = self.intersection_size(other) {
+                Ok(common as f64 / u64::max(1, size) as f64)
+            } else {
+                Ok(0.0)
+            }
         }
     }
 

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -460,7 +460,29 @@ impl KmerMinHash {
 
     pub fn count_common(&self, other: &KmerMinHash, downsample: bool) -> Result<u64, Error> {
         if downsample {
-            Ok(0 as u64)
+            if self.max_hash < other.max_hash {
+                let new_mh = KmerMinHash::new(
+                    other.num,
+                    other.ksize,
+                    other.hash_function,
+                    other.seed,
+                    self.max_hash,
+                    other.abunds.is_some(),
+                );
+                return self.count_common(&new_mh, false)
+            } else if other.max_hash < self.max_hash {
+                let new_mh = KmerMinHash::new(
+                    self.num,
+                    self.ksize,
+                    self.hash_function,
+                    self.seed,
+                    other.max_hash,
+                    self.abunds.is_some(),
+                );
+                return new_mh.count_common(other, false)
+            } else {
+                return self.count_common(other, false)
+            }
         }
         else{
             self.check_compatible(other)?;
@@ -523,7 +545,29 @@ impl KmerMinHash {
 
     pub fn compare(&self, other: &KmerMinHash, downsample: bool) -> Result<f64, Error> {
         if downsample {
-            Ok(0.0)
+            if self.max_hash < other.max_hash {
+                let new_mh = KmerMinHash::new(
+                    other.num,
+                    other.ksize,
+                    other.hash_function,
+                    other.seed,
+                    self.max_hash,
+                    other.abunds.is_some(),
+                );
+                return self.compare(&new_mh, false)
+            } else if other.max_hash < self.max_hash {
+                let new_mh = KmerMinHash::new(
+                    self.num,
+                    self.ksize,
+                    self.hash_function,
+                    self.seed,
+                    other.max_hash,
+                    self.abunds.is_some(),
+                );
+                return new_mh.compare(other, false)
+            } else {
+                return self.compare(other, false)
+            }
         }
         else {
             self.check_compatible(other)?;

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -2079,6 +2079,35 @@ def test_do_sourmash_sbt_search_bestonly():
         assert 'short.fa' in out
 
 
+def test_do_sourmash_sbt_search_bestonly_scaled():
+    # as currently implemented, the query signature will be automatically
+    # downsampled to match the tree.
+    with utils.TempDirectory() as location:
+        testdata1 = utils.get_test_data('short.fa')
+        testdata2 = utils.get_test_data('short2.fa')
+        status, out, err = utils.runscript('sourmash',
+                                           ['compute', testdata1, testdata2,
+                                            '--scaled', '1'],
+                                           in_directory=location)
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['index', '-k', '31', 'zzz',
+                                            'short.fa.sig',
+                                            'short2.fa.sig',
+                                            '--scaled', '10'],
+                                           in_directory=location)
+
+        assert os.path.exists(os.path.join(location, 'zzz.sbt.json'))
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['search', '--best-only',
+                                            'short.fa.sig', 'zzz'],
+                                           in_directory=location)
+        print(out)
+
+        assert 'short.fa' in out
+
+
 def test_sbt_search_order_dependence():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('genome-s10.fa.gz')


### PR DESCRIPTION
This is a merge into #856 

* add 'downsample' boolean parameter to rust `compare`, `similarity`, and `count_common`;
* refactor 'sourmash watch' to use new Index.search function instead of SBT-specific interface
* simplify and clean up sbt and sbtmh functionality around downsampling in searches; discovery of some unused functionality => removal.

Questions for @luizirber -

* advice requested on how I did the rust code for `compare` and `count_common`...
* I don't know how to call `add_many_with_abunds` in rust `similarity` function
* `containment_ignore_maxhash` is now identical in behavior to `contained_by(..., downsample=True)`. However, `contained_by` has a lot more checks and is presumably slower. In this PR I've replaced `containment_ignore_maxhash` with `contained_by`, but I'm happy to reconsider. (I didn't remove `containment_ignore_maxhash` tho :)