### PR TITLE
[MRG] remove mentions of ijson and khmer

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -8,7 +8,7 @@ You can get the latest development master branch with:
 git clone https://github.com/dib-lab/sourmash.git
 ```
 sourmash runs under both Python 2.7.x and Python 3.5+.  The base
-requirements are screed and ijson, together with a Rust environment (for the
+requirements are screed and cffi, together with a Rust environment (for the
 extension code). We suggest using `rustup` to install the Rust environment:
 
     curl https://sh.rustup.rs -sSf | sh

--- a/doc/release.md
+++ b/doc/release.md
@@ -113,7 +113,7 @@ deactivate
 source bin/activate
 python -m pip install -U setuptools pip wheel
 # install as much as possible from non-test server!
-python -m pip install screed pytest numpy matplotlib scipy khmer ijson bam2fasta deprecation cffi
+python -m pip install screed pytest numpy matplotlib scipy bam2fasta deprecation cffi
 python -m pip install -i https://test.pypi.org/simple --pre sourmash
 sourmash info  # should print "sourmash version ${new_version}${rc}"
 ```

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -2,7 +2,7 @@ from sourmash import signature
 from . import sourmash_tst_utils as utils
 
 def test_load_textmode(track_abundance):
-    # ijson requires a file in binary mode or bytes,
+    # ijson required a file in binary mode or bytes,
     # but we had an API example in the docs using 'rt'.
     # I fixed the docs, but I'm keeping this test here
     # to make sure we still support it =/


### PR DESCRIPTION
This updates the docs to remove mentions of these two no-longer-needed packages.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
