### PR TITLE
Doctest permission error

### DIFF
--- a/doc/api-example.md
+++ b/doc/api-example.md
@@ -112,8 +112,10 @@ add some metadata to MinHashes.
 
 ```
 >>> from sourmash import SourmashSignature, save_signatures
+>>> from tempfile import mkdtemp
 >>> sig1 = SourmashSignature(minhashes[0], name=genomes[0][:20])
->>> with open('/tmp/genome1.sig', 'wt') as fp:
+>>> tempdir = mkdtemp(suffix = "temp")
+>>> with open(tempdir + '/genome1.sig', 'wt') as fp:
 ...   save_signatures([sig1], fp)
 
 ```
@@ -123,7 +125,7 @@ compared -- first, load:
 
 ```
 >>> from sourmash import load_one_signature
->>> loaded_sig = load_one_signature('/tmp/genome1.sig')
+>>> loaded_sig = load_one_signature(tempdir + '/genome1.sig')
 
 ```
 
@@ -420,7 +422,7 @@ checks.)
 Now, save the tree:
 
 ```
->>> filename = tree.save('/tmp/test.sbt.json')
+>>> filename = tree.save(tempdir + '/test.sbt.json')
 
 ```
 
@@ -431,7 +433,7 @@ from within Python?
 
 The SBT filename is `/tmp/test.sbt.json`, as above:
 ```
->>> SBT_filename = '/tmp/test.sbt.json'
+>>> SBT_filename = tempdir + '/test.sbt.json'
 
 ```
 

--- a/doc/api-example.md
+++ b/doc/api-example.md
@@ -120,7 +120,7 @@ add some metadata to MinHashes.
 
 ```
 
-Here, `{}/genome1.sig`.format(tempdir) is a JSON file that can now be loaded and
+Here, `genome1.sig` is a JSON file that can now be loaded and
 compared -- first, load:
 
 ```
@@ -431,7 +431,7 @@ Now, save the tree:
 How do we load the SBT and search it with a DNA sequence,
 from within Python?
 
-The SBT filename is `{}/test.sbt.json`.format(tempdir), as above:
+The SBT filename is `test.sbt.json`, as above:
 ```
 >>> SBT_filename = tempdir + '/test.sbt.json'
 

--- a/doc/api-example.md
+++ b/doc/api-example.md
@@ -120,7 +120,7 @@ add some metadata to MinHashes.
 
 ```
 
-Here, `/tmp/genome1.sig` is a JSON file that can now be loaded and
+Here, `{}/genome1.sig`.format(tempdir) is a JSON file that can now be loaded and
 compared -- first, load:
 
 ```
@@ -431,7 +431,7 @@ Now, save the tree:
 How do we load the SBT and search it with a DNA sequence,
 from within Python?
 
-The SBT filename is `/tmp/test.sbt.json`, as above:
+The SBT filename is `{}/test.sbt.json`.format(tempdir), as above:
 ```
 >>> SBT_filename = tempdir + '/test.sbt.json'
 


### PR DESCRIPTION
Changes the temp directory name from a constant `/tmp/` to a unique name.
Fixes #1007 
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
