### PR TITLE
Replace mins_push and abunds_push with set_abundances

### DIFF
--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -98,8 +98,6 @@ void computeparams_set_scaled(ComputeParameters *ptr, uint64_t scaled);
 
 uint64_t hash_murmur(const char *kmer, uint64_t seed);
 
-void kmerminhash_abunds_push(KmerMinHash *ptr, uint64_t val);
-
 void kmerminhash_add_from(KmerMinHash *ptr, const KmerMinHash *other);
 
 void kmerminhash_add_hash(KmerMinHash *ptr, uint64_t h);
@@ -164,8 +162,6 @@ void kmerminhash_merge(KmerMinHash *ptr, const KmerMinHash *other);
 
 bool kmerminhash_is_compatible(const KmerMinHash *ptr, const KmerMinHash *other);
 
-void kmerminhash_mins_push(KmerMinHash *ptr, uint64_t val);
-
 KmerMinHash *kmerminhash_new(uint32_t n,
                              uint32_t k,
                              bool prot,
@@ -182,6 +178,8 @@ void kmerminhash_remove_hash(KmerMinHash *ptr, uint64_t h);
 void kmerminhash_remove_many(KmerMinHash *ptr, const uint64_t *hashes_ptr, uintptr_t insize);
 
 uint64_t kmerminhash_seed(KmerMinHash *ptr);
+
+void kmerminhash_set_abundances(KmerMinHash *ptr, const uint64_t *hashes_ptr, const uint64_t *abunds_ptr, uintptr_t insize);
 
 bool kmerminhash_track_abundance(KmerMinHash *ptr);
 

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -438,15 +438,13 @@ class MinHash(RustObject):
 
     def set_abundances(self, values):
         if self.track_abundance:
-            added = 0
+            hashes = []
+            abunds = []
+            for h, v in values.items():
+                hashes.append(h)
+                abunds.append(v)
 
-            for k, v in sorted(values.items()):
-                if not self.max_hash or k <= self.max_hash:
-                    self._methodcall(lib.kmerminhash_mins_push, k)
-                    self._methodcall(lib.kmerminhash_abunds_push, v)
-                    added += 1
-                    if self.num > 0 and added >= self.num:
-                        break
+            self._methodcall(lib.kmerminhash_set_abundances, hashes, abunds, len(hashes))
         else:
             raise RuntimeError(
                 "Use track_abundance=True when constructing "

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -274,7 +274,14 @@ unsafe fn kmerminhash_set_abundances(
         slice::from_raw_parts(abunds_ptr as *const u64, insize)
     };
 
-    let pairs: Vec<_> = hashes.iter().cloned().zip(abunds.iter().cloned()).collect();
+    let mut pairs: Vec<_> = hashes.iter().cloned().zip(abunds.iter().cloned()).collect();
+    pairs.sort();
+
+    // Reset the minhash
+    mh.mins.clear();
+    if let Some(ref mut abunds) = mh.abunds {
+        abunds.clear();
+    }
 
     mh.add_many_with_abund(&pairs)?;
 

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -252,13 +252,34 @@ pub unsafe extern "C" fn kmerminhash_get_mins_size(ptr: *mut KmerMinHash) -> usi
     mh.mins.len()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn kmerminhash_mins_push(ptr: *mut KmerMinHash, val: u64) {
+ffi_fn! {
+unsafe fn kmerminhash_set_abundances(
+    ptr: *mut KmerMinHash,
+    hashes_ptr: *const u64,
+    abunds_ptr: *const u64,
+    insize: usize,
+) -> Result<()> {
     let mh = {
         assert!(!ptr.is_null());
         &mut *ptr
     };
-    mh.mins.push(val)
+
+    let hashes = {
+        assert!(!hashes_ptr.is_null());
+        slice::from_raw_parts(hashes_ptr as *const u64, insize)
+    };
+
+    let abunds = {
+        assert!(!abunds_ptr.is_null());
+        slice::from_raw_parts(abunds_ptr as *const u64, insize)
+    };
+
+    let pairs: Vec<_> = hashes.iter().cloned().zip(abunds.iter().cloned()).collect();
+
+    mh.add_many_with_abund(&pairs)?;
+
+    Ok(())
+}
 }
 
 ffi_fn! {
@@ -285,17 +306,6 @@ pub unsafe extern "C" fn kmerminhash_get_abunds_size(ptr: *mut KmerMinHash) -> u
         abunds.len()
     } else {
         0
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn kmerminhash_abunds_push(ptr: *mut KmerMinHash, val: u64) {
-    let mh = {
-        assert!(!ptr.is_null());
-        &mut *ptr
-    };
-    if let Some(ref mut abunds) = mh.abunds {
-        abunds.push(val)
     }
 }
 


### PR DESCRIPTION
`kmerminhash_mins_push` and `kmerminhash_abunds_push` are too low level to expose on the C API, since they can leave the MinHash in an invalid state. This PR removes them and add `kmerminhash_set_abundances` instead, which doesn't assume as much.

It would be nice to have a `add_hash_with_abundance` and avoid the `add_many` behavior (calling `add_hash` in a loop), but that can be done later.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
