### PR TITLE
name signatures based on md5sum, not on name()

### DIFF
--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -169,7 +169,7 @@ class SBT(Index):
         "Add a new SourmashSignature in to the SBT."
         from .sbtmh import SigLeaf
         
-        leaf = SigLeaf(signature.name(), signature)
+        leaf = SigLeaf(signature.md5sum(), signature)
         self.add_node(leaf)
 
     def add_node(self, node):

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -2054,6 +2054,34 @@ def test_do_sourmash_check_search_vs_actual_similarity():
         assert status == 0
 
 
+def test_do_sourmash_check_sbt_filenames():
+    with utils.TempDirectory() as location:
+        files = [utils.get_test_data(f) for f in utils.SIG_FILES]
+
+        status, out, err = utils.runscript('sourmash',
+                                           ['index', '-k', '31', 'zzz'] + files,
+                                           in_directory=location)
+
+        assert os.path.exists(os.path.join(location, 'zzz.sbt.json'))
+
+        sig_names = set()
+        sig_md5s = set()
+        for f in files:
+            sig = signature.load_one_signature(f)
+            sig_names.add(sig.name())
+            sig_md5s.add(sig.md5sum())
+
+        sbt_files = glob.glob(os.path.join(location, '.sbt.zzz', '*'))
+        assert len(sbt_files) == 13
+
+        for f in sbt_files:
+            if 'internal' in f:
+                continue
+            f = os.path.basename(f)
+            assert f not in sig_names
+            assert f in sig_md5s
+
+
 def test_do_sourmash_sbt_search_bestonly():
     with utils.TempDirectory() as location:
         testdata1 = utils.get_test_data('short.fa')


### PR DESCRIPTION
Fixes #883 by naming signatures in SBT FSStorage based on their md5sum, preventing name collisions.

Note that this change is fully backwards and forwards compatible, because it merely changes the names that are put in the SBT JSON file.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
