### PR TITLE
[WIP] Improve signature save docstring; switch docstrings over to markdown

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -303,3 +303,17 @@ source_parsers = {
 }
 
 autodoc_mock_imports = ["sourmash._minhash"]
+
+### parse docstrings as markdown instead of ReST.
+
+import commonmark
+
+def docstring(app, what, name, obj, options, lines):
+    md  = '\n'.join(lines)
+    ast = commonmark.Parser().parse(md)
+    rst = commonmark.ReStructuredTextRenderer().render(ast)
+    lines.clear()
+    lines += rst.splitlines()
+
+def setup(app):
+    app.connect('autodoc-process-docstring', docstring)

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ SETUP_METADATA = {
         'demo' : ['jupyter', 'jupyter_client', 'ipython'],
         'doc' : ['sphinx', 'recommonmark', 'alabaster',
                  "sphinxcontrib-napoleon", "nbsphinx",
-                 "ipython"],
+                 "ipython", "commonmark"],
         '10x': ['bam2fasta==1.0.1'],
         'storage': ["ipfshttpclient", "redis"]
     },

--- a/sourmash/_minhash.py
+++ b/sourmash/_minhash.py
@@ -89,6 +89,7 @@ class MinHash(RustObject):
 
     Basic usage:
 
+    ```
     >>> from sourmash import MinHash
     >>> mh1 = MinHash(n=20, ksize=3)
     >>> mh1.add_sequence('ATGAGAGACGATAGACAGATGAC')
@@ -98,6 +99,7 @@ class MinHash(RustObject):
 
     >>> round(mh1.similarity(mh2), 2)
     0.85
+    ```
     """
     __dealloc_func__ = lib.kmerminhash_free
 
@@ -117,11 +119,11 @@ class MinHash(RustObject):
         """\
         Create a sourmash.MinHash object.
 
-        To create a standard (``num``) MinHash, use:
-           ``MinHash(<num>, <ksize>, ...)``
+        To create a standard (`num`) MinHash, use:
+           `MinHash(<num>, <ksize>, ...)`
 
-        To create a ``scaled`` MinHash, use
-            ``MinHash(0, <ksize>, scaled=<int>, ...)``
+        To create a `scaled` MinHash, use
+            `MinHash(0, <ksize>, scaled=<int>, ...)`
 
         Optional arguments:
            * is_protein (default False) - aa k-mers
@@ -132,7 +134,7 @@ class MinHash(RustObject):
            * seed (default 42) - murmurhash seed
 
         Deprecated: @CTB
-           * ``max_hash=<int>``; use ``scaled`` instead.
+           * `max_hash=<int>``; use ``scaled` instead.
         """
         if max_hash and scaled:
             raise ValueError("cannot set both max_hash and scaled")
@@ -250,8 +252,8 @@ class MinHash(RustObject):
     def add_many(self, hashes):
         """Add many hashes to the sketch at once.
 
-        ``hashes`` can be either an iterable (list, set, etc.), or another
-        ``MinHash`` object.
+        `hashes` can be either an iterable (list, set, etc.), or another
+        `MinHash` object.
         """
         if isinstance(hashes, MinHash):
             self._methodcall(lib.kmerminhash_add_from, hashes._objptr)
@@ -259,7 +261,7 @@ class MinHash(RustObject):
             self._methodcall(lib.kmerminhash_add_many, list(hashes), len(hashes))
 
     def remove_many(self, hashes):
-        "Remove many hashes at once; ``hashes`` must be an iterable."
+        "Remove many hashes at once; `hashes` must be an iterable."
         self._methodcall(lib.kmerminhash_remove_many, list(hashes), len(hashes))
 
     def update(self, other):
@@ -271,7 +273,7 @@ class MinHash(RustObject):
         return self._methodcall(lib.kmerminhash_get_mins_size)
 
     def get_mins(self, with_abundance=False):
-        """Return list of hashes or if ``with_abundance`` a list
+        """Return list of hashes or if `with_abundance` a list
         of (hash, abund).
         """
         size = self._methodcall(lib.kmerminhash_get_mins_size)
@@ -295,7 +297,7 @@ class MinHash(RustObject):
 
     def subtract_mins(self, other):
         """Get the list of mins in this MinHash, after removing the ones in
-        ``other``.
+        `other`.
         """
         a = set(self.get_mins())
         b = set(other.get_mins())
@@ -369,16 +371,16 @@ class MinHash(RustObject):
 
     def count_common(self, other, downsample=False):
         """\
-        Return the number of hashes in common between ``self`` and ``other``.
+        Return the number of hashes in common between `self` and `other`.
 
-        Optionally downsample ``scaled`` objects to highest ``scaled`` value.
+        Optionally downsample `scaled` objects to highest `scaled` value.
         """
         if not isinstance(other, MinHash):
             raise TypeError("Must be a MinHash!")
         return self._methodcall(lib.kmerminhash_count_common, other._get_objptr(), downsample)
 
     def downsample_n(self, new_num):
-        "Copy this object and downsample new object to num=``new_num``."
+        "Copy this object and downsample new object to num=`new_num`."
         if self.num and self.num < new_num:
             raise ValueError("new sample n is higher than current sample n")
 
@@ -393,9 +395,9 @@ class MinHash(RustObject):
         return a
 
     def downsample_max_hash(self, *others):
-        """Copy this object and downsample new object to min of ``*others``.
+        """Copy this object and downsample new object to min of `*others`.
 
-        Here, ``*others`` is one or more MinHash objects.
+        Here, `*others` is one or more MinHash objects.
         """
         max_hashes = [x.max_hash for x in others]
         new_max_hash = min(self.max_hash, *max_hashes)
@@ -404,7 +406,7 @@ class MinHash(RustObject):
         return self.downsample_scaled(new_scaled)
 
     def downsample_scaled(self, new_scaled):
-        """Copy this object and downsample new object to scaled=``new_scaled``.
+        """Copy this object and downsample new object to scaled=`new_scaled`.
         """
         if self.num:
             raise ValueError("num != 0 - cannot downsample a standard MinHash")
@@ -444,11 +446,11 @@ class MinHash(RustObject):
                 current_version=VERSION,
                 details='Use count_common or set methods instead.')
     def intersection(self, other, in_common=False):
-        """Calculate the intersection between ``self`` and ``other``, and
-        return ``(mins, size)`` where ``mins`` are the hashes in common, and
-        ``size`` is the number of hashes.
+        """Calculate the intersection between `self` and `other`, and
+        return `(mins, size)` where `mins` are the hashes in common, and
+        `size` is the number of hashes.
 
-        if ``in_common``, return the actual hashes. Otherwise, mins will be
+        if `in_common`, return the actual hashes. Otherwise, mins will be
         empty.
         """
         if not isinstance(other, MinHash):
@@ -492,7 +494,7 @@ class MinHash(RustObject):
     def similarity(self, other, ignore_abundance=False, downsample=False):
         """Calculate similarity of two sketches.
 
-        If the sketches are not abundance weighted, or ignore_abundance=True,
+        If the sketches are not abundance weighted, or `ignore_abundance=True`,
         compute Jaccard similarity.
 
         If the sketches are abundance weighted, calculate the angular
@@ -541,8 +543,8 @@ class MinHash(RustObject):
     merge = __iadd__
 
     def set_abundances(self, values):
-        """Set abundances for hashes from ``values``, where
-        ``values[hash] = abund``
+        """Set abundances for hashes from `values`, where
+        `values[hash] = abund`
         """
         if self.track_abundance:
             hashes = []

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -2,8 +2,9 @@
 """
 An implementation of sequence bloom trees, Solomon & Kingsford, 2015.
 
-To try it out, do::
+To try it out, do:
 
+```
     factory = GraphFactory(ksize, tablesizes, n_tables)
     root = Node(factory)
 
@@ -11,9 +12,11 @@ To try it out, do::
     # ... add stuff to graph1 ...
     leaf1 = Leaf("a", graph1)
     root.insert(leaf1)
+```
 
-For example, ::
+For example,
 
+```
     # filenames: list of fa/fq files
     # ksize: k-mer size
     # tablesizes: Bloom filter table sizes
@@ -27,9 +30,11 @@ For example, ::
         graph.consume_fasta(filename)
         leaf = Leaf(filename, graph)
         root.insert(leaf)
+```
 
 then define a search function, ::
 
+```
     def kmers(k, seq):
         for start in range(len(seq) - k + 1):
             yield seq[start:start + k]
@@ -39,6 +44,7 @@ then define a search function, ::
         if sum(presence) >= int(threshold * len(seq)):
             return 1
         return 0
+```
 """
 
 from __future__ import print_function, unicode_literals, division

--- a/sourmash/signature.py
+++ b/sourmash/signature.py
@@ -191,9 +191,10 @@ def load_signatures(
 ):
     """Load a JSON string with signatures into classes.
 
-    Returns list of SourmashSignature objects.
+    Returns list of SourmashSignature objects.  Note, the order is not
+    necessarily the same as what is in the source file.
 
-    Note, the order is not necessarily the same as what is in the source file.
+    Here, `data` is either a file handle, a filename, or a JSON string.
     """
     if ksize:
         ksize = int(ksize)
@@ -297,6 +298,11 @@ def load_signatures(
 
 
 def load_one_signature(data, ksize=None, select_moltype=None, ignore_md5sum=False):
+    """
+    Load exactly one signature (or raise a ValueError).
+
+    Here, `data` is either a file handle, a filename, or a JSON string.
+    """
     sigiter = load_signatures(
         data, ksize=ksize, select_moltype=select_moltype, ignore_md5sum=ignore_md5sum
     )
@@ -315,7 +321,17 @@ def load_one_signature(data, ksize=None, select_moltype=None, ignore_md5sum=Fals
 
 
 def save_signatures(siglist, fp=None):
-    "Save multiple signatures into a JSON string (or into file handle 'fp')"
+    """\
+    Save multiple signatures into a JSON string (or into file handle 'fp')
+
+    Example:
+
+    ```
+    with open('output.sig', 'wt') as fp:
+         save_signatures([list_of_sig_objects], fp)
+    ```
+    
+    """
     attached_refs = weakref.WeakKeyDictionary()
     collected = []
     for obj in siglist:


### PR DESCRIPTION
This addresses part of #919.

I decided to try out [this idea](https://stackoverflow.com/questions/56062402/force-sphinx-to-interpret-markdown-in-python-docstrings-instead-of-restructuredt) and switch docstrings over to markdown from reStructuredText. I think this makes things friendlier to people used to markdown (which is used much more widely than ReST but we would need to redo the SBT docstrings. @luizirber any thoughts?

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
