### PR TITLE
Adds --majority option to classify using majority vote algorithm

### DIFF
--- a/sourmash/cli/lca/classify.py
+++ b/sourmash/cli/lca/classify.py
@@ -11,6 +11,10 @@ def subparser(subparsers):
                            help='file containing list of signature files to query')
     subparser.add_argument('--threshold', metavar='T', type=int, default=5)
     subparser.add_argument(
+        '--majority_vote', action='store_true',
+        help='use majority vote classification instead of lca'
+    )
+    subparser.add_argument(
         '-q', '--quiet', action='store_true',
         help='suppress non-error output'
     )

--- a/sourmash/cli/lca/classify.py
+++ b/sourmash/cli/lca/classify.py
@@ -11,7 +11,7 @@ def subparser(subparsers):
                            help='file containing list of signature files to query')
     subparser.add_argument('--threshold', metavar='T', type=int, default=5)
     subparser.add_argument(
-        '--majority_vote', action='store_true',
+        '--majority', action='store_true',
         help='use majority vote classification instead of lca'
     )
     subparser.add_argument(

--- a/sourmash/lca/command_classify.py
+++ b/sourmash/lca/command_classify.py
@@ -15,7 +15,7 @@ from .lca_utils import check_files_exist
 DEFAULT_THRESHOLD=5                  # how many counts of a taxid at min
 
 
-def classify_signature(query_sig, dblist, threshold):
+def classify_signature(query_sig, dblist, threshold, majority_vote):
     """
     Classify 'query_sig' using the given list of databases.
 
@@ -48,11 +48,15 @@ def classify_signature(query_sig, dblist, threshold):
     # threshold.
 
     tree = {}
+    lca = []
 
-    for lca, count in counts.most_common():
-        if count < threshold:
-            break
-
+    if majority_vote:
+        majority = counts.most_common()[0][0]
+        lca_utils.build_tree([majority], tree)
+    else:
+        for lca, count in counts.most_common():
+            if count < threshold:
+                break
         # update tree with this set of assignments
         lca_utils.build_tree([lca], tree)
 
@@ -136,7 +140,7 @@ def classify(args):
 
                 # do the classification
                 lineage, status = classify_signature(query_sig, dblist,
-                                                     args.threshold)
+                                                     args.threshold, args.majority_vote)
                 debug(lineage)
 
                 # output each classification to the spreadsheet

--- a/sourmash/lca/command_classify.py
+++ b/sourmash/lca/command_classify.py
@@ -15,7 +15,7 @@ from .lca_utils import check_files_exist
 DEFAULT_THRESHOLD=5                  # how many counts of a taxid at min
 
 
-def classify_signature(query_sig, dblist, threshold, majority_vote):
+def classify_signature(query_sig, dblist, threshold, majority):
     """
     Classify 'query_sig' using the given list of databases.
 
@@ -48,17 +48,18 @@ def classify_signature(query_sig, dblist, threshold, majority_vote):
     # threshold.
 
     tree = {}
-    lca = []
 
-    if majority_vote:
-        majority = counts.most_common()[0][0]
-        lca_utils.build_tree([majority], tree)
-    else:
-        for lca, count in counts.most_common():
-            if count < threshold:
-                break
-        # update tree with this set of assignments
-        lca_utils.build_tree([lca], tree)
+    if counts:
+        if majority:
+            majority_vote, count = counts.most_common()[0]
+            if count > threshold:
+                lca_utils.build_tree([majority_vote], tree)
+        else:
+            for lca, count in counts.most_common():
+                if count < threshold:
+                    break
+                # update tree with this set of assignments
+                lca_utils.build_tree([lca], tree)
 
     status = 'nomatch'
     if not tree:
@@ -140,7 +141,7 @@ def classify(args):
 
                 # do the classification
                 lineage, status = classify_signature(query_sig, dblist,
-                                                     args.threshold, args.majority_vote)
+                                                     args.threshold, args.majority)
                 debug(lineage)
 
                 # output each classification to the spreadsheet

--- a/sourmash/lca/command_classify.py
+++ b/sourmash/lca/command_classify.py
@@ -49,17 +49,16 @@ def classify_signature(query_sig, dblist, threshold, majority):
 
     tree = {}
 
-    if counts:
-        if majority:
-            majority_vote, count = counts.most_common()[0]
-            if count > threshold:
-                lca_utils.build_tree([majority_vote], tree)
-        else:
-            for lca, count in counts.most_common():
-                if count < threshold:
-                    break
-                # update tree with this set of assignments
-                lca_utils.build_tree([lca], tree)
+    if counts and majority:
+        majority_vote, count = counts.most_common()[0]
+        if count > threshold:
+            lca_utils.build_tree([majority_vote], tree)
+    else:
+        for lca, count in counts.most_common():
+            if count < threshold:
+                break
+            # update tree with this set of assignments
+            lca_utils.build_tree([lca], tree)
 
     status = 'nomatch'
     if not tree:

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -1235,8 +1235,7 @@ def test_classify_majority_vote_2(c):
 
 @utils.in_tempdir
 def test_classify_majority_vote_3(c):
-    # classify signature with no match to the 
-    # same database using --majority. Should yield nomatch
+    # classify signature with nothing in counts
 
     # build database
     taxcsv = utils.get_test_data('lca/delmont-6.csv')

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -1153,6 +1153,56 @@ def test_index_and_classify_internal_unassigned_multi():
         assert 'loaded 1 LCA databases' in err
 
 
+@utils.in_tempdir
+def test_index_and_classify_internal_unassigned_multi_2(c):
+    taxcsv = utils.get_test_data('lca/delmont-6.csv')
+    input_sig1 = utils.get_test_data('lca/TARA_ASE_MAG_00031.sig')
+    input_sig2 = utils.get_test_data('lca/TARA_PSW_MAG_00136.sig')
+    lca_db = c.output('delmont-1.lca.json')
+
+    c.run_sourmash('lca', 'index', taxcsv, lca_db, input_sig1, input_sig2)
+
+    print(c.last_command)
+    print(c.last_result.out)
+    print(c.last_result.err)
+
+    assert os.path.exists(lca_db)
+
+    assert "** assuming column 'MAGs' is identifiers in spreadsheet" in c.last_result.err
+    assert "** assuming column 'Domain' is superkingdom in spreadsheet" in c.last_result.err
+    assert '2 identifiers used out of 2 distinct identifiers in spreadsheet.' in c.last_result.err
+
+    # merge input_sig1 and input_sig2
+    c.run_sourmash('signature', 'merge', input_sig1, input_sig2, '-k', '31', '--flatten', '-o', 'sig1and2.sig')
+    sig1and2 = c.output('sig1and2.sig')
+
+    # lca classify should yield no results
+    c.run_sourmash('lca', 'classify', '--db', lca_db, '--query', sig1and2)
+
+    print("\n\nLCA CLASSIFY:")
+    print("\nc.last_command =", c.last_command)
+    print("\nc.last_result.out =", c.last_result.out)
+    print("\nc.last_result.err =", c.last_result.err)
+
+    assert 'ID,status,superkingdom,phylum,class,order,family,genus,species' in c.last_result.out
+    assert 'nomatch' in c.last_result.out
+    assert 'classified 1 signatures total' in c.last_result.err
+    assert 'loaded 1 LCA databases' in c.last_result.err
+
+    # majority vote classify should yeild results
+    c.run_sourmash('lca', 'classify', '--db', lca_db, '--query', sig1and2, '--majority_vote')
+
+    print("\n\nMAJORITY CLASSIFY")
+    print("\nc.last_command =", c.last_command)
+    print("\nc.last_result.out =", c.last_result.out)
+    print("\nc.last_result.err =", c.last_result.err)
+
+    assert 'ID,status,superkingdom,phylum,class,order,family,genus,species' in c.last_result.out
+    assert 'found,Eukaryota,Chlorophyta,Prasinophyceae,unassigned,unassigned,Ostreococcus' in c.last_result.out
+    assert 'classified 1 signatures total' in c.last_result.err
+    assert 'loaded 1 LCA databases' in c.last_result.err
+
+
 def test_multi_db_classify():
     with utils.TempDirectory() as location:
         db1 = utils.get_test_data('lca/delmont-1.lca.json')


### PR DESCRIPTION
This PR adds command line option of `--majority` to `lca classify` which will use the **majority vote** algorithm instead of **lca**.
Fixes #984
- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make coverage` Is the new code covered?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
