### PR TITLE
MinHash compatibility check to sourmash sig intersect

### DIFF
--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -423,6 +423,7 @@ def intersect(args):
                 # check signature compatibility --
                 try:
                     sigobj.minhash.count_common(first_sig.minhash)
+                    sigobj.minhash.is_compatible(first_sig.minhash)
                 except ValueError:
                     error('incompatible minhashes; specify -k and/or molecule type.')
                     sys.exit(-1)

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -421,12 +421,8 @@ def intersect(args):
                 mins = set(sigobj.minhash.get_mins())
             else:
                 # check signature compatibility --
-                try:
-                    sigobj.minhash.count_common(first_sig.minhash)
-                    sigobj.minhash.is_compatible(first_sig.minhash)
-                except ValueError:
-                    error('incompatible minhashes; specify -k and/or molecule type.')
-                    sys.exit(-1)
+                if not sigobj.minhash.is_compatible(first_sig.minhash):
+                    raise ValueError("incompatible minhashes; specify -k and/or molecule type.")
 
             mins.intersection_update(sigobj.minhash.get_mins())
             total_loaded += 1
@@ -495,11 +491,8 @@ def subtract(args):
                                                         select_moltype=moltype,
                                                         traverse=True,
                                                         progress=progress):
-            try:
-                sigobj.minhash.count_common(from_mh)
-            except ValueError:
-                error('incompatible minhashes; specify -k and/or molecule type.')
-                sys.exit(-1)
+            if not sigobj.minhash.is_compatible(from_mh):
+                raise ValueError("incompatible minhashes; specify -k and/or molecule type.")
 
             if sigobj.minhash.track_abundance and not args.flatten:
                 error('Cannot use subtract on signatures with abundance tracking, sorry!')

--- a/sourmash/sig/__main__.py
+++ b/sourmash/sig/__main__.py
@@ -422,7 +422,8 @@ def intersect(args):
             else:
                 # check signature compatibility --
                 if not sigobj.minhash.is_compatible(first_sig.minhash):
-                    raise ValueError("incompatible minhashes; specify -k and/or molecule type.")
+                    error("incompatible minhashes; specify -k and/or molecule type.")
+                    sys.exit(-1)
 
             mins.intersection_update(sigobj.minhash.get_mins())
             total_loaded += 1
@@ -492,7 +493,8 @@ def subtract(args):
                                                         traverse=True,
                                                         progress=progress):
             if not sigobj.minhash.is_compatible(from_mh):
-                raise ValueError("incompatible minhashes; specify -k and/or molecule type.")
+                error("incompatible minhashes; specify -k and/or molecule type.")
+                sys.exit(-1)
 
             if sigobj.minhash.track_abundance and not args.flatten:
                 error('Cannot use subtract on signatures with abundance tracking, sorry!')


### PR DESCRIPTION
This PR calls `minhash.is_compatible(...)` to check for MinHash compatibility before intersecting two MinHashes.
Fixes #1107 
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
