### PR TITLE
Better sourmash compare error handling

### DIFF
--- a/sourmash/cli/compare.py
+++ b/sourmash/cli/compare.py
@@ -27,6 +27,10 @@ def subparser(subparsers):
         help='compare all signatures underneath directories'
     )
     subparser.add_argument(
+        '-f', '--force', action='store_true',
+        help='continue past errors in file loading'
+    )
+    subparser.add_argument(
         '--csv', metavar='F',
         help='write matrix to specified file in CSV format (with column '
         'headers)'

--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -59,7 +59,12 @@ def compare(args):
     ksizes = set()
     moltypes = set()
     for filename in inp_files:
-        notify('loading {}', filename, end='\r')
+        if not os.path.exists(filename) and not \
+               (args.force or args.traverse_directory):
+            error("file '{}' does not exist! exiting.", filename)
+            sys.exit(-1)
+
+        notify("loading '{}'", filename, end='\r')
         loaded = sig.load_signatures(filename,
                                      ksize=args.ksize,
                                      select_moltype=moltype)
@@ -76,6 +81,10 @@ def compare(args):
         # error out while loading if we have more than one ksize/moltype
         if len(ksizes) > 1 or len(moltypes) > 1:
             break
+
+    if not siglist:
+        error('no signatures found! exiting.')
+        sys.exit(-1)
 
     # check ksizes and type
     if len(ksizes) > 1:

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -771,6 +771,35 @@ def test_gather_csv_output_filename_bug(c):
         assert row['filename'] == lca_db_1
 
 
+@utils.in_tempdir
+def test_compare_no_such_file(c):
+    with pytest.raises(ValueError) as e:
+        c.run_sourmash('compare', 'nosuchfile.sig')
+
+    assert "file 'nosuchfile.sig' does not exist! exiting." in c.last_result.err
+
+
+@utils.in_tempdir
+def test_compare_no_such_file_force(c):
+    with pytest.raises(ValueError) as e:
+        c.run_sourmash('compare', 'nosuchfile.sig', '-f')
+
+    print(c.last_result.err)
+    assert "no signatures found! exiting." in c.last_result.err
+
+
+def test_compare_no_matching_sigs():
+    query = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
+    status, out, err = utils.runscript('sourmash', ['compare', '-k', '100',
+                                        query], fail_ok=True)
+
+    print(out)
+    print(err)
+    assert status
+    assert 'warning: no signatures loaded at given ksize/molecule type' in err
+    assert 'no signatures found! exiting.' in err
+
+
 def test_compare_deduce_molecule():
     # deduce DNA vs protein from query, if it is unique
     with utils.TempDirectory() as location:


### PR DESCRIPTION
Error out with correct error messages when files don't exist or no signatures are found.

Also adds a `-f/--force` argument.

Fixes #858.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
