### PR TITLE
bug: add_hash with num doesn't set abundances properly

### DIFF
--- a/src/core/src/sketch/minhash.rs
+++ b/src/core/src/sketch/minhash.rs
@@ -270,7 +270,7 @@ impl KmerMinHash {
                 }
                 return;
             } else if hash <= self.max_hash
-                || current_max > hash
+                || current_max >= hash
                 || (self.mins.len() as u32) < self.num
             {
                 // "good" hash - within range, smaller than current entry, or

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -1138,6 +1138,14 @@ def test_reviving_minhash():
         mh.add_hash(m)
 
 
+def test_set_abundance_num():
+    a = MinHash(2, 10, track_abundance=True)
+
+    a.set_abundances({1: 3, 2: 4})
+
+    assert a.get_mins(with_abundance=True) == {1: 3, 2: 4}
+
+
 def test_mh_copy_and_clear(track_abundance):
     # test basic creation of new, empty MinHash
     a = MinHash(20, 10, track_abundance=track_abundance)


### PR DESCRIPTION
Found this while updating #661. All our tests use scaled MH, so this didn't pop up...

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
