### PR TITLE
Update #1021 with a Makefile fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: all
 	$(PYTHON) -m pytest
 	cargo test
 
-doc: build
+doc: build .PHONY
 	cd doc && make html
 
 include/sourmash.h: src/core/src/lib.rs \


### PR DESCRIPTION
Adds .PHONY to the 'doc' target so as to force a docs build attempt.

This is a PR into #1021.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
