### PR TITLE
[MRG] switch to enum-compat instead of enum34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ SETUP_METADATA = {
         'sourmash = sourmash.__main__:main'
         ]
     },
-    "install_requires": ["screed>=0.9", "cffi>=1.14.0", "enum34", 'numpy',
+    "install_requires": ["screed>=0.9", "cffi>=1.14.0", "enum-compat", 'numpy',
                          'matplotlib', 'scipy', "deprecation>=2.0.6"],
     "setup_requires": [
         "setuptools>=38.6.0",


### PR DESCRIPTION
When setting up a v3.3.0 release, I ran into a problem with enum34 and python version incompatibilities -- briefly, when installing enum34 with pip install, I get

```
AttributeError: module 'enum' has no attribute 'IntFlag'  
``

This uses the [enum-compat package as a solution, via StackOverflow](https://stackoverflow.com/questions/43124775/why-python-3-6-1-throws-attributeerror-module-enum-has-no-attribute-intflag).

@luizirber approved this via slack :)

---

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
