### PR TITLE
functionality re: lineages that match but have addl taxonomic detail?

### DIFF
--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -121,6 +121,15 @@ def test_find_lca_2():
     assert lca == ((LineagePair('rank1', 'name1'),), 2)
 
 
+def test_find_lca_3():
+    lin1 = lca_utils.make_lineage('a;b;c')
+    lin2 = lca_utils.make_lineage('a;b')
+
+    tree = build_tree([lin1, lin2])
+    lca, reason = find_lca(tree)
+    assert lca == lin1                    # find most specific leaf node
+
+
 ### command line tests
 
 

--- a/tests/test_lca_functions.py
+++ b/tests/test_lca_functions.py
@@ -229,8 +229,8 @@ def test_count_lca_for_assignments_abund_4():
     assert counts[lca_lin] == 2           # yes!
 
 def test_count_lca_for_assignments_abund_5():
-    # test basic mechanics of gather_assignments function with three lineages
-    # and three hashvals
+    # test basic mechanics of gather_assignments function with two lineages
+    # and two hashvals when linages match but one has lower taxo detail
     hashval = 12345678
     hashval2 = 87654321
     hashval_counts = dict()

--- a/tests/test_lca_functions.py
+++ b/tests/test_lca_functions.py
@@ -21,7 +21,7 @@ def test_gather_assignments_1():
     # test basic mechanics of gather_assignments function
     hashval = 12345678
     lin = lca_utils.make_lineage('a;b;c')
-    
+
     db = FakeLCA_Database()
     db._set_lineage_assignment(hashval, set([ lin ]))
 
@@ -36,7 +36,7 @@ def test_gather_assignments_2():
     hashval = 12345678
     lin = lca_utils.make_lineage('a;b;c')
     lin2 = lca_utils.make_lineage('a;b;d')
-    
+
     db = FakeLCA_Database()
     db._set_lineage_assignment(hashval, set([ lin, lin2 ]))
 
@@ -53,7 +53,7 @@ def test_gather_assignments_3():
     hashval2 = 87654321
     lin = lca_utils.make_lineage('a;b;c')
     lin2 = lca_utils.make_lineage('a;b;d')
-    
+
     db = FakeLCA_Database()
     db._set_lineage_assignment(hashval, set([ lin, lin2 ]))
     db._set_lineage_assignment(hashval2, set([ lin ]))
@@ -69,7 +69,7 @@ def test_count_lca_for_assignments_1():
     # test basic mechanics of gather_assignments function
     hashval = 12345678
     lin = lca_utils.make_lineage('a;b;c')
-    
+
     db = FakeLCA_Database()
     db._set_lineage_assignment(hashval, set([ lin ]))
 
@@ -86,7 +86,7 @@ def test_count_lca_for_assignments_2():
     hashval = 12345678
     lin = lca_utils.make_lineage('a;b;c')
     lin2 = lca_utils.make_lineage('a;b;d')
-    
+
     db = FakeLCA_Database()
     db._set_lineage_assignment(hashval, set([ lin, lin2 ]))
 
@@ -109,7 +109,7 @@ def test_count_lca_for_assignments_3():
     hashval2 = 87654321
     lin = lca_utils.make_lineage('a;b;c')
     lin2 = lca_utils.make_lineage('a;b;d')
-    
+
     db = FakeLCA_Database()
     db._set_lineage_assignment(hashval, set([ lin, lin2 ]))
     db._set_lineage_assignment(hashval2, set([ lin ]))
@@ -192,6 +192,39 @@ def test_count_lca_for_assignments_abund_3():
     assert len(counts) == 2
     assert counts[lin] == 5               # makes sense
     assert counts[lin2] == 0              # makes sense
+
+    lca_lin = lca_utils.make_lineage('a;b')
+    assert counts[lca_lin] == 2           # yes!
+
+def test_count_lca_for_assignments_abund_4():
+    # test basic mechanics of gather_assignments function with three lineages
+    # and three hashvals
+    hashval = 12345678
+    hashval2 = 87654321
+    hashval3 = 34567891
+    hashval_counts = dict()
+    hashval_counts[hashval] = 2
+    hashval_counts[hashval2] = 5
+    hashval_counts[hashval3] = 3
+
+    lin = lca_utils.make_lineage('a;b;c')
+    lin2 = lca_utils.make_lineage('a;b;d')
+    lin3 = lca_utils.make_lineage('a;b;d;e')
+
+    db = FakeLCA_Database()
+    db._set_lineage_assignment(hashval, set([ lin, lin2 ]))
+    db._set_lineage_assignment(hashval2, set([ lin ]))
+    db._set_lineage_assignment(hashval3, set([ lin2, lin3 ]))
+
+    assignments = lca_utils.gather_assignments(hashval_counts, [db])
+    counts = count_lca_for_assignments(assignments, hashval_counts)
+    print(counts)
+    counts
+
+    assert len(counts) == 3
+    assert counts[lin] == 5               # makes sense
+    assert counts[lin2] == 0              # a;b;d (lin2) + a;b;d;e (lin3) -->a;b;d;e (lin3) only
+    assert counts[lin3] == 3
 
     lca_lin = lca_utils.make_lineage('a;b')
     assert counts[lca_lin] == 2           # yes!

--- a/tests/test_lca_functions.py
+++ b/tests/test_lca_functions.py
@@ -219,7 +219,6 @@ def test_count_lca_for_assignments_abund_4():
     assignments = lca_utils.gather_assignments(hashval_counts, [db])
     counts = count_lca_for_assignments(assignments, hashval_counts)
     print(counts)
-    counts
 
     assert len(counts) == 3
     assert counts[lin] == 5               # makes sense
@@ -228,3 +227,27 @@ def test_count_lca_for_assignments_abund_4():
 
     lca_lin = lca_utils.make_lineage('a;b')
     assert counts[lca_lin] == 2           # yes!
+
+def test_count_lca_for_assignments_abund_5():
+    # test basic mechanics of gather_assignments function with three lineages
+    # and three hashvals
+    hashval = 12345678
+    hashval2 = 87654321
+    hashval_counts = dict()
+    hashval_counts[hashval] = 2
+    hashval_counts[hashval2] = 5
+
+    lin = lca_utils.make_lineage('a;b;d')
+    lin2 = lca_utils.make_lineage('a;b;d;e')
+
+    db = FakeLCA_Database()
+    db._set_lineage_assignment(hashval, set([ lin, lin2 ]))
+    db._set_lineage_assignment(hashval2, set([ lin ]))
+
+    assignments = lca_utils.gather_assignments(hashval_counts, [db])
+    counts = count_lca_for_assignments(assignments, hashval_counts)
+    print(counts)
+
+    assert len(counts) == 2
+    assert counts[lin] == 5               # makes sense
+    assert counts[lin2] == 2              # lin+lin2 yield just lin2

--- a/tests/test_lca_functions.py
+++ b/tests/test_lca_functions.py
@@ -212,21 +212,21 @@ def test_count_lca_for_assignments_abund_4():
     lin3 = lca_utils.make_lineage('a;b;d;e')
 
     db = FakeLCA_Database()
-    db._set_lineage_assignment(hashval, set([ lin, lin2 ]))
-    db._set_lineage_assignment(hashval2, set([ lin ]))
-    db._set_lineage_assignment(hashval3, set([ lin2, lin3 ]))
+    db._set_lineage_assignment(hashval, set([ lin, lin2 ])) # lca: a;b
+    db._set_lineage_assignment(hashval2, set([ lin ])) # lca: a;b;c
+    db._set_lineage_assignment(hashval3, set([ lin2, lin3 ])) # a;b;d;e
 
     assignments = lca_utils.gather_assignments(hashval_counts, [db])
     counts = count_lca_for_assignments(assignments, hashval_counts)
     print(counts)
 
     assert len(counts) == 3
-    assert counts[lin] == 5               # makes sense
+    assert counts[lin] == 5               # makes sense b/c hashval2
     assert counts[lin2] == 0              # a;b;d (lin2) + a;b;d;e (lin3) -->a;b;d;e (lin3) only
-    assert counts[lin3] == 3
+    assert counts[lin3] == 3              # hashval3
 
     lca_lin = lca_utils.make_lineage('a;b')
-    assert counts[lca_lin] == 2           # yes!
+    assert counts[lca_lin] == 2           # yes, b/c hashval
 
 def test_count_lca_for_assignments_abund_5():
     # test basic mechanics of gather_assignments function with two lineages


### PR DESCRIPTION
So, I hadn't thought much about gather and needed to wrap my head around the gather_assignments functionality when lineages match, but one is more detailed: 

We keep the more detailed info, so  `a;b;d` + `a;b;d;e` yields `a;b;d;e`

This makes decent sense to me, as we always want to gather the best matches, and can summarize up later. But it's a little unintuitive to me that the count of `a;b;d` is 0 (abund test 4).

@ctb can you explain pls?