### PR TITLE
[MRG] improve lca index error message when inserting num signature

### DIFF
--- a/sourmash/lca/command_index.py
+++ b/sourmash/lca/command_index.py
@@ -227,7 +227,13 @@ def index(args):
                 continue
 
             # add the signature into the database.
-            db.insert(sig, ident=ident, lineage=lineage)
+            try:
+                db.insert(sig, ident=ident, lineage=lineage)
+            except ValueError as e:
+                error("ERROR: cannot insert signature '{}' (md5 {}, loaded from '{}') into database.",
+                      sig.name(), sig.md5sum()[:8], filename)
+                error("ERROR: {}", str(e))
+                sys.exit(-1)
 
             if lineage:
                 # remove from our list of remaining ident -> lineage

--- a/sourmash/lca/lca_db.py
+++ b/sourmash/lca/lca_db.py
@@ -125,7 +125,10 @@ class LCA_Database(Index):
 
         # downsample to specified scaled; this has the side effect of
         # making sure they're all at the same scaled value!
-        minhash = minhash.downsample_scaled(self.scaled)
+        try:
+            minhash = minhash.downsample_scaled(self.scaled)
+        except ValueError:
+            raise ValueError("cannot downsample signature; is it a scaled signature?")
 
         if ident is None:
             ident = sig.name()

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -787,6 +787,22 @@ def test_index_from_file(c):
     assert 'WARNING: 1 duplicate signatures.' in err
 
 
+@utils.in_tempdir
+def test_index_fail_on_num(c):
+    # lca index should yield a decent error message when attempted on 'num'
+    sigfile = utils.get_test_data('num/63.fa.sig')
+    taxcsv = utils.get_test_data('lca/podar-lineage.csv')
+
+    with pytest.raises(ValueError):
+        c.run_sourmash('lca', 'index', taxcsv, 'xxx.lca.json', sigfile, '-C', '3')
+
+    err = c.last_result.err
+    print(err)
+
+    assert 'ERROR: cannot insert signature ' in err
+    assert 'ERROR: cannot downsample signature; is it a scaled signature?' in err
+
+
 def test_index_traverse_real_spreadsheet_no_report():
     with utils.TempDirectory() as location:
         taxcsv = utils.get_test_data('lca/tara-delmont-SuppTable3.csv')


### PR DESCRIPTION
LCA databases cannot be created with `num` signatures; while `lca index` does error out, it does so with an uninformative error about downsampling. This improves the lca index error message.

Fixes #1029 
Fixes #462

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
