### PR TITLE
(build) pin virtualenv version for asv, and also run GH actions on rust version tags

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install asv virtualenv
+        pip install asv virtualenv==16.7.9
     - name: Runs benchmarks against master
       run: |
         asv machine --yes

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -165,21 +165,6 @@ jobs:
       - name: run wasm-pack
         run: wasm-pack build src/core -d ../../pkg
 
-      # Publish to NPM on tags
-      - name: Prepare node for NPM publishing
-        uses: actions/setup-node@v1
-        if: startsWith(github.ref, 'refs/tags/r')
-        with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
-
-      # Publish to NPM on tags
-      - name: Publish to NPM
-        run: '(cd pkg && npm publish)'
-        if: startsWith(github.ref, 'refs/tags/r')
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   wasm32-wasi:
     name: Run tests under wasm32-wasi
     runs-on: ubuntu-latest
@@ -230,22 +215,6 @@ jobs:
         with:
           command: publish
           args: --dry-run --manifest-path src/core/Cargo.toml
-
-      # Login to crates.io on tags
-      - name: login to crates.io
-        uses: actions-rs/cargo@v1
-        if: startsWith(github.ref, 'refs/tags/r')
-        with:
-          command: login
-          args: ${{ secrets.CRATES_IO_TOKEN }}
-
-      # Publish to crates.io on tags
-      - name: Publish to crates.io
-        uses: actions-rs/cargo@v1
-        if: startsWith(github.ref, 'refs/tags/r')
-        with:
-          command: publish
-          args: --manifest-path src/core/Cargo.toml
 
   minimum_rust_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust_publish.yml
+++ b/.github/workflows/rust_publish.yml
@@ -1,0 +1,68 @@
+name: Rust publish
+
+on:
+  push:
+    tags:
+      - 'r*'
+
+jobs:
+  wasm-pack:
+    name: Check if wasm-pack builds a valid package for the sourmash crate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --force wasm-pack --version 0.8.1
+      - name: run wasm-pack
+        run: wasm-pack build src/core -d ../../pkg
+
+      - name: Prepare node for NPM publishing
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
+      - name: Publish to NPM
+        run: '(cd pkg && npm publish)'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Make sure we can publish the sourmash crate
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --dry-run --manifest-path src/core/Cargo.toml
+
+      # Login to crates.io on tags
+      - name: login to crates.io
+        uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{ secrets.CRATES_IO_TOKEN }}
+
+      # Publish to crates.io on tags
+      - name: Publish to crates.io
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --manifest-path src/core/Cargo.toml


### PR DESCRIPTION
asv benchmarks are broken in GitHub Actions because a new `virtualenv` was released and removed the `--no-site-packages` flag (which is the default now). Keep older virtualenv until `asv` is fixed.

Rust tags were not being built for the last releases (`r0.4.0` and `r0.5.0`) and I ran the publish commands (to crates.io and npm) manually. They should trigger next time with the fix in this PR.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
