### PR TITLE
[MRG] Document and (lightly) fix the LCA_Database API.

### DIFF
--- a/doc/kmers-and-minhash.ipynb
+++ b/doc/kmers-and-minhash.ipynb
@@ -1021,14 +1021,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Other pointers\n",
+    "\n",
+    "[Sourmash: a practical guide](https://sourmash.readthedocs.io/en/latest/using-sourmash-a-guide.html)\n",
+    "\n",
+    "[Classifying signatures taxonomically](https://sourmash.readthedocs.io/en/latest/classifying-signatures.html)\n",
+    "\n",
+    "[Pre-built search databases](https://sourmash.readthedocs.io/en/latest/databases.html)\n",
+    "\n",
     "## A full list of notebooks\n",
     "\n",
     "[An introduction to k-mers for genome comparison and analysis](kmers-and-minhash.ipynb)\n",
     "\n",
     "[Some sourmash command line examples!](sourmash-examples.ipynb)\n",
     "\n",
-    "[Working with private collections of signatures.](sourmash-collections.ipynb)"
+    "[Working with private collections of signatures.](sourmash-collections.ipynb)\n",
+    "\n",
+    "[Using the LCA_Database API.](using-LCA-database-API.ipynb)\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/doc/sourmash-collections.ipynb
+++ b/doc/sourmash-collections.ipynb
@@ -1770,14 +1770,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Other pointers\n",
+    "\n",
+    "[Sourmash: a practical guide](https://sourmash.readthedocs.io/en/latest/using-sourmash-a-guide.html)\n",
+    "\n",
+    "[Classifying signatures taxonomically](https://sourmash.readthedocs.io/en/latest/classifying-signatures.html)\n",
+    "\n",
+    "[Pre-built search databases](https://sourmash.readthedocs.io/en/latest/databases.html)\n",
+    "\n",
     "## A full list of notebooks\n",
     "\n",
     "[An introduction to k-mers for genome comparison and analysis](kmers-and-minhash.ipynb)\n",
     "\n",
     "[Some sourmash command line examples!](sourmash-examples.ipynb)\n",
     "\n",
-    "[Working with private collections of signatures.](sourmash-collections.ipynb)"
+    "[Working with private collections of signatures.](sourmash-collections.ipynb)\n",
+    "\n",
+    "[Using the LCA_Database API.](using-LCA-database-API.ipynb)\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/doc/sourmash-examples.ipynb
+++ b/doc/sourmash-examples.ipynb
@@ -442,8 +442,17 @@
     "\n",
     "[Working with private collections of signatures.](sourmash-collections.ipynb)\n",
     "\n",
+    "[Using the LCA_Database API.](using-LCA-database-API.ipynb)\n",
+    "\n",
     "\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -23,6 +23,6 @@ yourself, or run interactively online via the
 
 ## More information
 
-If you are a Python programmer, you might also be interested in our [API examples](api-example.html).
+If you are a Python programmer, you might also be interested in our [API examples](api-example.html) as well as a short guide to [Using the `LCA_Database` API.](using-LCA-database-API.html)
 
 If you prefer R, we have [a short guide to using sourmash output with R](other-languages.html).

--- a/doc/using-LCA-database-API.ipynb
+++ b/doc/using-LCA-database-API.ipynb
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -460,74 +460,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(LineagePair(rank='superkingdom', name='Bacteria'),\n",
-      " LineagePair(rank='phylum', name='Proteobacteria'),\n",
-      " LineagePair(rank='class', name='Gammaproteobacteria'),\n",
-      " LineagePair(rank='order', name='Alteromonadales'),\n",
-      " LineagePair(rank='family', name='Shewanellaceae'),\n",
-      " LineagePair(rank='genus', name='Shewanella'),\n",
-      " LineagePair(rank='species', name='Shewanella baltica'),\n",
-      " LineagePair(rank='strain', name='Shewanella baltica OS223'))\n"
+      "[LineagePair(rank='superkingdom', name='Bacteria'),\n",
+      " LineagePair(rank='phylum', name='Verrucomicrobia'),\n",
+      " LineagePair(rank='class', name='Verrucomicrobiae'),\n",
+      " LineagePair(rank='order', name='Verrucomicrobiales'),\n",
+      " LineagePair(rank='family', name='Akkermansiaceae'),\n",
+      " LineagePair(rank='genus', name='Akkermansia'),\n",
+      " LineagePair(rank='species', name='Akkermansia muciniphila'),\n",
+      " LineagePair(rank='strain', name='Akkermansia muciniphila ATCC BAA-835')]\n"
      ]
     }
    ],
    "source": [
-    "linstr = [\"Bacteria\", \"Proteobacteria\", \"Gammaproteobacteria\",\n",
-    "          \"Alteromonadales\", \"Shewanellaceae\", \"Shewanella\",\n",
-    "          \"Shewanella baltica\", \"Shewanella baltica OS223\"]\n",
+    "linstr1 = [\"Bacteria\", \"Verrucomicrobia\", \"Verrucomicrobiae\",\n",
+    "           \"Verrucomicrobiales\", \"Akkermansiaceae\", \"Akkermansia\",\n",
+    "           \"Akkermansia muciniphila\", \"Akkermansia muciniphila ATCC BAA-835\"]\n",
     "\n",
-    "lineage1 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr) ]\n",
-    "lineage1 = tuple(lineage1)\n",
+    "lineage1 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr1) ]\n",
     "pprint(lineage1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "linstr2 = [\"Bacteria\", \"Proteobacteria\", \"Gammaproteobacteria\",\n",
-    "          \"Alteromonadales\", \"Shewanellaceae\", \"Shewanella\",\n",
-    "          \"Shewanella baltica\", \"Shewanella baltica OS185\"]\n",
-    "lineage2 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr2) ]\n",
-    "\n",
-    "linstr3 = [\"Bacteria\", \"Verrucomicrobia\", \"Verrucomicrobiae\",\n",
-    "           \"Verrucomicrobiales\", \"Akkermansiaceae\", \"Akkermansia\",\n",
-    "           \"Akkermansia muciniphila\", \"Akkermansia muciniphila ATCC BAA-835\"]\n",
-    "lineage3 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr3) ]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales;Shewanellaceae;Shewanella;Shewanella baltica;Shewanella baltica OS223'"
+       "'Bacteria;Verrucomicrobia;Verrucomicrobiae;Verrucomicrobiales;Akkermansiaceae;Akkermansia;Akkermansia muciniphila;Akkermansia muciniphila ATCC BAA-835'"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# display lineages as strings with 'sourmash.lca.display_lineage()'\n",
     "sourmash.lca.display_lineage(lineage1)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## sourmash lowest-common-ancestor functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The LCA functionality available in sourmash is built around some simple lineage manipulation functions -- `build_tree` and `find_lca`.\n",
+    "\n",
+    "First, let's define some more lineages --"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lineage2 is Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales;Shewanellaceae;Shewanella;Shewanella baltica;Shewanella baltica OS185\n",
+      "lineage3 is Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales;Shewanellaceae;Shewanella;Shewanella baltica;Shewanella baltica OS223\n"
+     ]
+    }
+   ],
+   "source": [
+    "linstr2 = [\"Bacteria\", \"Proteobacteria\", \"Gammaproteobacteria\",\n",
+    "           \"Alteromonadales\", \"Shewanellaceae\", \"Shewanella\",\n",
+    "           \"Shewanella baltica\", \"Shewanella baltica OS185\"]\n",
+    "lineage2 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr2) ]\n",
+    "\n",
+    "linstr3 = [\"Bacteria\", \"Proteobacteria\", \"Gammaproteobacteria\",\n",
+    "           \"Alteromonadales\", \"Shewanellaceae\", \"Shewanella\",\n",
+    "           \"Shewanella baltica\", \"Shewanella baltica OS223\"]\n",
+    "lineage3 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr3) ]\n",
+    "\n",
+    "print('lineage2 is', sourmash.lca.display_lineage(lineage2))\n",
+    "print('lineage3 is', sourmash.lca.display_lineage(lineage3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, build a tree structure that collapses these lineages where it can, and run some LCA analyses. Lineages 1 and 2 collapse to superkingdom:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -536,19 +571,26 @@
        "((LineagePair(rank='superkingdom', name='Bacteria'),), 2)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "tree = sourmash.lca.build_tree([lineage2, lineage3])\n",
+    "tree = sourmash.lca.build_tree([lineage1, lineage2])\n",
     "sourmash.lca.find_lca(tree)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "while lineages 2 and 3 collapse to species:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -564,64 +606,73 @@
        " 2)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "tree = sourmash.lca.build_tree([lineage1, lineage2])\n",
+    "tree = sourmash.lca.build_tree([lineage2, lineage3])\n",
     "sourmash.lca.find_lca(tree)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 22,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)\n",
-    "db.insert(sig1, lineage=lineage3)\n",
-    "db.insert(sig2, lineage=lineage2)\n",
-    "db.insert(sig3, lineage=lineage3)"
+    "## Convenience functions let you make use of LCA_Database stored lineages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's create a database from 3 signatures, and this time we'll store lineages in there:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)\n",
+    "db.insert(sig1, lineage=lineage1)\n",
+    "db.insert(sig2, lineage=lineage2)\n",
+    "db.insert(sig3, lineage=lineage3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, for any collection of hashes, you can retrieve all the lineage assignments into a dictionary:\n",
+    "`{ hashval: set of lineages }`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[(17302105753387,\n",
-       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
-       "    LineagePair(rank='phylum', name='Verrucomicrobia'),\n",
-       "    LineagePair(rank='class', name='Verrucomicrobiae'),\n",
-       "    LineagePair(rank='order', name='Verrucomicrobiales'),\n",
-       "    LineagePair(rank='family', name='Akkermansiaceae'),\n",
-       "    LineagePair(rank='genus', name='Akkermansia'),\n",
-       "    LineagePair(rank='species', name='Akkermansia muciniphila'),\n",
-       "    LineagePair(rank='strain', name='Akkermansia muciniphila ATCC BAA-835'))}),\n",
-       " (95741036335406,\n",
-       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
-       "    LineagePair(rank='phylum', name='Verrucomicrobia'),\n",
-       "    LineagePair(rank='class', name='Verrucomicrobiae'),\n",
-       "    LineagePair(rank='order', name='Verrucomicrobiales'),\n",
-       "    LineagePair(rank='family', name='Akkermansiaceae'),\n",
-       "    LineagePair(rank='genus', name='Akkermansia'),\n",
-       "    LineagePair(rank='species', name='Akkermansia muciniphila'),\n",
-       "    LineagePair(rank='strain', name='Akkermansia muciniphila ATCC BAA-835'))})]"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "num hashvals: 494\n"
+     ]
     }
    ],
    "source": [
-    "x = sourmash.lca.gather_assignments(sig1.minhash.get_mins(), [db])\n",
-    "list(x.items())[:2]"
+    "assignments = sourmash.lca.gather_assignments(sig2.minhash.get_mins(), [db])\n",
+    "print('num hashvals:', len(assignments))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, this particular hashvalue belongs to two different lineages:"
    ]
   },
   {
@@ -632,32 +683,22 @@
     {
      "data": {
       "text/plain": [
-       "[(74037001801154,\n",
-       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
-       "    LineagePair(rank='phylum', name='Proteobacteria'),\n",
-       "    LineagePair(rank='class', name='Gammaproteobacteria'),\n",
-       "    LineagePair(rank='order', name='Alteromonadales'),\n",
-       "    LineagePair(rank='family', name='Shewanellaceae'),\n",
-       "    LineagePair(rank='genus', name='Shewanella'),\n",
-       "    LineagePair(rank='species', name='Shewanella baltica'),\n",
-       "    LineagePair(rank='strain', name='Shewanella baltica OS185'))}),\n",
-       " (196037984804395,\n",
-       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
-       "    LineagePair(rank='phylum', name='Proteobacteria'),\n",
-       "    LineagePair(rank='class', name='Gammaproteobacteria'),\n",
-       "    LineagePair(rank='order', name='Alteromonadales'),\n",
-       "    LineagePair(rank='family', name='Shewanellaceae'),\n",
-       "    LineagePair(rank='genus', name='Shewanella'),\n",
-       "    LineagePair(rank='species', name='Shewanella baltica'),\n",
-       "    LineagePair(rank='strain', name='Shewanella baltica OS185')),\n",
-       "   (LineagePair(rank='superkingdom', name='Bacteria'),\n",
-       "    LineagePair(rank='phylum', name='Verrucomicrobia'),\n",
-       "    LineagePair(rank='class', name='Verrucomicrobiae'),\n",
-       "    LineagePair(rank='order', name='Verrucomicrobiales'),\n",
-       "    LineagePair(rank='family', name='Akkermansiaceae'),\n",
-       "    LineagePair(rank='genus', name='Akkermansia'),\n",
-       "    LineagePair(rank='species', name='Akkermansia muciniphila'),\n",
-       "    LineagePair(rank='strain', name='Akkermansia muciniphila ATCC BAA-835'))})]"
+       "{(LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "  LineagePair(rank='phylum', name='Proteobacteria'),\n",
+       "  LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+       "  LineagePair(rank='order', name='Alteromonadales'),\n",
+       "  LineagePair(rank='family', name='Shewanellaceae'),\n",
+       "  LineagePair(rank='genus', name='Shewanella'),\n",
+       "  LineagePair(rank='species', name='Shewanella baltica'),\n",
+       "  LineagePair(rank='strain', name='Shewanella baltica OS185')),\n",
+       " (LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "  LineagePair(rank='phylum', name='Proteobacteria'),\n",
+       "  LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+       "  LineagePair(rank='order', name='Alteromonadales'),\n",
+       "  LineagePair(rank='family', name='Shewanellaceae'),\n",
+       "  LineagePair(rank='genus', name='Shewanella'),\n",
+       "  LineagePair(rank='species', name='Shewanella baltica'),\n",
+       "  LineagePair(rank='strain', name='Shewanella baltica OS223'))}"
       ]
      },
      "execution_count": 28,
@@ -666,8 +707,15 @@
     }
    ],
    "source": [
-    "x = sourmash.lca.gather_assignments(sig2.minhash.get_mins(), [db])\n",
-    "list(x.items())[:2]"
+    "assignments[196037984804395]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "you can summarize assignments by counting the number of times a particular lineage\n",
+    "occurs; this is used by `sourmash lca classify` and `sourmash lca summarize`."
    ]
   },
   {
@@ -686,7 +734,13 @@
        "          LineagePair(rank='genus', name='Shewanella'),\n",
        "          LineagePair(rank='species', name='Shewanella baltica'),\n",
        "          LineagePair(rank='strain', name='Shewanella baltica OS185')): 311,\n",
-       "         (LineagePair(rank='superkingdom', name='Bacteria'),): 183})"
+       "         (LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "          LineagePair(rank='phylum', name='Proteobacteria'),\n",
+       "          LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+       "          LineagePair(rank='order', name='Alteromonadales'),\n",
+       "          LineagePair(rank='family', name='Shewanellaceae'),\n",
+       "          LineagePair(rank='genus', name='Shewanella'),\n",
+       "          LineagePair(rank='species', name='Shewanella baltica')): 183})"
       ]
      },
      "execution_count": 29,
@@ -695,7 +749,7 @@
     }
    ],
    "source": [
-    "sourmash.lca.count_lca_for_assignments(x)"
+    "sourmash.lca.count_lca_for_assignments(assignments)"
    ]
   },
   {

--- a/doc/using-LCA-database-API.ipynb
+++ b/doc/using-LCA-database-API.ipynb
@@ -753,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -795,13 +795,6 @@
     "\n",
     "[Using the LCA_Database API.](using-LCA-database-API.ipynb)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/doc/using-LCA-database-API.ipynb
+++ b/doc/using-LCA-database-API.ipynb
@@ -354,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## TODO: add lineage manipulation examples"
+    "## Lineage storage and retrieval"
    ]
   },
   {
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,12 +381,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
     "db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)\n",
     "db.insert(sig1, lineage=lineage)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ident 'CP001071.1 Akkermansia muciniphila ATCC BAA-835, complete genome' has idx 0\n",
+      "lid for idx 0 is 0\n",
+      "lineage for lid 0 is Bacteria;Verrucomicrobia;Verrucomicrobiae\n"
+     ]
+    }
+   ],
+   "source": [
+    "# by default, the identifier is the signature name --\n",
+    "ident = sig1.name()\n",
+    "idx = db.ident_to_idx[ident]\n",
+    "print(\"ident '{}' has idx {}\".format(ident, idx))\n",
+    "\n",
+    "lid = db.idx_to_lid[idx]\n",
+    "print(\"lid for idx {} is {}\".format(idx, lid))\n",
+    "\n",
+    "lineage = db.lid_to_lineage[lid]\n",
+    "display = sourmash.lca.display_lineage(lineage)\n",
+    "print(\"lineage for lid {} is {}\".format(lid, display))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lineage manipulation"
    ]
   },
   {

--- a/doc/using-LCA-database-API.ipynb
+++ b/doc/using-LCA-database-API.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -272,14 +272,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "belonging to signatures {0, 1, 2}\n"
+      "belonging to signatures with idx {0, 1, 2}\n"
      ]
     }
    ],
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -355,6 +355,311 @@
    "metadata": {},
    "source": [
     "## TODO: add lineage manipulation examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sourmash.lca import LineagePair"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superkingdom = LineagePair('superkingdom', 'Bacteria')\n",
+    "phylum = LineagePair('phylum', 'Verrucomicrobia')\n",
+    "klass = LineagePair('class', 'Verrucomicrobiae')\n",
+    "\n",
+    "lineage = (superkingdom, phylum, klass)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)\n",
+    "db.insert(sig1, lineage=lineage)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Default taxonomy ranks for lineages\n",
+    "\n",
+    "While sourmash lineage functions can work with any taxonomy ranks and any taxonomy names, both the NCBI and GTDB taxonomies use superkingdom/phylum/etc, so there is a hard coded list availalbe via `sourmash.lca.taxlist()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['superkingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species', 'strain']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(list(sourmash.lca.taxlist()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given a taxonomy as a list, you can then construct a lineage like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(LineagePair(rank='superkingdom', name='Bacteria'),\n",
+      " LineagePair(rank='phylum', name='Proteobacteria'),\n",
+      " LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+      " LineagePair(rank='order', name='Alteromonadales'),\n",
+      " LineagePair(rank='family', name='Shewanellaceae'),\n",
+      " LineagePair(rank='genus', name='Shewanella'),\n",
+      " LineagePair(rank='species', name='Shewanella baltica'),\n",
+      " LineagePair(rank='strain', name='Shewanella baltica OS223'))\n"
+     ]
+    }
+   ],
+   "source": [
+    "linstr = [\"Bacteria\", \"Proteobacteria\", \"Gammaproteobacteria\",\n",
+    "          \"Alteromonadales\", \"Shewanellaceae\", \"Shewanella\",\n",
+    "          \"Shewanella baltica\", \"Shewanella baltica OS223\"]\n",
+    "\n",
+    "lineage1 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr) ]\n",
+    "lineage1 = tuple(lineage1)\n",
+    "pprint(lineage1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linstr2 = [\"Bacteria\", \"Proteobacteria\", \"Gammaproteobacteria\",\n",
+    "          \"Alteromonadales\", \"Shewanellaceae\", \"Shewanella\",\n",
+    "          \"Shewanella baltica\", \"Shewanella baltica OS185\"]\n",
+    "lineage2 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr2) ]\n",
+    "\n",
+    "linstr3 = [\"Bacteria\", \"Verrucomicrobia\", \"Verrucomicrobiae\",\n",
+    "           \"Verrucomicrobiales\", \"Akkermansiaceae\", \"Akkermansia\",\n",
+    "           \"Akkermansia muciniphila\", \"Akkermansia muciniphila ATCC BAA-835\"]\n",
+    "lineage3 = [ LineagePair(*pair) for pair in zip(sourmash.lca.taxlist(), linstr3) ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales;Shewanellaceae;Shewanella;Shewanella baltica;Shewanella baltica OS223'"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sourmash.lca.display_lineage(lineage1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((LineagePair(rank='superkingdom', name='Bacteria'),), 2)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tree = sourmash.lca.build_tree([lineage2, lineage3])\n",
+    "sourmash.lca.find_lca(tree)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "  LineagePair(rank='phylum', name='Proteobacteria'),\n",
+       "  LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+       "  LineagePair(rank='order', name='Alteromonadales'),\n",
+       "  LineagePair(rank='family', name='Shewanellaceae'),\n",
+       "  LineagePair(rank='genus', name='Shewanella'),\n",
+       "  LineagePair(rank='species', name='Shewanella baltica')),\n",
+       " 2)"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tree = sourmash.lca.build_tree([lineage1, lineage2])\n",
+    "sourmash.lca.find_lca(tree)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)\n",
+    "db.insert(sig1, lineage=lineage3)\n",
+    "db.insert(sig2, lineage=lineage2)\n",
+    "db.insert(sig3, lineage=lineage3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(17302105753387,\n",
+       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "    LineagePair(rank='phylum', name='Verrucomicrobia'),\n",
+       "    LineagePair(rank='class', name='Verrucomicrobiae'),\n",
+       "    LineagePair(rank='order', name='Verrucomicrobiales'),\n",
+       "    LineagePair(rank='family', name='Akkermansiaceae'),\n",
+       "    LineagePair(rank='genus', name='Akkermansia'),\n",
+       "    LineagePair(rank='species', name='Akkermansia muciniphila'),\n",
+       "    LineagePair(rank='strain', name='Akkermansia muciniphila ATCC BAA-835'))}),\n",
+       " (95741036335406,\n",
+       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "    LineagePair(rank='phylum', name='Verrucomicrobia'),\n",
+       "    LineagePair(rank='class', name='Verrucomicrobiae'),\n",
+       "    LineagePair(rank='order', name='Verrucomicrobiales'),\n",
+       "    LineagePair(rank='family', name='Akkermansiaceae'),\n",
+       "    LineagePair(rank='genus', name='Akkermansia'),\n",
+       "    LineagePair(rank='species', name='Akkermansia muciniphila'),\n",
+       "    LineagePair(rank='strain', name='Akkermansia muciniphila ATCC BAA-835'))})]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = sourmash.lca.gather_assignments(sig1.minhash.get_mins(), [db])\n",
+    "list(x.items())[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(74037001801154,\n",
+       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "    LineagePair(rank='phylum', name='Proteobacteria'),\n",
+       "    LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+       "    LineagePair(rank='order', name='Alteromonadales'),\n",
+       "    LineagePair(rank='family', name='Shewanellaceae'),\n",
+       "    LineagePair(rank='genus', name='Shewanella'),\n",
+       "    LineagePair(rank='species', name='Shewanella baltica'),\n",
+       "    LineagePair(rank='strain', name='Shewanella baltica OS185'))}),\n",
+       " (196037984804395,\n",
+       "  {(LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "    LineagePair(rank='phylum', name='Proteobacteria'),\n",
+       "    LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+       "    LineagePair(rank='order', name='Alteromonadales'),\n",
+       "    LineagePair(rank='family', name='Shewanellaceae'),\n",
+       "    LineagePair(rank='genus', name='Shewanella'),\n",
+       "    LineagePair(rank='species', name='Shewanella baltica'),\n",
+       "    LineagePair(rank='strain', name='Shewanella baltica OS185')),\n",
+       "   (LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "    LineagePair(rank='phylum', name='Verrucomicrobia'),\n",
+       "    LineagePair(rank='class', name='Verrucomicrobiae'),\n",
+       "    LineagePair(rank='order', name='Verrucomicrobiales'),\n",
+       "    LineagePair(rank='family', name='Akkermansiaceae'),\n",
+       "    LineagePair(rank='genus', name='Akkermansia'),\n",
+       "    LineagePair(rank='species', name='Akkermansia muciniphila'),\n",
+       "    LineagePair(rank='strain', name='Akkermansia muciniphila ATCC BAA-835'))})]"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = sourmash.lca.gather_assignments(sig2.minhash.get_mins(), [db])\n",
+    "list(x.items())[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({(LineagePair(rank='superkingdom', name='Bacteria'),\n",
+       "          LineagePair(rank='phylum', name='Proteobacteria'),\n",
+       "          LineagePair(rank='class', name='Gammaproteobacteria'),\n",
+       "          LineagePair(rank='order', name='Alteromonadales'),\n",
+       "          LineagePair(rank='family', name='Shewanellaceae'),\n",
+       "          LineagePair(rank='genus', name='Shewanella'),\n",
+       "          LineagePair(rank='species', name='Shewanella baltica'),\n",
+       "          LineagePair(rank='strain', name='Shewanella baltica OS185')): 311,\n",
+       "         (LineagePair(rank='superkingdom', name='Bacteria'),): 183})"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sourmash.lca.count_lca_for_assignments(x)"
    ]
   },
   {

--- a/doc/using-LCA-database-API.ipynb
+++ b/doc/using-LCA-database-API.ipynb
@@ -11,6 +11,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "`LCA_Database` objects combine a fast in-memory storage of signatures\n",
+    "indexed by their hash values, with taxonomic lineage storage.  They are\n",
+    "limited to storing scaled DNA signatures with a single ksize; the scaled\n",
+    "and ksize values are specified at creation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running this notebook.\n",
+    "\n",
+    "You can run this notebook interactively via mybinder; click on this button:\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dib-lab/sourmash/master?filepath=doc%2Fusing-LCA-database-API.ipynb)\n",
+    "\n",
+    "A rendered version of this notebook is available at [sourmash.readthedocs.io](https://sourmash.readthedocs.io) under \"Tutorials and notebooks\".\n",
+    "\n",
+    "You can also get this notebook from the [doc/ subdirectory of the sourmash github repository](https://github.com/dib-lab/sourmash/tree/master/doc). See [binder/environment.yaml](https://github.com/dib-lab/sourmash/blob/master/binder/environment.yml) for installation dependencies.\n",
+    "\n",
+    "### What is this?\n",
+    "\n",
+    "This is a Jupyter Notebook using Python 3. If you are running this via [binder](https://mybinder.org), you can use Shift-ENTER to run cells, and double click on code cells to edit them.\n",
+    "\n",
+    "Contact: C. Titus Brown, ctbrown@ucdavis.edu. Please [file issues on GitHub](https://github.com/dib-lab/sourmash/issues/) if you have any questions or comments!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating an `LCA_Database` object\n",
+    "\n",
     "Create an `LCA_Database` like so:"
    ]
   },
@@ -714,42 +746,54 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "you can summarize assignments by counting the number of times a particular lineage\n",
-    "occurs; this is used by `sourmash lca classify` and `sourmash lca summarize`."
+    "sourmash also includes functions to summarize assignments by counting the number of\n",
+    "times a particular lineage occurs; this is\n",
+    "used by `sourmash lca classify` and `sourmash lca summarize`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Counter({(LineagePair(rank='superkingdom', name='Bacteria'),\n",
-       "          LineagePair(rank='phylum', name='Proteobacteria'),\n",
-       "          LineagePair(rank='class', name='Gammaproteobacteria'),\n",
-       "          LineagePair(rank='order', name='Alteromonadales'),\n",
-       "          LineagePair(rank='family', name='Shewanellaceae'),\n",
-       "          LineagePair(rank='genus', name='Shewanella'),\n",
-       "          LineagePair(rank='species', name='Shewanella baltica'),\n",
-       "          LineagePair(rank='strain', name='Shewanella baltica OS185')): 311,\n",
-       "         (LineagePair(rank='superkingdom', name='Bacteria'),\n",
-       "          LineagePair(rank='phylum', name='Proteobacteria'),\n",
-       "          LineagePair(rank='class', name='Gammaproteobacteria'),\n",
-       "          LineagePair(rank='order', name='Alteromonadales'),\n",
-       "          LineagePair(rank='family', name='Shewanellaceae'),\n",
-       "          LineagePair(rank='genus', name='Shewanella'),\n",
-       "          LineagePair(rank='species', name='Shewanella baltica')): 183})"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "311 hashes have LCA: Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales;Shewanellaceae;Shewanella;Shewanella baltica;Shewanella baltica OS185\n",
+      "183 hashes have LCA: Bacteria;Proteobacteria;Gammaproteobacteria;Alteromonadales;Shewanellaceae;Shewanella;Shewanella baltica\n"
+     ]
     }
    ],
    "source": [
-    "sourmash.lca.count_lca_for_assignments(assignments)"
+    "counter = sourmash.lca.count_lca_for_assignments(assignments)\n",
+    "\n",
+    "# count_lca_for_assignments returns a collections.Counter object\n",
+    "for lineage, count in counter.most_common():\n",
+    "    print('{} hashes have LCA: {}'.format(count, sourmash.lca.display_lineage(lineage)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Other pointers\n",
+    "\n",
+    "[Sourmash: a practical guide](https://sourmash.readthedocs.io/en/latest/using-sourmash-a-guide.html)\n",
+    "\n",
+    "[Classifying signatures taxonomically](https://sourmash.readthedocs.io/en/latest/classifying-signatures.html)\n",
+    "\n",
+    "[Pre-built search databases](https://sourmash.readthedocs.io/en/latest/databases.html)\n",
+    "\n",
+    "## A full list of notebooks\n",
+    "\n",
+    "[An introduction to k-mers for genome comparison and analysis](kmers-and-minhash.ipynb)\n",
+    "\n",
+    "[Some sourmash command line examples!](sourmash-examples.ipynb)\n",
+    "\n",
+    "[Working with private collections of signatures.](sourmash-collections.ipynb)\n",
+    "\n",
+    "[Using the LCA_Database API.](using-LCA-database-API.ipynb)"
    ]
   },
   {

--- a/doc/using-LCA-database-API.ipynb
+++ b/doc/using-LCA-database-API.ipynb
@@ -1,0 +1,389 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using the `LCA_Database` API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an `LCA_Database` like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sourmash\n",
+    "db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create signatures for some genomes, load them, and add them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[K\r\n",
+      "== This is sourmash version 3.2.4.dev5+g6484e78f. ==\r\n",
+      "\r",
+      "\u001b[K== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==\r\n",
+      "\r\n",
+      "\r",
+      "\u001b[Ksetting num_hashes to 0 because --scaled is set\r\n",
+      "\r",
+      "\u001b[Kcomputing signatures for files: genomes/akkermansia.fa, genomes/shew_os185.fa, genomes/shew_os223.fa\r\n",
+      "\r",
+      "\u001b[KComputing signature for ksizes: [31]\r\n",
+      "\r",
+      "\u001b[KComputing only nucleotide (and not protein) signatures.\r\n",
+      "\r",
+      "\u001b[KComputing a total of 1 signature(s).\r\n",
+      "\r",
+      "\u001b[Kskipping genomes/akkermansia.fa - already done\r\n",
+      "\r",
+      "\u001b[Kskipping genomes/shew_os185.fa - already done\r\n",
+      "\r",
+      "\u001b[Kskipping genomes/shew_os223.fa - already done\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!sourmash compute --name-from-first -k 31 --scaled=1000 genomes/*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sig1 = sourmash.load_one_signature('akkermansia.fa.sig', ksize=31)\n",
+    "sig2 = sourmash.load_one_signature('shew_os185.fa.sig', ksize=31)\n",
+    "sig3 = sourmash.load_one_signature('shew_os223.fa.sig', ksize=31)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db.insert(sig1, ident='akkermansia')\n",
+    "db.insert(sig2, ident='shew_os185')\n",
+    "db.insert(sig3, ident='shew_os223')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run `search` and `gather` via the `Index` API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(1.0,\n",
+      "  SourmashSignature('CP001071.1 Akkermansia muciniphila ATCC BAA-835, complete genome', 6822e0b7),\n",
+      "  None)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pprint import pprint\n",
+    "pprint(db.search(sig1, threshold=0.1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(1.0,\n",
+      "  SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', b47b13ef),\n",
+      "  None),\n",
+      " (0.22846441947565543,\n",
+      "  SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', ae6659f6),\n",
+      "  None)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(db.search(sig2, threshold=0.1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(1.0,\n",
+      "  SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', ae6659f6),\n",
+      "  None)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(db.gather(sig3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve all signatures with `signatures()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SourmashSignature('CP001071.1 Akkermansia muciniphila ATCC BAA-835, complete genome', 6822e0b7)\n",
+      "SourmashSignature('NC_009665.1 Shewanella baltica OS185, complete genome', b47b13ef)\n",
+      "SourmashSignature('NC_011663.1 Shewanella baltica OS223, complete genome', ae6659f6)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in db.signatures():\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Access identifiers and names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The list of (unique) identifiers in the database can be accessed via the attribute `ident_to_idx`, which maps to integer identifiers; identifiers can also retrieve full names, which are taken from `sig.name()` upon insertion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['akkermansia', 'shew_os185', 'shew_os223'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(db.ident_to_idx.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'akkermansia': 'CP001071.1 Akkermansia muciniphila ATCC BAA-835, complete '\n",
+      "                'genome',\n",
+      " 'shew_os185': 'NC_009665.1 Shewanella baltica OS185, complete genome',\n",
+      " 'shew_os223': 'NC_011663.1 Shewanella baltica OS223, complete genome'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(db.ident_to_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Access hash values directly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The attribute `hashval_to_idx` contains a mapping from individual hash values to sets of `idx` indices.\n",
+    "\n",
+    "See the method `_find_signatures()` for an example of how this is used in `search` and `gather`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1300 hash values total in this database\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('{} hash values total in this database'.format(len(db.hashval_to_idx)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "belonging to signatures {0, 1, 2}\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_idx = set()\n",
+    "for idx_set in db.hashval_to_idx.values():\n",
+    "    all_idx.update(idx_set)\n",
+    "print('belonging to signatures with idx {}'.format(all_idx))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_three_hashvals = list(db.hashval_to_idx)[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hashval 17302105753387 belongs to idxs {0}\n",
+      "hashval 95741036335406 belongs to idxs {0}\n",
+      "hashval 165640715598232 belongs to idxs {0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "for hashval in first_three_hashvals:\n",
+    "    print('hashval {} belongs to idxs {}'.format(hashval, db.hashval_to_idx[hashval]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "490 hashvals belong to query idx 2\n",
+      "query idx 2 matches to ident shew_os223\n",
+      "query idx 2 matches to name NC_011663.1 Shewanella baltica OS223, complete genome\n"
+     ]
+    }
+   ],
+   "source": [
+    "query_idx = 2\n",
+    "hashval_set = set()\n",
+    "for hashval, idx_set in db.hashval_to_idx.items():\n",
+    "    if query_idx in idx_set:\n",
+    "        hashval_set.add(hashval)\n",
+    "        \n",
+    "print('{} hashvals belong to query idx {}'.format(len(hashval_set), query_idx))\n",
+    "\n",
+    "ident = db.idx_to_ident[query_idx]\n",
+    "print('query idx {} matches to ident {}'.format(query_idx, ident))\n",
+    "\n",
+    "name = db.ident_to_name[ident]\n",
+    "print('query idx {} matches to name {}'.format(query_idx, name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TODO: add lineage manipulation examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (myenv)",
+   "language": "python",
+   "name": "myenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -29,12 +29,32 @@ def cached_property(fun):
 
 class LCA_Database(Index):
     """
-    Wrapper class for taxonomic database.
+    An in-memory database that indexes signatures by hash, and provides
+    optional taxonomic lineage classification.
 
-    obj.ident_to_idx: key 'identifier' to 'idx'
-    obj.idx_to_lid: key 'idx' to 'lid'
-    obj.lid_to_lineage: key 'lid' to tuple of LineagePair objects
-    obj.hashval_to_idx: key 'hashval' => set('idx')
+    Follows the `Index` API for `insert`, `search`, `gather`, and `signatures`.
+
+    Identifiers `ident` must be unique, and are taken by default as the
+    entire signature name upon insertion. This can be overridden with
+    the `ident` keyword argument in `insert`.
+
+    Integer `idx` indices can be used as keys in dictionary attributes:
+    * `idx_to_lid`, to get an (optional) lineage index.
+    * `idx_to_ident`, to retrieve the unique string identifier for that `idx`.
+
+    Integer `lid` indices can be used as keys in dictionary attributes:
+    * `lid_to_idx`, to get a set of `idx` with that lineage.
+    * `lid_to_lineage`, to get a lineage for that `lid`.
+
+    `lineage_to_lid` is a dictionary with tuples of LineagePair as keys,
+    `lid` as values.
+
+    `ident_to_name` is a dictionary from unique str identifer to a name.
+
+    `ident_to_idx` is a dictionary from unique str identifer to integer `idx`.
+
+    `hashval_to_idx` is a dictionary from individual hash values to sets of
+    `idx`.
     """
     def __init__(self, ksize, scaled):
         self.ksize = int(ksize)
@@ -187,6 +207,7 @@ class LCA_Database(Index):
             # convert lineage_dict to proper lineages (tuples of LineagePairs)
             lid_to_lineage_2 = load_d['lid_to_lineage']
             lid_to_lineage = {}
+            lineage_to_lid = {}
             for k, v in lid_to_lineage_2.items():
                 v = dict(v)
                 vv = []
@@ -194,8 +215,11 @@ class LCA_Database(Index):
                     name = v.get(rank, '')
                     vv.append(LineagePair(rank, name))
 
-                lid_to_lineage[int(k)] = tuple(vv)
+                vv = tuple(vv)
+                lid_to_lineage[int(k)] = vv
+                lineage_to_lid[vv] = int(k)
             db.lid_to_lineage = lid_to_lineage
+            db.lineage_to_lid = lineage_to_lid
 
             # convert hashval -> lineage index keys to integers (looks like
             # JSON doesn't have a 64 bit type so stores them as strings)
@@ -445,13 +469,6 @@ class LCA_Database(Index):
             # ...and return.
             if score >= threshold:
                 yield score, match_sig, self.filename
-
-    @cached_property
-    def lineage_to_lids(self):
-        d = defaultdict(set)
-        for lid, lineage in self.lid_to_lineage.items():
-            d[lineage].add(lid)
-        return d
 
     @cached_property
     def lid_to_idx(self):

--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -129,6 +129,8 @@ class LCA_Database(Index):
         # identifier -> integer index (idx)
         idx = self._get_ident_index(ident, fail_on_duplicate=True)
         if lineage:
+            lineage = tuple(lineage)
+
             # (LineagePairs*) -> integer lineage ids (lids)
             lid = self._get_lineage_id(lineage)
 
@@ -141,8 +143,6 @@ class LCA_Database(Index):
 
         for hashval in minhash.get_mins():
             self.hashval_to_idx[hashval].add(idx)
-
-        return lineage
 
     def __repr__(self):
         return "LCA_Database('{}')".format(self.filename)

--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -123,7 +123,6 @@ class LCA_Database(Index):
         # making sure they're all at the same scaled value!
         minhash = minhash.downsample_scaled(self.scaled)
 
-
         if ident is None:
             ident = sig.name()
 
@@ -139,13 +138,16 @@ class LCA_Database(Index):
         # identifier -> integer index (idx)
         idx = self._get_ident_index(ident, fail_on_duplicate=True)
         if lineage:
-            lineage = tuple(lineage)
+            try:
+                lineage = tuple(lineage)
 
-            # (LineagePairs*) -> integer lineage ids (lids)
-            lid = self._get_lineage_id(lineage)
+                # (LineagePairs*) -> integer lineage ids (lids)
+                lid = self._get_lineage_id(lineage)
 
-            # map idx to lid as well.
-            self.idx_to_lid[idx] = lid
+                # map idx to lid as well.
+                self.idx_to_lid[idx] = lid
+            except TypeError:
+                raise ValueError('lineage cannot be used as a key?!')
 
         for hashval in minhash.get_mins():
             self.hashval_to_idx[hashval].add(idx)

--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -114,6 +114,16 @@ class LCA_Database(Index):
 
         'lineage', if specified, must contain a tuple of LineagePair objects.
         """
+        minhash = sig.minhash
+
+        if minhash.ksize != self.ksize:
+            raise ValueError("cannot insert signature with ksize {} into DB (ksize {})".format(minhash.ksize, self.ksize))
+
+        # downsample to specified scaled; this has the side effect of
+        # making sure they're all at the same scaled value!
+        minhash = minhash.downsample_scaled(self.scaled)
+
+
         if ident is None:
             ident = sig.name()
 
@@ -136,10 +146,6 @@ class LCA_Database(Index):
 
             # map idx to lid as well.
             self.idx_to_lid[idx] = lid
-
-        # downsample to specified scaled; this has the side effect of
-        # making sure they're all at the same scaled value!
-        minhash = sig.minhash.downsample_scaled(self.scaled)
 
         for hashval in minhash.get_mins():
             self.hashval_to_idx[hashval].add(idx)

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -273,9 +273,8 @@ def test_api_create_insert_w_lineage():
     assert lca_db.lid_to_lineage[0] == lineage
     assert lca_db.lid_to_idx[0] == { 0 }
 
-    assert len(lca_db.lineage_to_lids) == 1
-    assert len(lca_db.lineage_to_lids[lineage]) == 1
-    assert lca_db.lineage_to_lids[lineage] == { 0 }
+    assert len(lca_db.lineage_to_lid) == 1
+    assert lca_db.lineage_to_lid[lineage] == 0
 
 
 def test_api_create_gather():
@@ -494,11 +493,11 @@ def test_gather_db_scaled_lt_sig_scaled():
     assert sig.minhash == match_sig.minhash
 
 
-def test_db_lineage_to_lids():
+def test_db_lineage_to_lid():
     dbfile = utils.get_test_data('lca/47+63.lca.json')
     db, ksize, scaled = lca_utils.load_single_database(dbfile)
 
-    d = db.lineage_to_lids
+    d = db.lineage_to_lid
     items = list(d.items())
     items.sort()
     assert len(items) == 2

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -163,6 +163,28 @@ def test_api_create_insert():
     assert not lca_db.lid_to_lineage      # no lineage added
 
 
+def test_api_create_insert_bad_ksize():
+    # can we insert a ksize=21 signature into a ksize=31 DB? hopefully not.
+    ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),
+                                     ksize=31)
+
+    lca_db = sourmash.lca.LCA_Database(ksize=21, scaled=1000)
+    with pytest.raises(ValueError):
+        lca_db.insert(ss)
+
+
+def test_api_create_insert_bad_scaled():
+    # can we insert a scaled=1000 signature into a scaled=500 DB?
+    # hopefully not.
+    ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),
+                                     ksize=31)
+    assert ss.minhash.scaled == 1000
+
+    lca_db = sourmash.lca.LCA_Database(ksize=31, scaled=500)
+    with pytest.raises(ValueError):
+        lca_db.insert(ss)
+
+
 def test_api_create_insert_ident():
     # test some internal implementation stuff: signature inserted with
     # different ident than name.

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -260,13 +260,13 @@ def test_api_create_insert_two():
 
 
 def test_api_create_insert_w_lineage():
-    # test some internal implementation stuff - insert signature w/linage
+    # test some internal implementation stuff - insert signature w/lineage
     ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),
                                      ksize=31)
 
     lca_db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)
     lineage = ((LineagePair('rank1', 'name1'),
-               (LineagePair('rank2', 'name2'))))
+                LineagePair('rank2', 'name2')))
     
     lca_db.insert(ss, lineage=lineage)
 
@@ -297,6 +297,31 @@ def test_api_create_insert_w_lineage():
 
     assert len(lca_db.lineage_to_lid) == 1
     assert lca_db.lineage_to_lid[lineage] == 0
+
+
+def test_api_create_insert_w_bad_lineage():
+    # test some internal implementation stuff - insert signature w/bad lineage
+    ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),
+                                     ksize=31)
+
+    lca_db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)
+    lineage = ([LineagePair('rank1', 'name1'),
+                LineagePair('rank2', 'name2')],)
+
+    with pytest.raises(ValueError):
+        lca_db.insert(ss, lineage=lineage)
+
+
+def test_api_create_insert_w_bad_lineage_2():
+    # test some internal implementation stuff - insert signature w/bad lineage
+    ss = sourmash.load_one_signature(utils.get_test_data('47.fa.sig'),
+                                     ksize=31)
+
+    lca_db = sourmash.lca.LCA_Database(ksize=31, scaled=1000)
+    lineage = 1 # something non-iterable...
+
+    with pytest.raises(ValueError):
+        lca_db.insert(ss, lineage=lineage)
 
 
 def test_api_create_gather():


### PR DESCRIPTION
Put together a Jupyter Notebook for the `LCA_Database` API; see #965 for motivation/request.

[View notebook on branch](https://github.com/dib-lab/sourmash/blob/doc_lca_db_api/doc/using-LCA-database-API.ipynb)

In the process, I figured out that `lineage_to_lids` was redundant with `lineage_to_lid` and removed the former, which led to me realizing that `lineage_to_lid` wasn't being properly built on database load, so I fixed that, too.

- [x] check API for `insert(..., lineage=lin)` to be sure that `lin` can be tuple-ized

---

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
