### PR TITLE
[MRG] add initial progress reporting wrapper for load_file_as_signatures

### DIFF
--- a/sourmash/commands.py
+++ b/sourmash/commands.py
@@ -36,6 +36,8 @@ def compare(args):
         more_files = sourmash_args.load_file_list_of_signatures(args.from_file)
         inp_files.extend(more_files)
 
+    progress = sourmash_args.SignatureLoadingProgress()
+
     # load in the various signatures
     siglist = []
     ksizes = set()
@@ -46,7 +48,8 @@ def compare(args):
                                                        ksize=args.ksize,
                                                        select_moltype=moltype,
                                                        traverse=args.traverse_directory,
-                                                       yield_all_files=args.force)
+                                                       yield_all_files=args.force,
+                                                       progress=progress)
         loaded = list(loaded)
         if not loaded:
             notify('\nwarning: no signatures loaded at given ksize/molecule type from {}', filename)
@@ -352,20 +355,20 @@ def index(args):
 
     notify('loading {} files into SBT', len(inp_files))
 
+    progress = sourmash_args.SignatureLoadingProgress()
+
     n = 0
     ksizes = set()
     moltypes = set()
     nums = set()
     scaleds = set()
     for f in inp_files:
-        if n % 100 == 0:
-            notify('\r...reading from {} ({} signatures so far)', f, n, end='')
-
         siglist = sourmash_args.load_file_as_signatures(f,
                                                         ksize=args.ksize,
                                                         select_moltype=moltype,
                                                         traverse=args.traverse_directory,
-                                                        yield_all_files=args.force)
+                                                        yield_all_files=args.force,
+                                                        progress=progress)
 
         # load all matching signatures in this file
         ss = None

--- a/sourmash/sbt.py
+++ b/sourmash/sbt.py
@@ -585,7 +585,7 @@ class SBT(Index):
             if n % 100 == 0:
                 notify("{} of {} nodes saved".format(n+1, total_nodes), end='\r')
 
-        notify("\nFinished saving nodes, now saving SBT json file.")
+        notify("Finished saving nodes, now saving SBT index file.")
         info['nodes'] = nodes
         info['signatures'] = leaves
 
@@ -599,7 +599,7 @@ class SBT(Index):
             with open(index_filename, 'w') as fp:
                 json.dump(info, fp)
 
-        notify("\nFinished saving SBT, available at {0}\n".format(index_filename))
+        notify("Finished saving SBT index, available at {0}\n".format(index_filename))
 
         return path
 

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -169,13 +169,17 @@ def describe(args):
     """
     set_quiet(args.quiet)
 
+    progress = sourmash_args.SignatureLoadingProgress()
+
     siglist = []
     for sigfile in args.signatures:
         this_siglist = []
         try:
-            this_siglist = sourmash_args.load_file_as_signatures(sigfile, traverse=True)
-            for k in this_siglist:
-                siglist.append((k, sigfile))
+            loader = sourmash_args.load_file_as_signatures(sigfile,
+                                                           traverse=True,
+                                                           progress=progress)
+            for sig in loader:
+                siglist.append((sig, sigfile))
         except Exception as exc:
             error('\nError while reading signatures from {}:'.format(sigfile))
             error(str(exc))

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -185,10 +185,6 @@ def describe(args):
             error(str(exc))
             error('(continuing)')
 
-        this_siglist = list(this_siglist)
-        notify('loaded {} signatures from {}...', len(this_siglist), sigfile,
-               end='\r')
-
     notify('loaded {} signatures total.', len(siglist))
 
     # write CSV?

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -187,6 +187,7 @@ def describe(args):
             error('\nError while reading signatures from {}:'.format(sigfile))
             error(str(exc))
             error('(continuing)')
+            raise
 
     notify('loaded {} signatures total.', len(siglist))
 

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -461,6 +461,7 @@ def load_file_as_signatures(filename, select_moltype=None, ksize=None,
     """
     if progress:
         progress.notify(filename)
+
     db, dbtype = _load_database(filename, traverse, yield_all_files)
 
     loader = None
@@ -536,13 +537,15 @@ class SignatureLoadingProgress(object):
 
     Alternatively, call obj.start_file(filename, iter) each time you
     start loading signatures from a new file via iter.
+
+    You can optionally notify of reading a file with `.notify(filename)`.
     """
     def __init__(self, reporting_interval=10):
         self.n_sig = 0
         self.interval = reporting_interval
 
     def notify(self, filename):
-        notify("...opening file '{}'", filename, end='\r')
+        notify("...reading from file '{}'", filename, end='\r')
 
     def start_file(self, filename, loader):
         n_this = 0

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -543,9 +543,14 @@ class SignatureLoadingProgress(object):
     def __init__(self, reporting_interval=10):
         self.n_sig = 0
         self.interval = reporting_interval
-        self.screen_width = 80
+        self.screen_width = 79
 
     def short_notify(self, msg_template, *args, **kwargs):
+        """Shorten the notification message so that it fits on one line.
+
+        Good for repeating notifications with end='\r' especially...
+        """
+
         msg = msg_template.format(*args, **kwargs)
         end = kwargs.get('end', '\n')
         w = self.screen_width

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -459,6 +459,8 @@ def load_file_as_signatures(filename, select_moltype=None, ksize=None,
 
     Applies selector function if select_moltype and/or ksize are given.
     """
+    if progress:
+        progress.notify(filename)
     db, dbtype = _load_database(filename, traverse, yield_all_files)
 
     loader = None
@@ -539,6 +541,9 @@ class SignatureLoadingProgress(object):
         self.n_sig = 0
         self.interval = reporting_interval
 
+    def notify(self, filename):
+        notify("...opening file '{}'", filename, end='\r')
+
     def start_file(self, filename, loader):
         n_this = 0
         n_before = self.n_sig
@@ -548,7 +553,7 @@ class SignatureLoadingProgress(object):
                 # track n from this file, as well as total n
                 n_this += 1
                 n_total = n_before + n_this
-                if n_total % self.interval == 0:
+                if n_this and n_total % self.interval == 0:
                     notify("...loading from '{}' / {} sigs total",
                            filename, n_total, end='\r')
 

--- a/sourmash/sourmash_args.py
+++ b/sourmash/sourmash_args.py
@@ -543,9 +543,22 @@ class SignatureLoadingProgress(object):
     def __init__(self, reporting_interval=10):
         self.n_sig = 0
         self.interval = reporting_interval
+        self.screen_width = 80
+
+    def short_notify(self, msg_template, *args, **kwargs):
+        msg = msg_template.format(*args, **kwargs)
+        end = kwargs.get('end', '\n')
+        w = self.screen_width
+
+        if len(msg) > w:
+            truncate_len = len(msg) - w + 3
+            msg = '<<<' + msg[truncate_len:]
+
+        notify(msg, end=end)
 
     def notify(self, filename):
-        notify("...reading from file '{}'", filename, end='\r')
+        self.short_notify("...reading from file '{}'",
+                          filename, end='\r')
 
     def start_file(self, filename, loader):
         n_this = 0
@@ -557,8 +570,8 @@ class SignatureLoadingProgress(object):
                 n_this += 1
                 n_total = n_before + n_this
                 if n_this and n_total % self.interval == 0:
-                    notify("...loading from '{}' / {} sigs total",
-                           filename, n_total, end='\r')
+                    self.short_notify("...loading from '{}' / {} sigs total",
+                                      filename, n_total, end='\r')
 
                 yield result
         except KeyboardInterrupt:
@@ -568,4 +581,4 @@ class SignatureLoadingProgress(object):
         finally:
             self.n_sig += n_this
 
-        notify("loaded {} sigs from '{}'", n_this, filename)
+        self.short_notify("loaded {} sigs from '{}'", n_this, filename)

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -3702,7 +3702,7 @@ def test_do_sourmash_index_zipfile(c):
 
     print(c)
     assert c.last_result.status == 0
-    assert 'Finished saving SBT, available at' in c.last_result.err
+    assert 'Finished saving SBT index, available at' in c.last_result.err
 
     with zipfile.ZipFile(outfile) as zf:
         content = zf.namelist()
@@ -3733,7 +3733,7 @@ def test_do_sourmash_index_zipfile_append(c):
 
     print(c)
     assert c.last_result.status == 0
-    assert 'Finished saving SBT, available at' in c.last_result.err
+    assert 'Finished saving SBT index, available at' in c.last_result.err
 
     with pytest.warns(None) as record:
         c.run_sourmash('index', "--append", '-k', '31', 'zzz.sbt.zip',
@@ -3743,7 +3743,7 @@ def test_do_sourmash_index_zipfile_append(c):
 
     print(c)
     assert c.last_result.status == 0
-    assert 'Finished saving SBT, available at' in c.last_result.err
+    assert 'Finished saving SBT index, available at' in c.last_result.err
 
     with zipfile.ZipFile(outfile) as zf:
         content = zf.namelist()


### PR DESCRIPTION
Partial fix for #1082

```
% sourmash sig describe podar-ref.sbt.zip  podar-ref.sbt.zip podar-ref.lca.json.gz  ../charcoal/db/gtdb-release89-k31.sbt.zip  > /dev/null
```

produces

```
loaded 64 sigs from 'podar-ref.sbt.zip'
loaded 64 sigs from 'podar-ref.sbt.zip'
loaded 64 sigs from 'podar-ref.lca.json.gz'
...loading from '../charcoal/db/gtdb-release89-k31.sbt.zip' / 510 sigs total
```
This is all UX tweaking, no new tests.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
