### PR TITLE
[MRG] Trial improvements to sourmash argparse output for compute.

### DIFF
--- a/sourmash/cli/compare.py
+++ b/sourmash/cli/compare.py
@@ -1,4 +1,4 @@
-"""compare genomes"""
+"""compare sequence signatures made by compute"""
 
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 

--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -4,11 +4,11 @@ usage="""
 
    sourmash compute -k 21,31,51 *.fa *.fq
 
-This will create MinHash sketches at k-mer sizes of 21, 31 and 51, for
+Create MinHash sketches at k-mer sizes of 21, 31 and 51, for
 all FASTA and FASTQ files in the current directory, and save them in
 signature files ending in '.sig'. You can rapidly compare these files
 with `compare` and query them with `search`, among other operations;
-see the full documentation http://sourmash.rtfd.io/.
+see the full documentation at http://sourmash.rtfd.io/.
 
 The key options for compute are:
 
@@ -21,7 +21,7 @@ The key options for compute are:
  * `--name-from-first`: set name of signature from first sequence in file.
  * `-o/--output`: save all computed signatures to this file.
 
-Please see -h for more options and more detailed help.
+Please see -h for all of the options as well as more detailed help.
 
 ---
 """

--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -1,4 +1,30 @@
-"""compute genome signatures"""
+"""Compute sourmash signatures for input sequences.
+
+Basic usage:
+
+   sourmash compute -k 21,31,51 *.fa *.fq
+
+This will create MinHash sketches at k-mer sizes of 21, 31 and 51, for
+all FASTA and FASTQ files in the current directory, and save them in
+signature files ending in '.sig'. You can rapidly compare these files
+with `compare`, query them with `search`, among other operations; see
+the full documentation http://sourmash.rtfd.io/.
+
+The key options for compute are:
+
+ * `-k/--ksize <int>[, <int>]: k-mer size(s) to use, e.g. -k 21,31,51
+ * `-n/--num <int>` or `--scaled <int>`: set size or resolution of sketches
+ * `--track-abundance`: track abundances of hashes (default False)
+ * `--dna or --protein`: nucleotide and/or protein signatures (default `--dna`)
+ * `--merge <name>`: compute a merged signature across all inputs.
+ * `--singleton`: compute individual signatures for each sequence.
+ * `--name-from-first`: set name of signature from first sequence in file.
+ * `-o/--output`: save all computed signatures to this file.
+
+Please see -h for more options and more detailed help.
+
+---
+"""
 
 from argparse import FileType
 
@@ -18,7 +44,7 @@ def ksize_parser(ksizes):
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('compute')
+    subparser = subparsers.add_parser('compute', usage=__doc__)
 
     sketch_args = subparser.add_argument_group('Sketching options')
     sketch_args.add_argument(

--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -1,14 +1,14 @@
-"""Compute sourmash signatures for input sequences.
+"""compute sequence signatures for inputs"""
 
-Basic usage:
+usage="""
 
    sourmash compute -k 21,31,51 *.fa *.fq
 
 This will create MinHash sketches at k-mer sizes of 21, 31 and 51, for
 all FASTA and FASTQ files in the current directory, and save them in
 signature files ending in '.sig'. You can rapidly compare these files
-with `compare`, query them with `search`, among other operations; see
-the full documentation http://sourmash.rtfd.io/.
+with `compare` and query them with `search`, among other operations;
+see the full documentation http://sourmash.rtfd.io/.
 
 The key options for compute are:
 
@@ -44,7 +44,7 @@ def ksize_parser(ksizes):
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('compute', usage=__doc__)
+    subparser = subparsers.add_parser('compute', description=__doc__, usage=usage)
 
     sketch_args = subparser.add_argument_group('Sketching options')
     sketch_args.add_argument(

--- a/sourmash/cli/gather.py
+++ b/sourmash/cli/gather.py
@@ -1,5 +1,4 @@
-"""search a metagenome signature for multiple non-
-                                  overlapping matches"""
+"""search a metagenome signature against dbs"""
 
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 

--- a/sourmash/cli/search.py
+++ b/sourmash/cli/search.py
@@ -1,4 +1,4 @@
-"""search a signature against a list of signatures"""
+"""search a signature against other signatures"""
 
 from sourmash.cli.utils import add_ksize_arg, add_moltype_args
 


### PR DESCRIPTION
This makes `sourmash compute` return:

## new output:
```
sourmash compute
usage: 

   sourmash compute -k 21,31,51 *.fa *.fq

This will create MinHash sketches at k-mer sizes of 21, 31 and 51, for
all FASTA and FASTQ files in the current directory, and save them in
signature files ending in '.sig'. You can rapidly compare these files
with `compare` and query them with `search`, among other operations;
see the full documentation http://sourmash.rtfd.io/.

The key options for compute are:

 * `-k/--ksize <int>[, <int>]: k-mer size(s) to use, e.g. -k 21,31,51
 * `-n/--num <int>` or `--scaled <int>`: set size or resolution of sketches
 * `--track-abundance`: track abundances of hashes (default False)
 * `--dna or --protein`: nucleotide and/or protein signatures (default `--dna`)
 * `--merge <name>`: compute a merged signature across all inputs.
 * `--singleton`: compute individual signatures for each sequence.
 * `--name-from-first`: set name of signature from first sequence in file.
 * `-o/--output`: save all computed signatures to this file.

Please see -h for more options and more detailed help.

---
 compute: error: the following arguments are required: filenames
```
rather than

## old output:

```usage:  compute [-h] [-k KSIZES] [-n NUM_HASHES] [--track-abundance]
                [--scaled SCALED] [--protein] [--no-protein] [--dayhoff]
                [--no-dayhoff] [--hp] [--no-hp] [--dna] [--no-dna]
                [--input-is-protein] [--seed SEED] [--input-is-10x]
                [--count-valid-reads COUNT_VALID_READS]
                [--write-barcode-meta-csv WRITE_BARCODE_META_CSV]
                [-p PROCESSES] [--save-fastas SAVE_FASTAS]
                [--line-count LINE_COUNT] [--rename-10x-barcodes FILE]
                [--barcodes-file FILE] [-f] [-o OUTPUT] [--singleton]
                [--merge FILE] [--name-from-first] [--randomize] [-q]
                [--check-sequence] [--license LICENSE]
                filenames [filenames ...]
 compute: error: the following arguments are required: filenames
```
which I think is an improvement? Open to your thoughts on formatting, content, etc.

Addresses #899 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
