### PR TITLE
set_abundances fails with large signatures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ SETUP_METADATA = {
         'sourmash = sourmash.__main__:main'
         ]
     },
-    "install_requires": ["screed>=0.9", "khmer>=2.1", "cffi", 'numpy',
+    "install_requires": ["screed>=0.9", "khmer>=2.1", "cffi>=1.14.0", 'numpy',
                          'matplotlib', 'scipy', "deprecation>=2.0.6"],
     "setup_requires": [
         "setuptools>=38.6.0",

--- a/tests/test__minhash.py
+++ b/tests/test__minhash.py
@@ -36,6 +36,7 @@
 from __future__ import print_function
 from __future__ import absolute_import, unicode_literals
 
+import itertools
 import pickle
 import math
 
@@ -1365,3 +1366,13 @@ def test_add_many(track_abundance):
 
     assert len(b) == 50
     assert a == b
+
+
+def test_set_abundances_huge():
+    max_hash = 4000000
+    a = MinHash(0, 10, track_abundance=True, max_hash=max_hash)
+
+    hashes = list(range(max_hash))
+    abundances = itertools.repeat(2)
+
+    a.set_abundances(dict(zip(hashes, abundances)))


### PR DESCRIPTION
Added a test for triggering the bug, still need to figure out a fix :grimacing: 

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
