### PR TITLE
[MRG] Add --outdir argument to `sourmash compute`

### DIFF
--- a/sourmash/cli/compute.py
+++ b/sourmash/cli/compute.py
@@ -99,6 +99,9 @@ def subparser(subparsers):
         help='output computed signatures to this file'
     )
     file_args.add_argument(
+        '--outdir', help='output computed signatures to this directory'
+    )
+    file_args.add_argument(
         '--singleton', action='store_true',
         help='compute a signature for each sequence record individually'
     )

--- a/sourmash/command_compute.py
+++ b/sourmash/command_compute.py
@@ -109,11 +109,11 @@ def compute(args):
         sys.exit(-1)
 
     if args.merge and not args.output:
-        error("must specify -o with --merge")
+        error("ERROR: must specify -o with --merge")
         sys.exit(-1)
 
     if args.output and args.outdir:
-        error("--outdir doesn't make sense with -o/--output")
+        error("ERROR: --outdir doesn't make sense with -o/--output")
         sys.exit(-1)
 
     if args.track_abundance:

--- a/sourmash/command_compute.py
+++ b/sourmash/command_compute.py
@@ -219,10 +219,10 @@ def compute(args):
                        len(sigs), n + 1, filename)
 
             if not args.output:
-                save_siglist(siglist, args.output, sigfile)
+                save_siglist(siglist, sigfile)
 
         if args.output:
-            save_siglist(siglist, args.output, sigfile)
+            save_siglist(siglist, args.output)
     else:                             # single name specified - combine all
         # make minhashes for the whole file
         Elist = make_minhashes(ksizes, args.seed, args.protein,
@@ -274,20 +274,12 @@ def build_siglist(sig, filename, name=None):
     return [sig]
 
 
-def save_siglist(siglist, sigfile_name, filename=None):
+def save_siglist(siglist, sigfile_name):
     # save!
-    if sigfile_name:
-        with sourmash_args.FileOutput(sigfile_name, 'w') as fp:
-            save_signatures(siglist, fp)
-    else:
-        if filename is None:
-            raise Exception("internal error, filename is None")
-        with sourmash_args.FileOutput(filename, 'w') as fp:
-            sigfile_name = filename
-            save_signatures(siglist, fp)
-    notify(
-        'saved signature(s) to {}. Note: signature license is CC0.',
-        sigfile_name)
+    with sourmash_args.FileOutput(sigfile_name, 'w') as fp:
+        save_signatures(siglist, fp)
+    notify('saved signature(s) to {}. Note: signature license is CC0.',
+           sigfile_name)
 
 
 class ComputeParameters(RustObject):

--- a/sourmash/command_compute.py
+++ b/sourmash/command_compute.py
@@ -112,6 +112,10 @@ def compute(args):
         error("must specify -o with --merge")
         sys.exit(-1)
 
+    if args.output and args.outdir:
+        error("--outdir doesn't make sense with -o/--output")
+        sys.exit(-1)
+
     if args.track_abundance:
         notify('Tracking abundance of input k-mers.')
 
@@ -125,6 +129,9 @@ def _compute_individual(args):
 
     for filename in args.filenames:
         sigfile = os.path.basename(filename) + '.sig'
+        if args.outdir:
+            sigfile = os.path.join(args.outdir, sigfile)
+
         if not args.output and os.path.exists(sigfile) and not \
             args.force:
             notify('skipping {} - already done', filename)

--- a/tests/test_sourmash_compute.py
+++ b/tests/test_sourmash_compute.py
@@ -38,6 +38,21 @@ def test_do_sourmash_compute():
         assert sig.name().endswith('short.fa')
 
 
+@utils.in_tempdir
+def test_do_sourmash_compute_outdir(c):
+    testdata1 = utils.get_test_data('short.fa')
+    status, out, err = utils.runscript('sourmash',
+                                       ['compute', '-k', '31', testdata1,
+                                        '--outdir', c.location])
+
+
+    sigfile = os.path.join(c.location, 'short.fa.sig')
+    assert os.path.exists(sigfile)
+
+    sig = next(signature.load_signatures(sigfile))
+    assert sig.name().endswith('short.fa')
+
+
 def test_do_sourmash_compute_output_valid_file():
     """ Trigger bug #123 """
     with utils.TempDirectory() as location:
@@ -117,6 +132,23 @@ def test_do_sourmash_compute_output_and_name_valid_file():
             data_merged = json.load(f)
 
         assert data[0]['signatures'][0]['mins'] == data_merged[0]['signatures'][0]['mins']
+
+
+@utils.in_tempdir
+def test_do_sourmash_compute_output_and_name_valid_file_outdir(c):
+    testdata1 = utils.get_test_data('short.fa')
+    testdata2 = utils.get_test_data('short2.fa')
+    testdata3 = utils.get_test_data('short3.fa')
+    sigfile = os.path.join(c.location, 'short.fa.sig')
+
+    with pytest.raises(ValueError) as exc:
+        c.run_sourmash('compute', '-k', '31', '-o', sigfile,
+                       '--merge', '"name"',
+                       testdata1, testdata2, testdata3,
+                       '--outdir', c.location)
+
+    errmsg = c.last_result.err
+    assert "ERROR: --outdir doesn't make sense with -o/--output" in errmsg
 
 
 def test_do_sourmash_compute_singleton():


### PR DESCRIPTION
Fixes #472 by adding `--outdir` to sourmash compute for use when neither `--merge` nor `--output` are specified.

Also simplifies and refactors some of the `sourmash` compute command code.

- [x] test --outdir
- [x] check that --merged and --output are incompatible with --outdir

---

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
