### PR TITLE
fix enum34/python version mismatch more cleanly than #979

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,9 @@ SETUP_METADATA = {
         'sourmash = sourmash.__main__:main'
         ]
     },
-    "install_requires": ["screed>=0.9", "cffi>=1.14.0", "enum-compat", 'numpy',
-                         'matplotlib', 'scipy', "deprecation>=2.0.6"],
+    "install_requires": ['screed>=0.9', 'cffi>=1.14.0', 'numpy',
+                         'enum34; python_version < "3.4"',
+                         'matplotlib', 'scipy', 'deprecation>=2.0.6'],
     "setup_requires": [
         "setuptools>=38.6.0",
         "milksnake",


### PR DESCRIPTION
specify python versions for which enum34 should be installed.

ref #979 
fixes #980

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
