### PR TITLE
[MRG] fix bug when using Python 3.5 and before; refactor LCA_Database tests

### DIFF
--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -421,7 +421,7 @@ class LCA_Database(Index):
         debug('number of matching signatures for hashes: {}', len(c))
 
         # for each match, in order of largest overlap,
-        for idx, count in c.items():
+        for idx, count in c.most_common():
             # pull in the hashes. This reconstructs & caches all input
             # minhashes, which is kinda memory intensive...!
             # NOTE: one future low-mem optimization could be to support doing

--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -396,7 +396,7 @@ class LCA_Database(Index):
     def _find_signatures(self, minhash, threshold, containment=False,
                        ignore_scaled=False):
         """
-        Do a Jaccard similarity or containment search.
+        Do a Jaccard similarity or containment search, yield results.
 
         This is essentially a fast implementation of find that collects all
         the signatures with overlapping hash values. Note that similarity
@@ -430,17 +430,14 @@ class LCA_Database(Index):
             match_mh = match_sig.minhash
             match_size = len(match_mh)
 
-            debug('count: {}; query_mins: {}; match size: {}',
-                  count, len(query_mins), match_size)
-
             # calculate the containment or similarity
             if containment:
                 score = count / len(query_mins)
             else:
+                # query_mins is size of query signature
+                # match_size is size of match signature
+                # count is overlap
                 score = count / (len(query_mins) + match_size - count)
-
-            debug('score: {} (containment? {}), threshold: {}',
-                  score, containment, threshold)
 
             # ...and return.
             if score >= threshold:

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -324,6 +324,7 @@ class SBT(Index):
         
 
     def gather(self, query, *args, **kwargs):
+        "Return the match with the best Jaccard containment in the database."
         from .sbtmh import GatherMinHashes
 
         if not query.minhash:             # empty query? quit.
@@ -356,12 +357,15 @@ class SBT(Index):
 
         # actually do search!
         results = []
+
         for leaf in self.find(search_fn, query, threshold,
                               unload_data=unload_data):
             leaf_mh = leaf.data.minhash
             containment = query.minhash.contained_by(leaf_mh, True)
             if containment >= threshold:
                 results.append((containment, leaf.data, None))
+
+        results.sort(key=lambda x: -x[0])
 
         return results
 

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -11,6 +11,7 @@ import glob
 import json
 import csv
 import pytest
+import pprint
 
 from . import sourmash_tst_utils as utils
 import sourmash
@@ -1648,13 +1649,23 @@ def test_lca_index_empty(c):
     # can we load and search?
     lca_db_filename = c.output('xxx.lca.json')
     db, ksize, scaled = lca_utils.load_single_database(lca_db_filename)
+    siglist = list(db.signatures())
+    print(siglist)
+
+    linear = sourmash.index.LinearIndex(siglist)
+    pprint.pprint('XXX')
+    pprint.pprint(linear.gather(sig63))
 
     results = db.gather(sig63)
+    pprint.pprint('XYZ')
+    pprint.pprint(results)
     assert len(results) == 1
     containment, match_sig, name = results[0]
     assert containment == 1.0
     assert match_sig.minhash == sig63.minhash
     assert name == lca_db_filename
+
+    assert 0
 
 
 @utils.in_tempdir

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -1665,8 +1665,6 @@ def test_lca_index_empty(c):
     assert match_sig.minhash == sig63.minhash
     assert name == lca_db_filename
 
-    assert 0
-
 
 @utils.in_tempdir
 def test_lca_gather_threshold_1(c):

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -1645,7 +1645,6 @@ def test_lca_index_empty(c):
     c.run_sourmash('lca', 'index', 'empty.csv', 'xxx.lca.json',
                    sig2file, sig47file, sig63file, '--scaled', '1000')
 
-
     # can we load and search?
     lca_db_filename = c.output('xxx.lca.json')
     db, ksize, scaled = lca_utils.load_single_database(lca_db_filename)

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -1649,16 +1649,8 @@ def test_lca_index_empty(c):
     # can we load and search?
     lca_db_filename = c.output('xxx.lca.json')
     db, ksize, scaled = lca_utils.load_single_database(lca_db_filename)
-    siglist = list(db.signatures())
-    print(siglist)
-
-    linear = sourmash.index.LinearIndex(siglist)
-    pprint.pprint('XXX')
-    pprint.pprint(linear.gather(sig63))
 
     results = db.gather(sig63)
-    pprint.pprint('XYZ')
-    pprint.pprint(results)
     assert len(results) == 1
     containment, match_sig, name = results[0]
     assert containment == 1.0
@@ -1772,3 +1764,27 @@ def test_lca_gather_threshold_5(c):
     assert containment == 1.0
     assert match_sig.minhash == sig2.minhash
     assert name == None
+
+
+@utils.in_tempdir
+def test_gather_multiple_return(c):
+    sig2file = utils.get_test_data('2.fa.sig')
+    sig47file = utils.get_test_data('47.fa.sig')
+    sig63file = utils.get_test_data('63.fa.sig')
+
+    sig2 = load_one_signature(sig2file, ksize=31)
+    sig47 = load_one_signature(sig47file, ksize=31)
+    sig63 = load_one_signature(sig63file, ksize=31)
+
+    # construct LCA Database
+    db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)
+    db.insert(sig2)
+    db.insert(sig47)
+    db.insert(sig63)
+
+    # now, run gather. how many results do we get, and are they in the
+    # right order?
+    results = db.gather(sig63)
+    print(len(results))
+    assert len(results) == 1
+    assert results[0][0] == 1.0

--- a/tests/test_sbt.py
+++ b/tests/test_sbt.py
@@ -718,3 +718,30 @@ def test_sbt_gather_threshold_5():
     assert containment == 1.0
     assert match_sig == sig2
     assert name is None
+
+
+@utils.in_tempdir
+def test_gather_multiple_return(c):
+    # test gather() method number of returns
+    sig2file = utils.get_test_data('2.fa.sig')
+    sig47file = utils.get_test_data('47.fa.sig')
+    sig63file = utils.get_test_data('63.fa.sig')
+
+    sig2 = load_one_signature(sig2file, ksize=31)
+    sig47 = load_one_signature(sig47file, ksize=31)
+    sig63 = load_one_signature(sig63file, ksize=31)
+
+    # construct LCA Database
+    factory = GraphFactory(31, 1e5, 4)
+    tree = SBT(factory, d=2)
+
+    tree.insert(sig2)
+    tree.insert(sig47)
+    tree.insert(sig63)
+
+    # now, run gather. how many results do we get, and are they in the
+    # right order?
+    results = tree.gather(sig63)
+    print(len(results))
+    assert len(results) == 2
+    assert results[0][0] == 1.0


### PR DESCRIPTION
Now that the `LCA_Database` refactor in #946 has landed, we can simplify some of the test code in #942. This led to discovering a bug where `LCA_Database._find_signatures()` was using `Counter.items()` rather than `Counter.most_common()` to sort matches, which yielded results in the wrong order. Fixed! There's now an explicit test for this in LCA and SBT databases.

Separately, this highlights an inconsistency in `Index.gather()` - right now, `gather` returns only one match from LCA databases, but multiple from SBTs and LinearIndex. I don't think it makes sense to return multiple matches from gather... For sourmash 4, we might want to have gather return the best single result, rather than a list of results.

---

- [x] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
