### PR TITLE
Improve sketching performance for DNA

### DIFF
--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -656,59 +656,49 @@ impl SigsTrait for KmerMinHash {
         let rc = revcomp(&sequence);
 
         if self.is_dna() {
-            if _checkdna(&sequence) {
-                // fast path: all kmers are valid
-                for i in 0..=len - ksize {
-                    // ... and then while moving the k-mer window forward for the sequence
-                    // we move another window backwards for the RC.
-                    //   For a ksize = 3, and a sequence AGTCGT (len = 6):
-                    //                   +-+---------+---------------+-------+
-                    //   seq      RC     |i|i + ksize|len - ksize - i|len - i|
-                    //  AGTCGT   ACGACT  +-+---------+---------------+-------+
-                    //  +->         +->  |0|    2    |       3       |   6   |
-                    //   +->       +->   |1|    3    |       2       |   5   |
-                    //    +->     +->    |2|    4    |       1       |   4   |
-                    //     +->   +->     |3|    5    |       0       |   3   |
-                    //                   +-+---------+---------------+-------+
-                    // (leaving this table here because I had to draw to
-                    //  get the indices correctly)
-                    let kmer = &sequence[i..i + ksize];
-                    let krc = &rc[len - ksize - i..len - i];
+            let mut last_position_check = 0;
 
-                    self.add_word(std::cmp::min(kmer, krc));
-                }
-            } else {
-                // slow path: there are erroneous kmers in the middle
-                let mut last_position_check = 0;
-
-                let mut is_valid_kmer = |i| {
-                    for j in std::cmp::max(i, last_position_check)..i + ksize {
-                        if !VALID[sequence[j] as usize] {
-                            return false;
-                        }
-                        last_position_check += 1;
+            let mut is_valid_kmer = |i| {
+                for j in std::cmp::max(i, last_position_check)..i + ksize {
+                    if !VALID[sequence[j] as usize] {
+                        return false;
                     }
-                    return true;
-                };
+                    last_position_check += 1;
+                }
+                return true;
+            };
 
-                for i in 0..=len - ksize {
-                    let kmer = &sequence[i..i + ksize];
+            for i in 0..=len - ksize {
+                // ... and then while moving the k-mer window forward for the sequence
+                // we move another window backwards for the RC.
+                //   For a ksize = 3, and a sequence AGTCGT (len = 6):
+                //                   +-+---------+---------------+-------+
+                //   seq      RC     |i|i + ksize|len - ksize - i|len - i|
+                //  AGTCGT   ACGACT  +-+---------+---------------+-------+
+                //  +->         +->  |0|    2    |       3       |   6   |
+                //   +->       +->   |1|    3    |       2       |   5   |
+                //    +->     +->    |2|    4    |       1       |   4   |
+                //     +->   +->     |3|    5    |       0       |   3   |
+                //                   +-+---------+---------------+-------+
+                // (leaving this table here because I had to draw to
+                //  get the indices correctly)
 
-                    if !is_valid_kmer(i) {
-                        if !force {
-                            // throw error if DNA is not valid
-                            return Err(SourmashError::InvalidDNA {
-                                message: String::from_utf8(kmer.to_vec()).unwrap(),
-                            }
-                            .into());
+                let kmer = &sequence[i..i + ksize];
+
+                if !is_valid_kmer(i) {
+                    if !force {
+                        // throw error if DNA is not valid
+                        return Err(SourmashError::InvalidDNA {
+                            message: String::from_utf8(kmer.to_vec()).unwrap(),
                         }
-
-                        continue; // skip invalid k-mer
+                        .into());
                     }
 
-                    let krc = &rc[len - ksize - i..len - i];
-                    self.add_word(std::cmp::min(kmer, krc));
+                    continue; // skip invalid k-mer
                 }
+
+                let krc = &rc[len - ksize - i..len - i];
+                self.add_word(std::cmp::min(kmer, krc));
             }
         } else {
             // protein
@@ -1101,8 +1091,3 @@ const VALID: [bool; 256] = {
     lookup[b'T' as usize] = true;
     lookup
 };
-
-#[inline]
-fn _checkdna(seq: &[u8]) -> bool {
-    seq.iter().all(|n| VALID[*n as usize])
-}

--- a/src/core/tests/minhash.rs
+++ b/src/core/tests/minhash.rs
@@ -66,6 +66,19 @@ fn compare() {
 }
 
 #[test]
+fn invalid_dna() {
+    let mut a = KmerMinHash::new(20, 3, HashFunctions::murmur64_DNA, 42, 0, false);
+
+    a.add_sequence(b"AAANNCCCTN", true)
+        .unwrap();
+    assert_eq!(a.mins().len(), 3);
+
+    let mut b = KmerMinHash::new(20, 3, HashFunctions::murmur64_DNA, 42, 0, false);
+    b.add_sequence(b"NAAA", true).unwrap();
+    assert_eq!(b.mins().len(), 1);
+}
+
+#[test]
 fn similarity() -> Result<(), Box<dyn std::error::Error>> {
     let mut a = KmerMinHash::new(5, 20, HashFunctions::murmur64_hp, 42, 0, true);
     let mut b = KmerMinHash::new(5, 20, HashFunctions::murmur64_hp, 42, 0, true);


### PR DESCRIPTION
In #860 I described a performance issue in the sketching of DNA sequences: characters were repeatedly rechecked for their validity. The approach by @luizirber vastly speeds up the checking of characters (#861). However, most characters were still checked up to k times. Also, some valid k-mers were now missed due to a small logic error.

This pull request comes in three parts.

1. An initially failing unit test, showcasing the regression introduced in a07dd85.
2. Avoid rechecking valid characters.
3. Remove fast path as it was slowing us down.

Here are the benchmarks:

```
 add_sequence/valid      time:   [4.9079 ms 4.9765 ms 5.0571 ms]                               
                        change: [-7.5285% -6.2820% -4.8922%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking add_sequence/lowercase: Collecting 10 samples in estimated 5.1661 s (1045 iterati                                                                                              add_sequence/lowercase  time:   [4.9820 ms 5.1157 ms 5.3481 ms]
                        change: [-9.3013% -6.2065% -2.4192%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking add_sequence/invalid kmers: Collecting 10 samples in estimated 5.1394 s (1540 ite                                                                                              add_sequence/invalid kmers                        
                        time:   [3.2999 ms 3.3375 ms 3.3611 ms]
                        change: [-32.280% -31.194% -29.966%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking add_sequence/force with valid kmers: Collecting 10 samples in estimated 5.1789 s                                                                                               add_sequence/force with valid kmers                        
                        time:   [4.8650 ms 4.9078 ms 4.9668 ms]
                        change: [-11.240% -7.9411% -4.2589%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
```

This code is not particularly Rusty as I don't know the idioms. Feel free to request changes. Also I don't have all python dependencies installed, so please run the checks again.

Best,
Fabian

- [x] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
