### PR TITLE
[MRG] upgrade sourmash index usage docs on CLI

### DIFF
--- a/sourmash/cli/index.py
+++ b/sourmash/cli/index.py
@@ -1,11 +1,38 @@
 """index signatures for rapid search"""
 
+usage="""
+
+   sourmash index -k 31 dbname *.sig
+
+Create an on-disk database of signatures that can be searched in low
+memory with 'search' and 'gather'. All signatures must be the same
+k-mer size, molecule type, and num/scaled; the standard signature
+selectors (-k/--ksize, --scaled, --dna/--protein) choose which
+signatures to be added.
+
+The key options for index are:
+
+ * `-k/--ksize <int>`: k-mer size to select
+ * `--dna` or --protein`: nucleotide or protein signatures (default `--dna`)
+ * `--traverse-directory`: load all signatures below this directory
+
+If `dbname` ends with `.sbt.json`, index will create the database as a
+collection of multiple files, with an index `dbname.sbt.json` and a
+subdirectory `.sbt.dbname`. If `dbname` ends with `.sbt.zip`, index
+will create a zip archive containing the multiple files. For sourmash
+v2 and v3, `sbt.json` will be added automatically; this behavior will
+change in sourmash v4 to default to `.sbt.zip`.
+
+---
+"""
+
 from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 
 
 def subparser(subparsers):
-    subparser = subparsers.add_parser('index')
-    subparser.add_argument('sbt_name', help='name to save SBT into')
+    subparser = subparsers.add_parser('index', description=__doc__,
+                                      usage=usage)
+    subparser.add_argument('dbname', help='name to save index into; .sbt.zip or .sbt.json file')
     subparser.add_argument(
         'signatures', nargs='+',
         help='signatures to load into SBT'

--- a/sourmash/cli/index.py
+++ b/sourmash/cli/index.py
@@ -32,7 +32,7 @@ from sourmash.cli.utils import add_moltype_args, add_ksize_arg
 def subparser(subparsers):
     subparser = subparsers.add_parser('index', description=__doc__,
                                       usage=usage)
-    subparser.add_argument('dbname', help='name to save index into; .sbt.zip or .sbt.json file')
+    subparser.add_argument('sbt_name', help='name to save index into; .sbt.zip or .sbt.json file')
     subparser.add_argument(
         'signatures', nargs='+',
         help='signatures to load into SBT'


### PR DESCRIPTION
Adds a `compute`-like usage output for `sourmash index`. In particular, mentions `.sbt.zip` behavior.

Partly addresses #973 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
