### PR TITLE
Add make clean & rustup update to dev docs

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -32,28 +32,13 @@ You can run tests by invoking `make test` in the sourmash directory;
 `python -m pytest` will run the Python tests, and `cargo test` will
 run the Rust tests.
 
-### If you're having trouble installing the development environment
+### If you're having trouble installing or using the development environment
 
-Some installation issues can be solved by simply removing the intermediate build files with: 
+If you are getting an error that contains `ImportError: cannot import name 'to_bytes' from 'sourmash._minhash'`, then it's likely you need to update Rust and clean up your environment. Some installation issues can be solved by simply removing the intermediate build files with: 
 
 ```
 make clean
 ```
-
-If you are getting an error that contains `ImportError: cannot import name 'to_bytes' from 'sourmash._minhash'`, then it's likely you need to update Rust and clean up your environment. 
-
-Additionally, the Rust language is a fast-moving target and the latest version may be required, which can be acquired with 
-
-```
-rustup update
-```
-
-If you want to do both a Rust update and clean up the directories, one can do:
-
-```
-rustup update && make clean
-```
-
 
 
 ## Automated tests and code coverage calculation

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -32,6 +32,30 @@ You can run tests by invoking `make test` in the sourmash directory;
 `python -m pytest` will run the Python tests, and `cargo test` will
 run the Rust tests.
 
+### If you're having trouble installing the development environment
+
+Some installation issues can be solved by simply removing the intermediate build files with: 
+
+```
+make clean
+```
+
+If you are getting an error that contains `ImportError: cannot import name 'to_bytes' from 'sourmash._minhash'`, then it's likely you need to update Rust and clean up your environment. 
+
+Additionally, the Rust language is a fast-moving target and the latest version may be required, which can be acquired with 
+
+```
+rustup update
+```
+
+If you want to do both a Rust update and clean up the directories, one can do:
+
+```
+rustup update && make clean
+```
+
+
+
 ## Automated tests and code coverage calculation
 
 We use [Travis][0] and [GitHub Actions][2] for continuous integration.


### PR DESCRIPTION
As mentioned [here](https://github.com/dib-lab/sourmash/issues/926) update developer docs for `ImportError: cannot import name 'to_bytes'`.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
