### PR TITLE
Refactor functions that use run_shell_cmd() function in test_sourmash.py and test_sourmash_compute.py per #987

### DIFF
--- a/tests/sourmash_tst_utils.py
+++ b/tests/sourmash_tst_utils.py
@@ -233,27 +233,3 @@ def in_thisdir(fn):
         return fn(*newargs, **kwargs)
 
     return wrapper
-
-
-def run_shell_cmd(cmd, fail_ok=False, in_directory=None):
-    cwd = os.getcwd()
-    if in_directory:
-        os.chdir(in_directory)
-
-    print('running: ', cmd)
-    try:
-        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        (out, err) = proc.communicate()
-
-        out = out.decode('utf-8')
-        err = err.decode('utf-8')
-
-        if proc.returncode != 0 and not fail_ok:
-            print('out:', out)
-            print('err:', err)
-            raise AssertionError("exit code is non zero: %d" % proc.returncode)
-
-        return (proc.returncode, out, err)
-    finally:
-        os.chdir(cwd)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3317,50 +3317,34 @@ def test_sbt_categorize_multiple_ksizes_moltypes():
         assert 'multiple k-mer sizes/molecule types present' in err
 
 
-def test_watch():
-    with utils.TempDirectory() as location:
-        testdata0 = utils.get_test_data('genome-s10.fa.gz')
-        testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
-        shutil.copyfile(testdata1, os.path.join(location, '1.sig'))
+@utils.in_tempdir
+def test_watch(c):
+    testdata0 = utils.get_test_data('genome-s10.fa.gz')
+    testdata1 = utils.get_test_data('genome-s10.fa.gz.sig')
+    shutil.copyfile(testdata1, c.output('1.sig'))
 
-        args = ['index', '--dna', '-k', '21', 'zzz', '1.sig']
-        status, out, err = utils.runscript('sourmash', args,
-                                           in_directory=location)
+    c.run_sourmash('index', '--dna', '-k', '21', 'zzz', '1.sig')
 
-        cmd = """
+    c.run_sourmash('watch', '--ksize', '21', '--dna', 'zzz', testdata0)
 
-             gunzip -c {} | sourmash watch --ksize 21 --dna zzz
-
-        """.format(testdata0)
-        status, out, err = utils.run_shell_cmd(cmd, in_directory=location)
-
-        print(out)
-        print(err)
-        assert 'FOUND: genome-s10.fa.gz, at 1.000' in out
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert 'FOUND: genome-s10.fa.gz, at 1.000' in c.last_result.out
 
 
-def test_watch_deduce_ksize():
-    with utils.TempDirectory() as location:
-        testdata0 = utils.get_test_data('genome-s10.fa.gz')
-        utils.runscript('sourmash',
-                        ['compute', testdata0, '-k', '29', '-o', '1.sig'],
-                        in_directory=location)
+@utils.in_tempdir
+def test_watch_deduce_ksize(c):
+    testdata0 = utils.get_test_data('genome-s10.fa.gz')
+    c.run_sourmash('compute', testdata0, '-k', '29', '-o', '1.sig')
 
-        args = ['index', '--dna', '-k', '29', 'zzz', '1.sig']
-        status, out, err = utils.runscript('sourmash', args,
-                                           in_directory=location)
+    c.run_sourmash('index', '--dna', '-k', '29', 'zzz', '1.sig')
 
-        cmd = """
+    c.run_sourmash('watch', '--dna', 'zzz', testdata0)
 
-             gunzip -c {} | sourmash watch --dna zzz
-
-        """.format(testdata0)
-        status, out, err = utils.run_shell_cmd(cmd, in_directory=location)
-
-        print(out)
-        print(err)
-        assert 'Computing signature for k=29' in err
-        assert 'genome-s10.fa.gz, at 1.000' in out
+    print(c.last_result.out)
+    print(c.last_result.err)
+    assert 'Computing signature for k=29' in c.last_result.err
+    assert 'genome-s10.fa.gz, at 1.000' in c.last_result.out
 
 
 def test_watch_coverage():

--- a/tests/test_sourmash_compute.py
+++ b/tests/test_sourmash_compute.py
@@ -99,39 +99,31 @@ def test_do_sourmash_compute_output_stdout_valid():
                    for testdata in (testdata1, testdata2, testdata3))
 
 
-def test_do_sourmash_compute_output_and_name_valid_file():
-    with utils.TempDirectory() as location:
-        testdata1 = utils.get_test_data('short.fa')
-        testdata2 = utils.get_test_data('short2.fa')
-        testdata3 = utils.get_test_data('short3.fa')
-        sigfile = os.path.join(location, 'short.fa.sig')
+@utils.in_tempdir
+def test_do_sourmash_compute_output_and_name_valid_file(c):
+    testdata1 = utils.get_test_data('short.fa')
+    testdata2 = utils.get_test_data('short2.fa')
+    testdata3 = utils.get_test_data('short3.fa')
+    sigfile = c.output('short.fa.sig')
 
-        status, out, err = utils.runscript('sourmash',
-                                           ['compute', '-k', '31', '-o', sigfile,
-                                            '--merge', '"name"',
-                                            testdata1,
-                                            testdata2, testdata3],
-                                           in_directory=location)
+    c.run_sourmash('compute', '-k', '31', '-o', sigfile, '--merge', '"name"', testdata1, testdata2, testdata3)
 
-        assert os.path.exists(sigfile)
-        assert 'calculated 1 signatures for 4 sequences taken from 3 files' in err
+    assert os.path.exists(sigfile)
+    assert 'calculated 1 signatures for 4 sequences taken from 3 files' in c.last_result.err
 
-        # is it valid json?
-        with open(sigfile, 'r') as f:
-            data = json.load(f)
+    # is it valid json?
+    with open(sigfile, 'r') as f:
+        data = json.load(f)
 
-        assert len(data) == 1
+    assert len(data) == 1
 
-        all_testdata = " ".join([testdata1, testdata2, testdata3])
-        sigfile_merged = os.path.join(location, 'short.all.fa.sig')
-        cmd = "cat {} | sourmash compute -k 31 -o {} -".format(
-                all_testdata, sigfile_merged)
-        status, out, err = utils.run_shell_cmd(cmd, in_directory=location)
+    sigfile_merged = c.output('short.all.fa.sig')
+    c.run_sourmash('compute', '-k', '31', '-o', sigfile_merged, '--merge', '"name"', testdata1, testdata2, testdata3)
 
-        with open(sigfile_merged, 'r') as f:
-            data_merged = json.load(f)
+    with open(sigfile_merged, 'r') as f:
+        data_merged = json.load(f)
 
-        assert data[0]['signatures'][0]['mins'] == data_merged[0]['signatures'][0]['mins']
+    assert data[0]['signatures'][0]['mins'] == data_merged[0]['signatures'][0]['mins']
 
 
 @utils.in_tempdir


### PR DESCRIPTION
This PR removes all references to the old run_shell_cmd function and replaces it making use of the @utils.in_tempdir decorator
Fixes #987 
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
