### PR TITLE
be more strict on niffler versions, add new gz feature to it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -224,7 +224,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.34.0
+          toolchain: 1.37.0
           override: true
 
       - name: Set up Python 3.8

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -35,7 +35,7 @@ fixedbitset = "0.3.0"
 log = "0.4.8"
 md5 = "0.7.0"
 murmurhash3 = "0.0.5"
-niffler = { version = "2.0.0", default-features = false }
+niffler = { version = "2.2.0", default-features = false, features = ["gz"] }
 once_cell = "1.3.1"
 rayon = { version = "1.3.0", optional = true }
 serde = "1.0.110"


### PR DESCRIPTION
niffler 2.2.0 was released this morning, and now the `gz` compression is optional too (like `bz2` and `lzma` were before). Because we disable the default features it broke sourmash (because the `niffler` version was too lax).

This fixes the build errors in #1059 

## Checklist

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
