### PR TITLE
(docs) revert SBT databases links back to S3

### DIFF
--- a/doc/databases.md
+++ b/doc/databases.md
@@ -47,12 +47,13 @@ sourmash compute -k 21,31,51 \
 See [github.com/dib-lab/sourmash_databases](https://github.com/dib-lab/sourmash_databases) for a Snakemake workflow
 to build the databases.
 
-[0]: https://osf.io/k26ep/download
-[1]: https://osf.io/8snc9/download
-[2]: https://osf.io/gkqau/download
-[3]: https://osf.io/dm7n4/download
-[4]: https://osf.io/jgu93/download
-[5]: https://osf.io/2uvsc/download
+[0]: https://sourmash-databases.s3-us-west-2.amazonaws.com/zip/refseq-k21.sbt.zip
+[1]: https://sourmash-databases.s3-us-west-2.amazonaws.com/zip/refseq-k31.sbt.zip
+[2]: https://sourmash-databases.s3-us-west-2.amazonaws.com/zip/refseq-k51.sbt.zip
+
+[3]: https://sourmash-databases.s3-us-west-2.amazonaws.com/zip/genbank-k21.sbt.zip
+[4]: https://sourmash-databases.s3-us-west-2.amazonaws.com/zip/genbank-k31.sbt.zip
+[5]: https://sourmash-databases.s3-us-west-2.amazonaws.com/zip/genbank-k51.sbt.zip
 
 ## Genbank LCA Database
 


### PR DESCRIPTION
It was good while it lasted: osf+gdrive has quota limits, so reverting back to S3 for now...

## Checklist

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
