### PR TITLE
re-add 'signature' as alias for 'sig'

### DIFF
--- a/sourmash/cli/__init__.py
+++ b/sourmash/cli/__init__.py
@@ -34,6 +34,7 @@ from . import watch
 # Subcommand groups
 from . import lca
 from . import sig
+from . import sig as signature            # to support alias in sig/__init__.py
 from . import storage
 
 

--- a/sourmash/cli/__init__.py
+++ b/sourmash/cli/__init__.py
@@ -34,7 +34,7 @@ from . import watch
 # Subcommand groups
 from . import lca
 from . import sig
-from . import sig as signature            # to support alias in sig/__init__.py
+from . import signature
 from . import storage
 
 
@@ -93,6 +93,7 @@ def get_parser():
     module_descs = {
         'lca': 'Taxonomic operations',
         'sig': 'Manipulate signature files',
+        'signature': 'Manipulate signature files',
         'storage': 'Operations on storage',
     }
     expert = set(['categorize', 'dump', 'import_csv', 'migrate', 'multigather', 'sbt_combine', 'watch'])

--- a/sourmash/cli/__init__.py
+++ b/sourmash/cli/__init__.py
@@ -93,8 +93,10 @@ def get_parser():
     module_descs = {
         'lca': 'Taxonomic operations',
         'sig': 'Manipulate signature files',
-        'signature': 'Manipulate signature files',
         'storage': 'Operations on storage',
+    }
+    alias = {
+        "sig": "signature"
     }
     expert = set(['categorize', 'dump', 'import_csv', 'migrate', 'multigather', 'sbt_combine', 'watch'])
 
@@ -109,9 +111,13 @@ def get_parser():
     cmd_group_dirs = next(os.walk(clidir))[1]
     cmd_group_dirs = filter(utils.opfilter, cmd_group_dirs)
     cmd_group_dirs = sorted(cmd_group_dirs)
-    for dirpath in cmd_group_dirs:
+
+    cmd_group_usage = [cmd for cmd in cmd_group_dirs if cmd not in alias.values()]
+    for dirpath in cmd_group_usage:
         usage += '\n    ' + module_descs[dirpath] + '\n'
         usage += '        sourmash {gd:s} --help\n'.format(gd=dirpath)
+        if dirpath in alias:
+            usage += '        sourmash {gd:s} --help\n'.format(gd=alias[dirpath])
 
     desc = 'Compute, compare, manipulate, and analyze MinHash sketches of DNA sequences.\n\nUsage instructions:\n' + usage
     parser = SourmashParser(prog='sourmash', description=desc, formatter_class=RawDescriptionHelpFormatter, usage=SUPPRESS)

--- a/sourmash/cli/sig/__init__.py
+++ b/sourmash/cli/sig/__init__.py
@@ -23,7 +23,7 @@ import sys
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('sig', formatter_class=RawDescriptionHelpFormatter, usage=SUPPRESS, aliases=['signature'])
+    subparser = subparsers.add_parser('sig', formatter_class=RawDescriptionHelpFormatter, usage=SUPPRESS)
     desc = 'Operations\n'
     clidir = os.path.dirname(__file__)
     ops = command_list(clidir)

--- a/sourmash/cli/sig/__init__.py
+++ b/sourmash/cli/sig/__init__.py
@@ -23,7 +23,7 @@ import sys
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('sig', formatter_class=RawDescriptionHelpFormatter, usage=SUPPRESS)
+    subparser = subparsers.add_parser('sig', formatter_class=RawDescriptionHelpFormatter, usage=SUPPRESS, aliases=['signature'])
     desc = 'Operations\n'
     clidir = os.path.dirname(__file__)
     ops = command_list(clidir)

--- a/sourmash/cli/signature/__init__.py
+++ b/sourmash/cli/signature/__init__.py
@@ -1,0 +1,43 @@
+"""Define the command line interface for sourmash signature.
+
+Copy commands over from 'sourmash sig'.
+
+This can be removed once Python 2.7 is no longer supported, in favor of an
+'aliases' argument to add_subparser in ../sig/__init__.py.
+"""
+
+from ..sig import describe
+from ..sig import downsample
+from ..sig import extract
+from ..sig import filter
+from ..sig import flatten
+from ..sig import intersect
+from ..sig import merge
+from ..sig import rename
+from ..sig import subtract
+from ..sig import ingest
+from ..sig import export
+from ..sig import overlap
+from ..utils import command_list
+from argparse import SUPPRESS, RawDescriptionHelpFormatter
+import os
+import sys
+
+
+def subparser(subparsers):
+    subparser = subparsers.add_parser('signature', formatter_class=RawDescriptionHelpFormatter, usage=SUPPRESS)
+    desc = 'Operations\n'
+    clidir = os.path.join(os.path.dirname(__file__), '../sig/')
+    ops = command_list(clidir)
+    for subcmd in ops:
+        docstring = getattr(sys.modules[__name__], subcmd).__doc__
+        helpstring = 'sourmash signature {op:s} --help'.format(op=subcmd)
+        desc += '        {hs:33s} {ds:s}\n'.format(hs=helpstring, ds=docstring)
+    s = subparser.add_subparsers(
+        title='Manipulate signature files', dest='subcmd', metavar='subcmd', help=SUPPRESS,
+        description=desc
+    )
+    for subcmd in ops:
+        getattr(sys.modules[__name__], subcmd).subparser(s)
+    subparser._action_groups.reverse()
+    subparser._optionals.title = 'Options'

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -16,12 +16,37 @@ import sourmash
 
 def test_run_sourmash_signature_cmd():
     status, out, err = utils.runscript('sourmash', ['signature'], fail_ok=True)
+    assert not 'sourmash: error: argument cmd: invalid choice:' in err
+    assert 'Manipulate signature files:' in out
     assert status != 0                    # no args provided, ok ;)
 
 
 def test_run_sourmash_sig_cmd():
     status, out, err = utils.runscript('sourmash', ['sig'], fail_ok=True)
+    assert not 'sourmash: error: argument cmd: invalid choice:' in err
+    assert 'Manipulate signature files:' in out
     assert status != 0                    # no args provided, ok ;)
+
+
+@utils.in_tempdir
+def test_sig_merge_1_use_full_signature_in_cmd(c):
+    # merge of 47 & 63 should be union of mins
+    sig47 = utils.get_test_data('47.fa.sig')
+    sig63 = utils.get_test_data('63.fa.sig')
+    sig47and63 = utils.get_test_data('47+63.fa.sig')
+    c.run_sourmash('signature', 'merge', sig47, sig63)
+
+    # stdout should be new signature
+    out = c.last_result.out
+
+    test_merge_sig = sourmash.load_one_signature(sig47and63)
+    actual_merge_sig = sourmash.load_one_signature(out)
+
+    print(test_merge_sig.minhash)
+    print(actual_merge_sig.minhash)
+    print(out)
+
+    assert actual_merge_sig.minhash == test_merge_sig.minhash
 
 
 @utils.in_tempdir

--- a/tests/test_cmd_signature.py
+++ b/tests/test_cmd_signature.py
@@ -17,14 +17,16 @@ import sourmash
 def test_run_sourmash_signature_cmd():
     status, out, err = utils.runscript('sourmash', ['signature'], fail_ok=True)
     assert not 'sourmash: error: argument cmd: invalid choice:' in err
-    assert 'Manipulate signature files:' in out
+    # doesn't work in py2.7
+    # assert 'Manipulate signature files:' in out
     assert status != 0                    # no args provided, ok ;)
 
 
 def test_run_sourmash_sig_cmd():
     status, out, err = utils.runscript('sourmash', ['sig'], fail_ok=True)
     assert not 'sourmash: error: argument cmd: invalid choice:' in err
-    assert 'Manipulate signature files:' in out
+    # doesn't work in py2.7
+    # assert 'Manipulate signature files:' in out
     assert status != 0                    # no args provided, ok ;)
 
 


### PR DESCRIPTION
Fixes #880 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
