### PR TITLE
[MRG] fix markdown rendering on readthedocs / sphinx 3.x

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,7 +39,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinxcontrib.napoleon',
     'nbsphinx',
-    'IPython.sphinxext.ipython_console_highlighting'
+    'IPython.sphinxext.ipython_console_highlighting',
+    'recommonmark'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -295,11 +296,5 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
-
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
 
 autodoc_mock_imports = ["sourmash._minhash"]


### PR DESCRIPTION
revamped the docs config per https://www.sphinx-doc.org/en/master/usage/markdown.html

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
