### PR TITLE
more refactoring of MinHash API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Cargo.lock
 .asv
 pkg/
 wasm-pack.log
+.hypothesis

--- a/doc/api-example.md
+++ b/doc/api-example.md
@@ -15,21 +15,21 @@ Create two MinHashes using 3-mers, and add the sequences:
 
 ```
 >>> import sourmash
->>> E1 = sourmash.MinHash(n=20, ksize=3)
->>> E1.add_sequence(seq1)
+>>> mh1 = sourmash.MinHash(n=20, ksize=3)
+>>> mh1.add_sequence(seq1)
 
 ```
 
 ```
->>> E2 = sourmash.MinHash(n=20, ksize=3)
->>> E2.add_sequence(seq2)
+>>> mh2 = sourmash.MinHash(n=20, ksize=3)
+>>> mh2.add_sequence(seq2)
 
 ```
 
 One of the 3-mers (out of 7) overlaps, so Jaccard index is 1/7:
 
 ```
->>> round(E1.jaccard(E2), 2)
+>>> round(mh1.jaccard(mh2), 2)
 0.14
 
 ```
@@ -37,7 +37,7 @@ One of the 3-mers (out of 7) overlaps, so Jaccard index is 1/7:
 and of course the MinHashes match themselves:
 
 ```
->>> E1.jaccard(E1)
+>>> mh1.jaccard(mh1)
 1.0
 
 ```
@@ -45,8 +45,8 @@ and of course the MinHashes match themselves:
 We can add sequences and query at any time --
 
 ```
->>> E1.add_sequence(seq2)
->>> x = E1.jaccard(E2)
+>>> mh1.add_sequence(seq2)
+>>> x = mh1.jaccard(mh2)
 >>> round(x, 3)
 0.571
 
@@ -79,10 +79,10 @@ raising an exception.
 >>> import screed
 >>> minhashes = []
 >>> for g in genomes:
-...     E = sourmash.MinHash(n=500, ksize=31)
+...     mh = sourmash.MinHash(n=500, ksize=31)
 ...     for record in screed.open(g):
-...         E.add_sequence(record.sequence[:50000], True)
-...     minhashes.append(E)
+...         mh.add_sequence(record.sequence[:50000], True)
+...     minhashes.append(mh)
 
 ```
 
@@ -219,7 +219,7 @@ MinHash objects with different num or scaled values (or different ksizes):
 
 ```
 >>> signum2 = sourmash.MinHash(n=1000, ksize=31)
->>> signum.similarity(signum2)
+>>> signum.jaccard(signum2)
 Traceback (most recent call last):
   ...
 TypeError: must have same num: 500 != 1000

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -11,8 +11,11 @@ its Python API.  Please also see `examples of using the API <api-example.html>`_
 ``MinHash``: basic MinHash sketch functionality
 ===============================================
 
-.. automodule:: sourmash
+.. autoclass:: sourmash.MinHash
    :members:
+
+   .. automethod:: __init__
+
 
 ``SourmashSignature``: save and load MinHash sketches in JSON
 =============================================================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,9 @@
 import sys
 import os
 
+import sourmash
+print('sourmash at:', sourmash)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinxcontrib.napoleon',
-    'nbsphinx'
+    'nbsphinx',
+    'IPython.sphinxext.ipython_console_highlighting'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -295,14 +296,10 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
-try:
-    from recommonmark.parser import CommonMarkParser
+from recommonmark.parser import CommonMarkParser
 
-    source_parsers = {
-        '.md': CommonMarkParser,
-    }
-except ImportError:
-    raise
-    pass
+source_parsers = {
+    '.md': CommonMarkParser,
+}
 
 autodoc_mock_imports = ["sourmash._minhash"]

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -116,8 +116,6 @@ double kmerminhash_jaccard(KmerMinHash *ptr, const KmerMinHash *other, bool down
 double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance, bool downsample);
 double kmerminhash_angular_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance, bool downsample);
 
-double kmerminhash_containment_ignore_maxhash(KmerMinHash *ptr, const KmerMinHash *other);
-
 uint64_t kmerminhash_count_common(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 
 bool kmerminhash_dayhoff(KmerMinHash *ptr);

--- a/include/sourmash.h
+++ b/include/sourmash.h
@@ -108,7 +108,6 @@ void kmerminhash_add_protein(KmerMinHash *ptr, const char *sequence);
 
 void kmerminhash_add_word(KmerMinHash *ptr, const char *word);
 
-double kmerminhash_compare(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 double kmerminhash_jaccard(KmerMinHash *ptr, const KmerMinHash *other, bool downsample);
 
 double kmerminhash_similarity(KmerMinHash *ptr, const KmerMinHash *other, bool ignore_abundance, bool downsample);

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ SETUP_METADATA = {
         'test' : ['pytest', 'pytest-cov', 'recommonmark', 'hypothesis'],
         'demo' : ['jupyter', 'jupyter_client', 'ipython'],
         'doc' : ['sphinx', 'recommonmark', 'alabaster',
-                 "sphinxcontrib-napoleon", "nbsphinx"],
+                 "sphinxcontrib-napoleon", "nbsphinx",
+                 "ipython"],
         '10x': ['bam2fasta==1.0.1'],
         'storage': ["ipfshttpclient", "redis"]
     },

--- a/sourmash/__init__.py
+++ b/sourmash/__init__.py
@@ -11,27 +11,6 @@ from ._lowlevel import ffi, lib
 
 ffi.init_once(lib.sourmash_init, "init")
 
-from ._minhash import MinHash, get_minhash_default_seed, get_minhash_max_hash
-
-DEFAULT_SEED = get_minhash_default_seed()
-MAX_HASH = get_minhash_max_hash()
-
-from .signature import (
-    load_signatures,
-    load_one_signature,
-    SourmashSignature,
-    save_signatures,
-)
-from .sbtmh import load_sbt_index, search_sbt_index, create_sbt_index
-from . import lca
-from . import sbt
-from . import sbtmh
-from . import sbt_storage
-from . import signature
-from . import sig
-from . import cli
-from . import commands
-
 from pkg_resources import get_distribution, DistributionNotFound
 
 try:
@@ -45,3 +24,25 @@ except DistributionNotFound:  # pragma: no cover
             "This might be because you are installing from GitHub's tarballs, "
             "use the PyPI ones."
         )
+
+from ._minhash import MinHash, get_minhash_default_seed, get_minhash_max_hash
+
+DEFAULT_SEED = get_minhash_default_seed()
+MAX_HASH = get_minhash_max_hash()
+
+from .signature import (
+    load_signatures,
+    load_one_signature,
+    SourmashSignature,
+    save_signatures,
+)
+
+from .sbtmh import load_sbt_index, search_sbt_index, create_sbt_index
+from . import lca
+from . import sbt
+from . import sbtmh
+from . import sbt_storage
+from . import signature
+from . import sig
+from . import cli
+from . import commands

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -261,7 +261,7 @@ class MinHash(RustObject):
         self._methodcall(lib.kmerminhash_remove_many, list(hashes), len(hashes))
 
     def update(self, other):
-        "Update this sketch from all the hashes from the other."
+        "Update this sketch from all the hashes in the other."
         self.add_many(other)
 
     def __len__(self):
@@ -528,7 +528,7 @@ class MinHash(RustObject):
 
     def set_abundances(self, values):
         """Set abundances for hashes from ``values``, where
-        ```values[hash] = abund``
+        ``values[hash] = abund``
         """
         if self.track_abundance:
             hashes = []

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -426,6 +426,10 @@ class MinHash(RustObject):
         return self.count_common(other, downsample) / len(self)
 
     def containment_ignore_maxhash(self, other):
+        """Calculate contained_by, with downsampling.
+
+        @CTB to be deprecated/removed in v4 or v5.
+        """
         return self.contained_by(other, downsample=True)
 
     def __iadd__(self, other):

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -381,13 +381,14 @@ class MinHash(RustObject):
 
         return common, max(size, 1)
 
-    def compare(self, other, downsample=False):
-        "Compare two sketches, w/o abundance; calculates Jaccard similarity."
+    def jaccard(self, other, downsample=False):
+        """Calculate Jaccard similarity of two MinHash objects."""
         if self.num != other.num:
             err = "must have same num: {} != {}".format(self.num, other.num)
             raise TypeError(err)
         return self._methodcall(lib.kmerminhash_compare, other._get_objptr(), downsample)
-    jaccard = compare                     # @CTB should we deprecate this?
+    compare = jaccard # this will be removed at some point @CTB
+
 
     def similarity(self, other, ignore_abundance=False, downsample=False):
         """Calculate similarity of two sketches.
@@ -403,15 +404,14 @@ class MinHash(RustObject):
 
         See https://en.wikipedia.org/wiki/Cosine_similarity
         """
+        return self._methodcall(lib.kmerminhash_similarity,
+                                other._get_objptr(),
+                                ignore_abundance, downsample)
 
-        # if either signature is flat, calculate Jaccard only.
-        both_track_abundance = self.track_abundance and other.track_abundance
-        if not both_track_abundance or ignore_abundance:
-            return self.jaccard(other, downsample)
-        else:
-            return self._methodcall(lib.kmerminhash_similarity,
-                                    other._get_objptr(),
-                                    ignore_abundance, downsample)
+    def angular_similarity(self, other):
+        "Calculate the angular similarity."
+        return self._methodcall(lib.kmerminhash_angular_similarity,
+                                other._get_objptr())
 
     def is_compatible(self, other):
         return self._methodcall(lib.kmerminhash_is_compatible, other._get_objptr())

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -8,7 +8,7 @@ from ._compat import string_types, range_type
 from ._lowlevel import ffi, lib
 from .utils import RustObject, rustcall, decode_str
 from .exceptions import SourmashError
-from deprecated import deprecated
+from deprecation import deprecated
 
 # default MurmurHash seed
 MINHASH_DEFAULT_SEED = 42

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, division
 import math
 import copy
 
+from . import VERSION
 from ._compat import string_types, range_type
 from ._lowlevel import ffi, lib
 from .utils import RustObject, rustcall, decode_str
@@ -439,8 +440,9 @@ class MinHash(RustObject):
 
         return a
 
-    @deprecated(version='3.3',
-                reason='Use count_common or set methods instead.')
+    @deprecated(deprecated_in="3.3", removed_in="4.0",
+                current_version=VERSION,
+                details='Use count_common or set methods instead.')
     def intersection(self, other, in_common=False):
         """Calculate the intersection between ``self`` and ``other``, and
         return ``(mins, size)`` where ``mins`` are the hashes in common, and
@@ -479,8 +481,9 @@ class MinHash(RustObject):
             raise TypeError(err)
         return self._methodcall(lib.kmerminhash_similarity, other._get_objptr(), True, downsample)
 
-    @deprecated(version='3.3',
-                reason="Use 'similarity' instead of compare.")
+    @deprecated(deprecated_in="3.3", removed_in="4.0",
+                current_version=VERSION,
+                details="Use 'similarity' instead of compare.")
     def compare(self, other, downsample=False):
         "Calculate Jaccard similarity of two sketches."
         return self.jaccard(other, downsample=downsample)
@@ -521,8 +524,9 @@ class MinHash(RustObject):
 
         return self.count_common(other, downsample) / len(self)
 
-    @deprecated(version='3.3',
-                reason="Use 'contained_by' with downsample=True instead.")
+    @deprecated(deprecated_in="3.3", removed_in="4.0",
+                current_version=VERSION,
+                details="Use 'contained_by' with downsample=True instead.")
     def containment_ignore_maxhash(self, other):
         """Calculate contained_by, with downsampling.
         """

--- a/sourmash/index.py
+++ b/sourmash/index.py
@@ -88,7 +88,7 @@ class Index(ABC):
         "Return the match with the best Jaccard containment in the Index."
         results = []
         for ss in self.signatures():
-            cont = query.minhash.containment_ignore_maxhash(ss.minhash)
+            cont = query.minhash.contained_by(ss.minhash, True)
             if cont:
                 results.append((cont, ss, self.filename))
 

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -331,7 +331,7 @@ class SBT(Index):
         results = []
         for leaf in self.find(search_fn, query, threshold, unload_data=unload_data):
             leaf_e = leaf.data.minhash
-            similarity = query.minhash.containment_ignore_maxhash(leaf_e)
+            similarity = query.minhash.contained_by(leaf_e, True)
             if similarity > 0.0:
                 results.append((similarity, leaf.data, None))
 

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -57,7 +57,6 @@ from random import randint, random
 import sys
 from tempfile import NamedTemporaryFile
 
-from deprecation import deprecated
 import khmer
 
 try:

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -506,22 +506,6 @@ unsafe fn kmerminhash_intersection(ptr: *mut KmerMinHash, other: *const KmerMinH
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_containment_ignore_maxhash(ptr: *mut KmerMinHash, other: *const KmerMinHash)
-    -> Result<f64> {
-    let mh = {
-        assert!(!ptr.is_null());
-        &mut *ptr
-    };
-    let other_mh = {
-       assert!(!other.is_null());
-       &*other
-    };
-
-    mh.containment_ignore_maxhash(&other_mh)
-}
-}
-
-ffi_fn! {
 unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash, downsample: bool)
     -> Result<f64> {
     let mh = {

--- a/src/core/src/ffi/minhash.rs
+++ b/src/core/src/ffi/minhash.rs
@@ -523,22 +523,6 @@ unsafe fn kmerminhash_intersection(ptr: *mut KmerMinHash, other: *const KmerMinH
 }
 
 ffi_fn! {
-unsafe fn kmerminhash_compare(ptr: *mut KmerMinHash, other: *const KmerMinHash, downsample: bool)
-    -> Result<f64> {
-    let mh = {
-        assert!(!ptr.is_null());
-        &mut *ptr
-    };
-    let other_mh = {
-       assert!(!other.is_null());
-       &*other
-    };
-
-    // call similarity directly, with ignore_abundance=True
-    mh.similarity(other_mh, true, downsample)
-}
-}
-ffi_fn! {
 unsafe fn kmerminhash_jaccard(ptr: *mut KmerMinHash, other: *const KmerMinHash)
     -> Result<f64> {
     let mh = {

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -614,8 +614,7 @@ impl KmerMinHash {
             };
             let downsampled_mh = second.downsample_max_hash(first.max_hash)?;
             first.similarity(&downsampled_mh, ignore_abundance, false)
-        } else if ignore_abundance ||
-            self.abunds.is_none() || other.abunds.is_none() {
+        } else if ignore_abundance || self.abunds.is_none() || other.abunds.is_none() {
             self.jaccard(&other)
         } else {
             self.angular_similarity(&other)

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -606,12 +606,6 @@ impl KmerMinHash {
         }
     }
 
-    pub fn containment_ignore_maxhash(&self, other: &KmerMinHash) -> Result<f64, Error> {
-        let it = Intersection::new(self.mins.iter(), other.mins.iter());
-
-        Ok(it.count() as f64 / self.size() as f64)
-    }
-
     pub fn dayhoff(&self) -> bool {
         self.hash_function == HashFunctions::murmur64_dayhoff
     }

--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -543,7 +543,7 @@ impl KmerMinHash {
 
         if self.abunds.is_none() || other.abunds.is_none() {
             // TODO: throw error, we need abundance for this
-            unimplemented!()
+            unimplemented!() // @CTB fixme
         }
 
         let abunds = self.abunds.as_ref().unwrap();
@@ -598,7 +598,8 @@ impl KmerMinHash {
             };
             let downsampled_mh = second.downsample_max_hash(first.max_hash)?;
             first.similarity(&downsampled_mh, ignore_abundance, false)
-        } else if ignore_abundance {
+        } else if ignore_abundance ||
+            self.abunds.is_none() || other.abunds.is_none() {
             self.jaccard(&other)
         } else {
             self.angular_similarity(&other)

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -541,6 +541,8 @@ def test_intersection_errors(track_abundance):
         a.intersection(c)
 
 
+# this filter doesn't work, but leaving it in pour encourages les autres.
+@pytest.mark.filterwarnings("ignore")
 def test_intersection_1(track_abundance):
     a = MinHash(20, 10, track_abundance=track_abundance)
     b = MinHash(20, 10, track_abundance=track_abundance)
@@ -696,7 +698,7 @@ def test_mh_downsample_n_error(track_abundance):
         a.downsample_n(30)
 
 
-def test_mh_asymmetric(track_abundance):
+def test_mh_jaccard_asymmetric_num(track_abundance):
     a = MinHash(20, 10, track_abundance=track_abundance)
     for i in range(0, 40, 2):
         a.add_hash(i)


### PR DESCRIPTION
Minor refactoring:
* Move Python `MinHash.similarity(...)` entirely into Rust, fix Rust function up a bit.
* Add Python `MinHash.angular_similarity(...)` method.
* Remove `MinHash.containment_ignore_maxhash` usage entirely from Python and Rust, while leaving as part of the Python MinHash API.
* Remove unused `deprecation` import in sbt.py.
* deprecate `MinHash.containment_ignore_maxhash` as of v3.3; remove from Rust.
* deprecate `MinHash.compare` as of v3.3; remove from Rust.
* deprecate `MinHash.intersection` as of v3.3.
* add or update MinHash class/method docstrings.

TODO:

* maybe: write Python `MinHash` object API tests/docs.
* maybe: fix unnamed exception in rust `angular_similarity` method.

Ref #885.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
