### PR TITLE
[MRG] deprecate `import sourmash_lib`

### DIFF
--- a/sourmash_lib/__init__.py
+++ b/sourmash_lib/__init__.py
@@ -1,8 +1,13 @@
 #! /usr/bin/env python
 """
 An implementation of a MinHash bottom sketch, applied to k-mers in DNA.
+
+Legacy / deprecated; will be removed in sourmash 4.0.
 """
 import sys
+import warnings
+
+warnings.warn("Please import sourmash, instead of sourmash_lib; sourmash_lib will be removed in 4.x", FutureWarning)
 
 import sourmash
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -11,3 +11,7 @@ def test_load_textmode(track_abundance):
         siglist = list(signature.load_signatures(sigfp))
     loaded_sig = siglist[0]
     assert loaded_sig.name() == 's10+s11'
+
+
+def test_import_sourmash_lib():
+    import sourmash_lib

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,7 +7,7 @@ import zipfile
 import sourmash
 from sourmash import load_one_signature, SourmashSignature
 from sourmash.index import LinearIndex
-from sourmash_lib.sbt import SBT, GraphFactory, Leaf
+from sourmash.sbt import SBT, GraphFactory, Leaf
 from . import sourmash_tst_utils as utils
 
 


### PR DESCRIPTION
Fixes #441.

As in https://github.com/dib-lab/sourmash/pull/1128#issuecomment-667690185, I used `FutureWarning` instead of `DeprecationWarning` so it would show up without any special configuration.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make coverage` Is the new code covered?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
