### PR TITLE
make LCA signatures() method return signatures with the correct original name

### DIFF
--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -422,10 +422,6 @@ class LCA_Database(Index):
 
         # for each match, in order of largest overlap,
         for idx, count in c.items():
-            # retrieve the identifier and name
-            ident = self.idx_to_ident[idx]
-            name = self.ident_to_name[ident]
-
             # pull in the hashes. This reconstructs & caches all input
             # minhashes, which is kinda memory intensive...!
             # NOTE: one future low-mem optimization could be to support doing

--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -346,32 +346,33 @@ class LCA_Database(Index):
         minhash = MinHash(n=0, ksize=self.ksize, scaled=self.scaled)
 
         debug('creating signatures for LCA DB...')
-        sigd = defaultdict(minhash.copy_and_clear)
+        mhd = defaultdict(minhash.copy_and_clear)
         temp_vals = defaultdict(list)
 
-        for (k, v) in self.hashval_to_idx.items():
-            for vv in v:
-                temp_hashes = temp_vals[vv]
-                temp_hashes.append(k)
+        # invert the hashval_to_idx dictionary
+        for (hashval, idlist) in self.hashval_to_idx.items():
+            for idx in idlist:
+                temp_hashes = temp_vals[idx]
+                temp_hashes.append(hashval)
 
                 # 50 is an arbitrary number. If you really want
                 # to micro-optimize, list is resized and grow in this pattern:
                 # 0, 4, 8, 16, 25, 35, 46, 58, 72, 88, ...
                 # (from https://github.com/python/cpython/blob/b2b4a51f7463a0392456f7772f33223e57fa4ccc/Objects/listobject.c#L57)
                 if len(temp_hashes) > 50:
-                    sigd[vv].add_many(temp_hashes)
+                    mhd[idx].add_many(temp_hashes)
 
                     # Sigh, python 2... when it goes away,
                     # we can do `temp_hashes.clear()` instead.
-                    del temp_vals[vv]
+                    del temp_vals[idx]
 
         # We loop temp_vals again to add any remainder hashes
         # (each list of hashes is smaller than 50 items)
         for sig, vals in temp_vals.items():
-            sigd[sig].add_many(vals)
+            mhd[sig].add_many(vals)
 
-        debug('=> {} signatures!', len(sigd))
-        return sigd
+        debug('=> {} signatures!', len(mhd))
+        return mhd
 
     def _find_signatures(self, minhash, threshold, containment=False,
                        ignore_scaled=False):

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -336,6 +336,22 @@ def test_api_insert_update():
     assert ss2.minhash in all_mh
 
 
+def test_api_insert_retrieve_check_name():
+    # check that signatures retrieved from LCA_Database objects have the
+    # right name.
+    ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),
+                                     ksize=31)
+
+    lca_db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)
+    lca_db.insert(ss)
+
+    sigs = list(lca_db.signatures())
+    assert len(sigs) == 1
+    retrieved_sig = sigs[0]
+    assert retrieved_sig.name() == ss.name()
+    assert retrieved_sig.minhash == ss.minhash
+
+
 def test_api_create_insert_two_then_scale():
     # construct database, THEN downsample
     ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),


### PR DESCRIPTION


In [2020-cami](https://github.com/luizirber/2020-cami) I built an LCA index out of an SBT index ([relevant snakemake rules](https://github.com/luizirber/2020-cami/blob/master/Snakefile#L349L385)). While writing a script for extracting accessions from an index (in https://github.com/dib-lab/2019-12-12-sourmash_viz) I noticed that the `.signatures` method for LCA is not returning the original name from the signature, but the md5sum.

So, how does `gather` return the correct name? :thinking: 

Turns out that the logic for picking the right name is in `find_signatures`, so I just moved it to `_signatures` instead (and made `_signatures` store `Signature`s instead of `MinHash`s). Now signatures from the `.signatures` method have the original signature name.

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
