### PR TITLE
[MRG] Improve lca index error

### DIFF
--- a/doc/tutorials-lca.md
+++ b/doc/tutorials-lca.md
@@ -135,7 +135,7 @@ curl -O -L https://github.com/ctb/2017-sourmash-lca/raw/master/tara-delmont-Supp
 Build a sourmash LCA database named `delmont.lca.json`:
 
 ```
-sourmash lca index tara-delmont-SuppTable3.csv delmont.lca.json delmont-subsample-sigs/*.sig
+sourmash lca index -f tara-delmont-SuppTable3.csv delmont.lca.json delmont-subsample-sigs/*.sig
 ```
 
 ### Using the LCA database to classify signatures

--- a/sourmash/lca/command_index.py
+++ b/sourmash/lca/command_index.py
@@ -99,7 +99,12 @@ def load_taxonomy_assignments(filename, delimiter=',', start_column=2,
     # any more, when building a large GTDB-based database :) --CTB
     if len(assignments) * 0.2 > n_species and len(assignments) > 50:
         if not force:
-            raise Exception("error: fewer than 20% of lineages have species-level resolution!? ({} total found)".format(n_species))
+            error('')
+            error("ERROR: fewer than 20% of lineages have species-level resolution!?")
+            error("({} species assignments found, of {} assignments total)",
+                  n_species, len(assignments))
+            error("** If this is intentional, re-run the command with -f.")
+            sys.exit(-1)
 
     return assignments, num_rows
 

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -629,7 +629,7 @@ def test_basic_index_too_few_species():
         cmd = ['lca', 'index', taxcsv, lca_db, input_sig, '-C', '3']
         status, out, err = utils.runscript('sourmash', cmd, fail_ok=True)
 
-        assert 'error: fewer than 20% of lineages' in err
+        assert not '"ERROR: fewer than 20% of lineages have species-level resolution' in err
         assert status != 0
 
 


### PR DESCRIPTION
Update `sourmash lca index` error message  about lca index and too few species so that it's a proper error message and not an unhandled Exception. Fix test and tutorial to match.

Fixes #958 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
