### PR TITLE
Fix travis for 3.2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - "$HOME/.cargo"
     - "target"
 
-if: (type = push AND ((branch = master) OR (tag = "/^v.*$/"))) OR (type = pull_request)
+if: (type = push AND ((branch = master) OR (tag = ^v.*$))) OR (type = pull_request)
 
 script: tox -vv
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ cache:
     - "$HOME/.cargo"
     - "target"
 
-if: (type = push AND ((branch = master) OR (tag = ^v.*$))) OR (type = pull_request)
+if: |
+  (type = push AND (branch = master)) OR \
+  (tag =~ ^v) OR \
+  (type = pull_request)
 
 script: tox -vv
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ cache:
 if: |
   (type = push AND (branch = master)) OR \
   (tag =~ ^v) OR \
-  (type = pull_request)
+  (type = pull_request) OR \
+  (type = cron)
 
 script: tox -vv
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dist: FORCE
 	$(PYTHON) setup.py sdist
 
 test: all
-	pip install -e '.[test]'
+	$(PYTHON) -m pip install -e '.[test]'
 	$(PYTHON) -m pytest
 	cargo test
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -38,6 +38,7 @@ git push --tags git@github.com:dib-lab/sourmash.git
 
 3\. Test the release candidate. Bonus: repeat on macOS:
 ```
+set -e
 python -m pip install -U setuptools pip virtualenv wheel
 
 cd ..
@@ -90,7 +91,7 @@ You will need to [change your PyPI credentials].
 We will be using `twine` to upload the package to TestPyPI and verify
 everything works before sending it to PyPI:
 ```
-pip install twine
+python -m pip install twine
 twine upload --repository-url https://test.pypi.org/legacy/ dist/sourmash-${new_version}${rc}.tar.gz
 ```
 Test the PyPI release in a new virtualenv:
@@ -98,10 +99,10 @@ Test the PyPI release in a new virtualenv:
 cd ../../testenv4
 deactivate
 source bin/activate
-pip install -U setuptools pip wheel
+python -m pip install -U setuptools pip wheel
 # install as much as possible from non-test server!
-pip install screed pytest numpy matplotlib scipy khmer ijson bam2fasta deprecation
-pip install -i https://test.pypi.org/simple --pre sourmash
+python -m pip install screed pytest numpy matplotlib scipy khmer ijson bam2fasta deprecation cffi
+python -m pip install -i https://test.pypi.org/simple --pre sourmash
 sourmash info  # should print "sourmash version ${new_version}${rc}"
 ```
 
@@ -174,5 +175,5 @@ Examples:
 
 ```
 apt-cache update && apt-get -y install python-dev libfreetype6-dev && \
-pip install sourmash[test]
+python -m pip install sourmash[test]
 ```


### PR DESCRIPTION
Change remaining `pip` commands to `python -m pip` in release docs.

Properly set the travis condition for building jobs (push to master, new `vX.Y.Z` tag, pull requests against any branch, cron jobs).

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
