### PR TITLE
Fix `lca classify` bug with -o

### DIFF
--- a/sourmash/lca/command_classify.py
+++ b/sourmash/lca/command_classify.py
@@ -113,40 +113,41 @@ def classify(args):
     notify("outputting classifications to {}", args.output)
     with sourmash_args.FileOutput(args.output, 'wt') as outfp:
         csvfp = csv.writer(outfp)
-    csvfp.writerow(['ID','status'] + list(lca_utils.taxlist()))
 
-    # for each query, gather all the matches across databases
-    total_count = 0
-    n = 0
-    total_n = len(inp_files)
-    for query_filename in inp_files:
-        n += 1
-        for query_sig in load_signatures(query_filename, ksize=ksize):
-            notify(u'\r\033[K', end=u'')
-            notify('... classifying {} (file {} of {})', query_sig.name(),
-                   n, total_n, end='\r')
-            debug('classifying', query_sig.name())
-            total_count += 1
+        csvfp.writerow(['ID','status'] + list(lca_utils.taxlist()))
 
-            # make sure we're looking at the same scaled value as database
-            query_sig.minhash = query_sig.minhash.downsample_scaled(scaled)
-
-            # do the classification
-            lineage, status = classify_signature(query_sig, dblist,
-                                                 args.threshold)
-            debug(lineage)
-
-            # output each classification to the spreadsheet
-            row = [query_sig.name(), status]
-            row += lca_utils.zip_lineage(lineage)
-
-            # when outputting to stdout, make output intelligible
-            if not args.output:
+        # for each query, gather all the matches across databases
+        total_count = 0
+        n = 0
+        total_n = len(inp_files)
+        for query_filename in inp_files:
+            n += 1
+            for query_sig in load_signatures(query_filename, ksize=ksize):
                 notify(u'\r\033[K', end=u'')
-            csvfp.writerow(row)
+                notify('... classifying {} (file {} of {})', query_sig.name(),
+                       n, total_n, end='\r')
+                debug('classifying', query_sig.name())
+                total_count += 1
 
-    notify(u'\r\033[K', end=u'')
-    notify('classified {} signatures total', total_count)
+                # make sure we're looking at the same scaled value as database
+                query_sig.minhash = query_sig.minhash.downsample_scaled(scaled)
+
+                # do the classification
+                lineage, status = classify_signature(query_sig, dblist,
+                                                     args.threshold)
+                debug(lineage)
+
+                # output each classification to the spreadsheet
+                row = [query_sig.name(), status]
+                row += lca_utils.zip_lineage(lineage)
+
+                # when outputting to stdout, make output intelligible
+                if not args.output:
+                    notify(u'\r\033[K', end=u'')
+                csvfp.writerow(row)
+
+        notify(u'\r\033[K', end=u'')
+        notify('classified {} signatures total', total_count)
 
 
 if __name__ == '__main__':

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -551,6 +551,25 @@ def test_single_classify():
         assert 'loaded 1 LCA databases' in err
 
 
+def test_single_classify_to_output():
+    with utils.TempDirectory() as location:
+        db1 = utils.get_test_data('lca/delmont-1.lca.json')
+        input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
+
+        cmd = ['lca', 'classify', '--db', db1, '--query', input_sig,
+               '-o', 'outfile.txt']
+        status, out, err = utils.runscript('sourmash', cmd)
+
+        print(cmd)
+        print(out)
+        print(err)
+
+        outdata = open('outfile.txt', 'rt').read()
+        assert 'TARA_ASE_MAG_00031,found,Bacteria,Proteobacteria,Gammaproteobacteria,Alteromonadales,Alteromonadaceae,Alteromonas,Alteromonas_macleodii' in outdata
+        assert 'classified 1 signatures total' in err
+        assert 'loaded 1 LCA databases' in err
+
+
 def test_single_classify_empty():
     with utils.TempDirectory() as location:
         db1 = utils.get_test_data('lca/both.lca.json')

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -841,6 +841,28 @@ def test_single_summarize():
         assert '100.0%   200   Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales' in out
 
 
+def test_single_summarize_to_output():
+    with utils.TempDirectory() as location:
+        db1 = utils.get_test_data('lca/delmont-1.lca.json')
+        input_sig = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
+        in_dir = os.path.join(location, 'sigs')
+        os.mkdir(in_dir)
+        shutil.copyfile(input_sig, os.path.join(in_dir, 'q.sig'))
+
+        cmd = ['lca', 'summarize', '--db', db1, '--query', input_sig,
+               '-o', 'output.txt']
+        status, out, err = utils.runscript('sourmash', cmd)
+
+        print(cmd)
+        print(out)
+        print(err)
+
+        outdata = open('output.txt', 'rt').read()
+
+        assert 'loaded 1 signatures from 1 files total.' in err
+        assert '100.0%   200   Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales' in outdata
+
+
 def test_single_summarize_scaled():
     with utils.TempDirectory() as location:
         db1 = utils.get_test_data('lca/delmont-1.lca.json')

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -860,7 +860,7 @@ def test_single_summarize_to_output():
         outdata = open('output.txt', 'rt').read()
 
         assert 'loaded 1 signatures from 1 files total.' in err
-        assert '100.0%   200   Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales' in outdata
+        assert '200,Bacteria,Proteobacteria,Gammaproteobacteria' in outdata
 
 
 def test_single_summarize_scaled():


### PR DESCRIPTION
Fixes #900. Introduced bug in #883, where we apparently never actually tested `lca classify -o ...` :)

Briefly, the new `sourmash_args.FileOutput` context manager tracks whether it's working with stdout, and will not close it if it is. So this allows bugs where, if stdout is given, the fp returned by `FileOutput` is still valid; but if a filename is specified, the fp is closed.

I verified by manual inspection that this isn't happening anywhere else in the code base.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
